### PR TITLE
Feat/toast message 기능 추가 #655

### DIFF
--- a/components/modal/admin/AdminNotiAllModal.tsx
+++ b/components/modal/admin/AdminNotiAllModal.tsx
@@ -2,8 +2,19 @@ import { useSetRecoilState } from 'recoil';
 import { useEffect, useState } from 'react';
 import styles from 'styles/admin/modal/AdminNotiAll.module.scss';
 import { modalState } from 'utils/recoil/modal';
+import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import Snackbar from '@mui/material/Snackbar';
+import MuiAlert, { AlertProps } from '@mui/material/Alert';
 import instance from 'utils/axios';
 import { finished } from 'stream';
+
+const Alert = React.forwardRef<HTMLDivElement, AlertProps>(function Alert(
+  props,
+  ref
+) {
+  return <MuiAlert elevation={6} ref={ref} variant='filled' {...props} />;
+});
 
 interface EditedAllNoti {
   notification: string | number;
@@ -42,20 +53,20 @@ export default function AdminNotiAllModal(props: any) {
   // useEffect(() => {
   //   getBasicPenaltyHandler();
   // }, []);
-  const finishEditHandler = () => {
-    let errMsg = '';
-    if (editedAllNoti.notification < 0) {
-      errMsg += '시간은 0 이상이어야합니다.\n';
-      console.log(errMsg);
-      editedAllNoti.notification = '';
-    }
-    if (errMsg) alert(errMsg);
-    setAllNoti({
-      ...editedAllNoti,
-      intraID: props.value,
-    });
-    // setModal({ modalName: null });
-  };
+  // const finishEditHandler = () => {
+  //   let errMsg = '';
+  //   if (editedAllNoti.notification < 0) {
+  //     errMsg += '시간은 0 이상이어야합니다.\n';
+  //     console.log(errMsg);
+  //     editedAllNoti.notification = '';
+  //   }
+  //   if (errMsg) alert(errMsg);
+  //   setAllNoti({
+  //     ...editedAllNoti,
+  //     intraID: props.value,
+  //   });
+  //   // setModal({ modalName: null });
+  // };
   useEffect(() => {
     console.log({ allNoti });
     return () => {
@@ -63,7 +74,24 @@ export default function AdminNotiAllModal(props: any) {
     };
   }, [allNoti]);
   const setModal = useSetRecoilState(modalState);
+  const finishEditHandler = () => setModal({ modalName: null });
   const cancelEditHandler = () => setModal({ modalName: null });
+  const [open, setOpen] = React.useState(false);
+
+  const handleClick = () => {
+    setOpen(true);
+  };
+
+  const handleClose = (
+    event?: React.SyntheticEvent | Event,
+    reason?: string
+  ) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+
+    setOpen(false);
+  };
 
   return (
     <div className={styles.whole}>
@@ -84,12 +112,25 @@ export default function AdminNotiAllModal(props: any) {
         </label>
 
         <div className={styles.btns}>
-          <button
-            className={allNoti ? `${styles.hide}` : `${styles.btn}`}
-            onClick={finishEditHandler}
-          >
-            적용
-          </button>
+          <Stack spacing={2} sx={{ width: '100%' }}>
+            <button
+              onClick={() => {
+                handleClick();
+              }}
+              className={styles.btn}
+            >
+              적용
+            </button>
+            <Snackbar open={open} autoHideDuration={6000} onClose={handleClose}>
+              <Alert
+                onClose={handleClose}
+                severity='success'
+                sx={{ width: '100%' }}
+              >
+                This is a success message!
+              </Alert>
+            </Snackbar>
+          </Stack>
           <button className={styles.btn} onClick={cancelEditHandler}>
             취소
           </button>

--- a/components/toastmsg/toastmsg.tsx
+++ b/components/toastmsg/toastmsg.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import Button from '@mui/material/Button';
+import Snackbar from '@mui/material/Snackbar';
+import MuiAlert, { AlertProps } from '@mui/material/Alert';
+
+const Alert = React.forwardRef<HTMLDivElement, AlertProps>(function Alert(
+  props,
+  ref
+) {
+  return <MuiAlert elevation={6} ref={ref} variant='filled' {...props} />;
+});
+
+export default function CustomizedSnackbars() {
+  const [open, setOpen] = React.useState(false);
+
+  const handleClick = () => {
+    setOpen(true);
+  };
+
+  const handleClose = (
+    event?: React.SyntheticEvent | Event,
+    reason?: string
+  ) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+
+    setOpen(false);
+  };
+
+  return (
+    <Stack spacing={2} sx={{ width: '100%' }}>
+      <Button variant='outlined' onClick={handleClick}>
+        Open success snackbar
+      </Button>
+      <Snackbar open={open} autoHideDuration={6000} onClose={handleClose}>
+        <Alert onClose={handleClose} severity='success' sx={{ width: '100%' }}>
+          This is a success message!
+        </Alert>
+      </Snackbar>
+      <Alert severity='error'>This is an error message!</Alert>
+      <Alert severity='warning'>This is a warning message!</Alert>
+      <Alert severity='info'>This is an information message!</Alert>
+      <Alert severity='success'>This is a success message!</Alert>
+    </Stack>
+  );
+}

--- a/components/toastmsg/toastmsg.tsx
+++ b/components/toastmsg/toastmsg.tsx
@@ -39,10 +39,6 @@ export default function CustomizedSnackbars() {
           This is a success message!
         </Alert>
       </Snackbar>
-      <Alert severity='error'>This is an error message!</Alert>
-      <Alert severity='warning'>This is a warning message!</Alert>
-      <Alert severity='info'>This is an information message!</Alert>
-      <Alert severity='success'>This is a success message!</Alert>
     </Stack>
   );
 }


### PR DESCRIPTION
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 관리자 전체 알림 모달에 토스트 메시지 기능 추가
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
- [x] 토스트 메시지 component 개별 추가
- [x] 토스트 메시지와 관리자 전체 알림 모달 연결

 ## 시연
1. `npm i & npm run dev`
2. 브라우저 열기 (localhost:3000/admin) & `알림 관리` 선택
3. 우측 상단에 있는 [All] 버튼 클릭
4. 전체 알림 모달 내에 있는 [적용] 버튼 클릭 후 토스트 메시지 정상 작동 확인

## 관련 이슈
- #655 
- #650 