### PR TITLE
Feat/유저 모달 에러 관리 #666

### DIFF
--- a/components/admin/users/UserManagementTable.tsx
+++ b/components/admin/users/UserManagementTable.tsx
@@ -49,13 +49,17 @@ export default function UserManagementTable() {
 
   const buttonList: string[] = [styles.detail, styles.penalty];
 
-  const handleButtonAction = (buttonName: string, userId: number) => {
+  const handleButtonAction = (
+    buttonName: string,
+    userId: number,
+    intraId: string
+  ) => {
     switch (buttonName) {
       case '자세히':
         setModal({ modalName: 'ADMIN-PROFILE', userId });
         break;
       case '패널티 부여':
-        //  setModal({ modalName: 'ADMIN-PENALTY', userId });
+        setModal({ modalName: 'ADMIN-PENALTY', intraId });
         break;
     }
   };
@@ -140,7 +144,11 @@ export default function UserManagementTable() {
                                   key={buttonName}
                                   className={`${styles.button} ${buttonList[index]}`}
                                   onClick={() =>
-                                    handleButtonAction(buttonName, userInfo.id)
+                                    handleButtonAction(
+                                      buttonName,
+                                      userInfo.id,
+                                      userInfo.intraId
+                                    )
                                   }
                                 >
                                   {buttonName}

--- a/components/admin/users/UserManagementTable.tsx
+++ b/components/admin/users/UserManagementTable.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
+import { useSetRecoilState } from 'recoil';
+import { modalState } from 'utils/recoil/modal';
 import { tableFormat } from 'constants/admin/table';
 import instance from 'utils/axios';
 import PageNation from 'components/Pagination';
@@ -35,6 +37,7 @@ export default function UserManagementTable() {
   });
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [intraId, setIntraId] = useState<string>('');
+  const setModal = useSetRecoilState(modalState);
 
   const tableTitle: { [key: string]: string } = {
     id: 'Id',
@@ -46,13 +49,13 @@ export default function UserManagementTable() {
 
   const buttonList: string[] = [styles.detail, styles.penalty];
 
-  const handleButtonAction = (buttonName: string) => {
+  const handleButtonAction = (buttonName: string, userId: number) => {
     switch (buttonName) {
       case '자세히':
-        console.log('상세보기'); // TODO insert modalHandler
+        setModal({ modalName: 'ADMIN-PROFILE', userId });
         break;
       case '패널티 부여':
-        console.log('패널티 부여'); // TODO insert modalHandler
+        //  setModal({ modalName: 'ADMIN-PENALTY', userId });
         break;
     }
   };
@@ -136,7 +139,9 @@ export default function UserManagementTable() {
                                 <button
                                   key={buttonName}
                                   className={`${styles.button} ${buttonList[index]}`}
-                                  onClick={() => handleButtonAction(buttonName)}
+                                  onClick={() =>
+                                    handleButtonAction(buttonName, userInfo.id)
+                                  }
                                 >
                                   {buttonName}
                                 </button>

--- a/components/modal/admin/AdminProfileModal.tsx
+++ b/components/modal/admin/AdminProfileModal.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useSetRecoilState } from 'recoil';
 import {
   AdminProfileProps,
@@ -8,6 +8,7 @@ import {
 } from 'types/admin/adminUserTypes';
 import { racketTypes } from 'types/userTypes';
 import { modalState } from 'utils/recoil/modal';
+import { toastState } from 'utils/recoil/toast';
 import instance from 'utils/axios';
 import useUploadImg from 'hooks/useUploadImg';
 import styles from 'styles/admin/modal/AdminProfile.module.scss';
@@ -30,7 +31,7 @@ export default function AdminProfileModal(props: AdminProfileProps) {
 
   const { imgData, imgPreview, uploadImg } = useUploadImg();
   const setModal = useSetRecoilState(modalState);
-  const setError = useSetRecoilState(errorState);
+  const setSnackBar = useSetRecoilState(toastState);
 
   useEffect(() => {
     getBasicProfileHandler();
@@ -43,7 +44,12 @@ export default function AdminProfileModal(props: AdminProfileProps) {
       );
       setUserInfo(res?.data);
     } catch (e) {
-      setError('SW01');
+      setSnackBar({
+        toastName: 'profile',
+        severity: 'error',
+        message: `api 불러오기 실패 ${userInfo.intraId}`,
+        clicked: true,
+      });
     }
   };
 
@@ -94,10 +100,28 @@ export default function AdminProfileModal(props: AdminProfileProps) {
         `/pingpong/admin/users/${props.value}/detail`,
         formData
       );
-      //if (res.status === 207)
-      // CustomizedSnackbars
-    } catch (e) {
-      //   CustomizedSnackbars(severity='error', message=`${e.response.message}`, clicked=true);
+      if (res.status === 207) {
+        setSnackBar({
+          toastName: 'profile',
+          severity: 'info',
+          message: '이 유저는 승,패,ppp를 수정할 수 없습니다.',
+          clicked: true,
+        });
+      } else {
+        setSnackBar({
+          toastName: 'profile',
+          severity: 'success',
+          message: '수정 완료',
+          clicked: true,
+        });
+      }
+    } catch (e: any) {
+      setSnackBar({
+        toastName: 'profile',
+        severity: 'error',
+        message: `${e.response.message}`,
+        clicked: true,
+      });
     }
   };
 

--- a/components/modal/admin/AdminProfileModal.tsx
+++ b/components/modal/admin/AdminProfileModal.tsx
@@ -94,7 +94,7 @@ export default function AdminProfileModal(props: AdminProfileProps) {
         formData
       );
     } catch (e) {
-      setError('SW02');
+      //   CustomizedSnackbars(severity='error', message=`${e.response.message}`, clicked=true);
     }
   };
 
@@ -113,7 +113,7 @@ export default function AdminProfileModal(props: AdminProfileProps) {
                     src={imgPreview ? imgPreview : `${userInfo?.userImageUri}`}
                     width='200'
                     height='200'
-                    alt='Profile Image'
+                    alt='이미지가 규격에 맞지 않거나 없습니다'
                   />
                 )}
                 <input

--- a/components/modal/admin/AdminProfileModal.tsx
+++ b/components/modal/admin/AdminProfileModal.tsx
@@ -203,21 +203,21 @@ export default function AdminProfileModal(props: AdminProfileProps) {
                 <input
                   name='wins'
                   onChange={inputNumHandler}
-                  value={userInfo?.wins}
+                  value={userInfo.wins ?? ''}
                 />
               </div>
               <div>
                 <input
                   name='losses'
                   onChange={inputNumHandler}
-                  value={userInfo?.losses}
+                  value={userInfo.losses ?? ''}
                 />
               </div>
               <div>
                 <input
                   name='ppp'
                   onChange={inputNumHandler}
-                  value={userInfo?.ppp}
+                  value={userInfo.ppp ?? ''}
                 />
               </div>
             </div>

--- a/components/modal/admin/AdminProfileModal.tsx
+++ b/components/modal/admin/AdminProfileModal.tsx
@@ -24,7 +24,7 @@ export default function AdminProfileModal(props: AdminProfileProps) {
     wins: 0,
     losses: 0,
     ppp: 0,
-    eMail: '',
+    email: '',
     roleType: 'ROLE_USER',
   });
 
@@ -73,7 +73,7 @@ export default function AdminProfileModal(props: AdminProfileProps) {
       wins: userInfo.wins,
       losses: userInfo.losses,
       ppp: userInfo.ppp,
-      eMail: userInfo.eMail,
+      email: userInfo.email,
       roleType: userInfo.roleType,
     };
     formData.append(
@@ -128,9 +128,9 @@ export default function AdminProfileModal(props: AdminProfileProps) {
                 <div>
                   <input
                     className={styles.topRightInput}
-                    name='eMail'
+                    name='email'
                     onChange={inputHandler}
-                    value={userInfo?.eMail}
+                    value={userInfo?.email}
                   />
                 </div>
               </div>

--- a/components/modal/admin/AdminProfileModal.tsx
+++ b/components/modal/admin/AdminProfileModal.tsx
@@ -21,9 +21,9 @@ export default function AdminProfileModal(props: AdminProfileProps) {
     userImageUri: null,
     statusMessage: '',
     racketType: 'shakeHand',
-    wins: 0,
-    losses: 0,
-    ppp: 0,
+    wins: '',
+    losses: '',
+    ppp: '',
     email: '',
     roleType: 'ROLE_USER',
   });
@@ -59,7 +59,8 @@ export default function AdminProfileModal(props: AdminProfileProps) {
   const inputNumHandler = ({
     target: { name, value },
   }: React.ChangeEvent<HTMLInputElement>) => {
-    const intValue = parseInt(value);
+    let intValue = parseInt(value);
+    if (isNaN(intValue)) intValue = 0;
     setUserInfo({ ...userInfo, [name]: intValue });
   };
 
@@ -111,8 +112,6 @@ export default function AdminProfileModal(props: AdminProfileProps) {
                 {userInfo.userImageUri && (
                   <Image
                     src={imgPreview ? imgPreview : `${userInfo?.userImageUri}`}
-                    width='200'
-                    height='200'
                     alt='이미지가 규격에 맞지 않거나 없습니다'
                     layout='fill'
                   />
@@ -134,7 +133,7 @@ export default function AdminProfileModal(props: AdminProfileProps) {
                     className={styles.topRightInput}
                     name='email'
                     onChange={inputHandler}
-                    value={userInfo?.email}
+                    value={userInfo.email ?? ''}
                   />
                 </div>
               </div>
@@ -147,7 +146,7 @@ export default function AdminProfileModal(props: AdminProfileProps) {
           <textarea
             name='statusMessage'
             onChange={inputHandler}
-            value={userInfo?.statusMessage}
+            value={userInfo.statusMessage ?? ''}
           />
         </div>
         <div className={styles.bottom}>
@@ -201,7 +200,6 @@ export default function AdminProfileModal(props: AdminProfileProps) {
               <div>
                 <input
                   name='wins'
-                  type='number'
                   onChange={inputNumHandler}
                   value={userInfo?.wins}
                 />
@@ -209,7 +207,6 @@ export default function AdminProfileModal(props: AdminProfileProps) {
               <div>
                 <input
                   name='losses'
-                  type='number'
                   onChange={inputNumHandler}
                   value={userInfo?.losses}
                 />
@@ -217,7 +214,6 @@ export default function AdminProfileModal(props: AdminProfileProps) {
               <div>
                 <input
                   name='ppp'
-                  type='number'
                   onChange={inputNumHandler}
                   value={userInfo?.ppp}
                 />

--- a/components/modal/admin/AdminProfileModal.tsx
+++ b/components/modal/admin/AdminProfileModal.tsx
@@ -90,10 +90,12 @@ export default function AdminProfileModal(props: AdminProfileProps) {
       );
     }
     try {
-      await instance.put(
+      const res = await instance.put(
         `/pingpong/admin/users/${props.value}/detail`,
         formData
       );
+      //if (res.status === 207)
+      // CustomizedSnackbars
     } catch (e) {
       //   CustomizedSnackbars(severity='error', message=`${e.response.message}`, clicked=true);
     }

--- a/components/modal/admin/AdminProfileModal.tsx
+++ b/components/modal/admin/AdminProfileModal.tsx
@@ -114,6 +114,7 @@ export default function AdminProfileModal(props: AdminProfileProps) {
                     width='200'
                     height='200'
                     alt='이미지가 규격에 맞지 않거나 없습니다'
+                    layout='fill'
                   />
                 )}
                 <input

--- a/components/modal/admin/AdminProfileModal.tsx
+++ b/components/modal/admin/AdminProfileModal.tsx
@@ -108,12 +108,14 @@ export default function AdminProfileModal(props: AdminProfileProps) {
           <div className={styles.top}>
             <div className={styles.imageWrap}>
               <label className={styles.image}>
-                <Image
-                  src={imgPreview ? imgPreview : `${userInfo?.userImageUri}`}
-                  width='200'
-                  height='200'
-                  alt='Profile Image'
-                />
+                {userInfo.userImageUri && (
+                  <Image
+                    src={imgPreview ? imgPreview : `${userInfo?.userImageUri}`}
+                    width='200'
+                    height='200'
+                    alt='Profile Image'
+                  />
+                )}
                 <input
                   type='file'
                   style={{ display: 'none' }}

--- a/components/modal/admin/AdminProfileModal.tsx
+++ b/components/modal/admin/AdminProfileModal.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSetRecoilState } from 'recoil';
 import {
   AdminProfileProps,
@@ -12,7 +12,6 @@ import { toastState } from 'utils/recoil/toast';
 import instance from 'utils/axios';
 import useUploadImg from 'hooks/useUploadImg';
 import styles from 'styles/admin/modal/AdminProfile.module.scss';
-import { errorState } from 'utils/recoil/error';
 
 const STAT_MSG_LIMIT = 30;
 
@@ -115,6 +114,7 @@ export default function AdminProfileModal(props: AdminProfileProps) {
           clicked: true,
         });
       }
+      setModal({ modalName: null });
     } catch (e: any) {
       setSnackBar({
         toastName: 'profile',

--- a/components/modal/admin/AdminProfileModal.tsx
+++ b/components/modal/admin/AdminProfileModal.tsx
@@ -82,11 +82,12 @@ export default function AdminProfileModal(props: AdminProfileProps) {
         type: 'application/json',
       })
     );
-    formData.append(
-      'multipartFile',
-      new Blob([imgData as File], { type: 'image/jpeg' })
-    );
-
+    if (imgData) {
+      formData.append(
+        'multipartFile',
+        new Blob([imgData], { type: 'image/jpeg' })
+      );
+    }
     try {
       await instance.put(
         `/pingpong/admin/users/${props.value}/detail`,
@@ -109,8 +110,8 @@ export default function AdminProfileModal(props: AdminProfileProps) {
               <label className={styles.image}>
                 <Image
                   src={imgPreview ? imgPreview : `${userInfo?.userImageUri}`}
-                  width='120'
-                  height='110'
+                  width='200'
+                  height='200'
                   alt='Profile Image'
                 />
                 <input

--- a/components/modal/admin/AdminProfileModal.tsx
+++ b/components/modal/admin/AdminProfileModal.tsx
@@ -138,7 +138,7 @@ export default function AdminProfileModal(props: AdminProfileProps) {
                 {userInfo.userImageUri && (
                   <Image
                     src={imgPreview ? imgPreview : `${userInfo?.userImageUri}`}
-                    alt='이미지가 규격에 맞지 않거나 없습니다'
+                    alt='Profile Image'
                     layout='fill'
                   />
                 )}

--- a/hooks/useUploadImg.ts
+++ b/hooks/useUploadImg.ts
@@ -3,7 +3,7 @@ import { useSetRecoilState } from 'recoil';
 import { errorState } from 'utils/recoil/error';
 import imageCompression from 'browser-image-compression';
 
-export default async function useUploadImg() {
+export default function useUploadImg() {
   const [imgData, setImgData] = useState<File | null>(null);
   const [imgPreview, setImgPreview] = useState<string>('');
   const [file, setFile] = useState<File | null>(null);

--- a/hooks/useUploadImg.ts
+++ b/hooks/useUploadImg.ts
@@ -1,6 +1,6 @@
 import { ChangeEvent, useEffect, useState } from 'react';
 import { useSetRecoilState } from 'recoil';
-import { errorState } from 'utils/recoil/error';
+import { toastState } from 'utils/recoil/toast';
 import imageCompression from 'browser-image-compression';
 
 export default function useUploadImg() {
@@ -8,7 +8,7 @@ export default function useUploadImg() {
   const [imgPreview, setImgPreview] = useState<string>('');
   const [file, setFile] = useState<File | null>(null);
 
-  const setError = useSetRecoilState(errorState);
+  const setSnackbar = useSetRecoilState(toastState);
   const uploadImg = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files?.[0]) setFile(e.target.files?.[0]);
   };
@@ -29,7 +29,12 @@ export default function useUploadImg() {
         setImgPreview(reader.result as string);
       };
     } catch (error) {
-      setError('SW00');
+      setSnackbar({
+        toastName: 'uploadImg',
+        severity: 'error',
+        message: '이미지 압축에 실패했습니다.',
+        clicked: false,
+      });
     }
   };
 

--- a/hooks/useUploadImg.ts
+++ b/hooks/useUploadImg.ts
@@ -3,28 +3,28 @@ import { useSetRecoilState } from 'recoil';
 import { errorState } from 'utils/recoil/error';
 import imageCompression from 'browser-image-compression';
 
-export default function useUploadImg() {
-  const [imgData, setImgData] = useState<File>();
-  const [imgPreview, setImgPreview] = useState<string>();
+export default async function useUploadImg() {
+  const [imgData, setImgData] = useState<File | null>(null);
+  const [imgPreview, setImgPreview] = useState<string>('');
+  const [file, setFile] = useState<File | null>(null);
 
   const setError = useSetRecoilState(errorState);
   const uploadImg = (e: ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      setImgData(file);
-    }
+    if (e.target.files?.[0]) setFile(e.target.files?.[0]);
   };
 
   const imgCompress = async (fileSrc: File) => {
-    /* const options = {
-      maxSizeMB: 0.1,
-      maxWidthOrHeight: 320,
+    const options = {
+      maxSizeMB: 0.03,
+      maxWidthOrHeight: 150,
+      filetype: 'image/jpeg',
       useWebWorker: true,
-    }; */
+    };
     try {
-      //   const res = await imageCompression(fileSrc, options);
+      const res = await imageCompression(fileSrc, options);
       const reader = new FileReader();
-      reader.readAsDataURL(fileSrc);
+      setImgData(res);
+      reader.readAsDataURL(res);
       reader.onloadend = () => {
         setImgPreview(reader.result as string);
       };
@@ -34,10 +34,10 @@ export default function useUploadImg() {
   };
 
   useEffect(() => {
-    if (imgData) {
-      imgCompress(imgData);
+    if (file) {
+      imgCompress(file);
     }
-  }, [imgData]);
+  }, [file]);
 
   return { imgData, imgPreview, uploadImg };
 }

--- a/hooks/useUploadImg.ts
+++ b/hooks/useUploadImg.ts
@@ -33,7 +33,7 @@ export default function useUploadImg() {
         toastName: 'uploadImg',
         severity: 'error',
         message: '이미지 압축에 실패했습니다.',
-        clicked: false,
+        clicked: true,
       });
     }
   };

--- a/pages/admin/penalty.tsx
+++ b/pages/admin/penalty.tsx
@@ -1,19 +1,3 @@
-import { useSetRecoilState } from 'recoil';
-import { modalState } from 'utils/recoil/modal';
-
 export default function Penalty() {
-  const setModal = useSetRecoilState(modalState);
-
-  return (
-    <div>
-      penalty page{' '}
-      <button
-        onClick={() =>
-          setModal({ modalName: 'ADMIN-PENALTY', intraId: 'daijeong' })
-        }
-      >
-        패널티 부여
-      </button>
-    </div>
-  );
+  return <div></div>;
 }

--- a/styles/admin/modal/AdminProfile.module.scss
+++ b/styles/admin/modal/AdminProfile.module.scss
@@ -149,6 +149,7 @@
   background-color: #2678f3;
   font-size: 15px;
   color: white;
+  cursor: pointer;
 }
 
 .btnGray {
@@ -163,6 +164,7 @@
   background-color: #6c757d;
   font-size: 15px;
   color: white;
+  cursor: pointer;
 }
 
 .racketTypeWrap {

--- a/types/admin/adminUserTypes.ts
+++ b/types/admin/adminUserTypes.ts
@@ -2,11 +2,11 @@ export type UserInfo = {
   intraId: string;
   userImageUri: string | null;
   racketType: string;
-  statusMessage: string | '';
-  wins: number;
-  losses: number;
-  ppp: number;
-  email: string | '';
+  statusMessage: string;
+  wins: number | '';
+  losses: number | '';
+  ppp: number | '';
+  email: string;
   roleType: string;
 };
 

--- a/types/admin/adminUserTypes.ts
+++ b/types/admin/adminUserTypes.ts
@@ -6,7 +6,7 @@ export type UserInfo = {
   wins: number;
   losses: number;
   ppp: number;
-  eMail: string | '';
+  email: string | '';
   roleType: string;
 };
 


### PR DESCRIPTION
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
이미지 압축기능 추가
토스트로 오류 처리 (아직 토스트가 완성되지 않아서 주석으로 처리)
여러가지 에러 처리
이메일 eMail->email로 변경 (eMail로 작성해도 백에서 자동으로 email로 바꿔준다고 합니다)
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
<details>

- 정보가 수정되지 않았을 때 보내는 방식 수정   
    - 이미지는 수정되지 않으면 폼데이터에서 제거   
    - 이미지 제외 모든 정보는 수정 여부에 상관없이 폼데이터에 추가   
- 에러 수정
    - 404 에러 수정 (유저 이미지 초기값이 null인 상태로 렌더링하여 띄워주려해서 생긴 현상)
    - 이미지 정보를 받아도 모달에 뜨지 않는 현상 해결
       (이미지 태그의 width, height 값이 실제 이미지 크기보다 작아서 생김 -> 압축으로 크기 지정)
- 압축 기능 추가
    - browser-image-compression 라이브러리를 사용하는데 에러 발생 해결
      (현재 custom hook으로 파일 업로드를 따로 빼서 관리하는데 export하는 함수에 async를 제거하여 해결)
    - 압축하고 보내는데 타입 관련해서 문제가 지속적으로 발생 해결
      (압축된 imgData를 제대로 보내지 않아 생긴 문제)
- 에러 상태 수정
      (200 정상, 207 랭크정보만 없어서 수정 불가, 400 잘못된 요청, 401 권한 없음, 413 파일 용량제한 에러, 415 파일 확장자 에러)
      - 토스트 메시지로 처리
- 프로필 이미지가 없는 경우
    - 현재 유저에게 보여지는 프로필은 돔의 규격에 맞지 않으면 다스베이더를 보여줍니다
      하지만 관리자에게 다스베이더를 보여줄 필요는 없다고 판단하여 alt 메세지 수정
      관리자가 이미지를 바꿔주면 이미지 압축을 맞게 해주어 문제 없을 것으로 판단 (사용자가 보는 프로필 이미지는 다시 확인 필요)
- input type=number 에러
  api를 불러왔을 때 null이면 warning문구가 나타남
  여러 방식을 써본 결과 input type을 number로 고정시키면 null일 때 0으로 만들어주면 해결되지만
  0일때 입력을 넣으면 0에 숫자가 이어붙어 01 이런식으로 표현이 됩니다
  결국 input type을 없애고 0일때 숫자를 입력하면 바로 그 숫자로 바뀌게 수정했습니다
  -> 무슨 상황인지 이해 안되시면 바꾸기 이전 커밋으로 가서 pages/admin/users에 userid를 370으로 바꾸고 모달을 띄워보시면 됩니다
</details>
저번 PR에서 달라진 점이 거의 없어서 마지막 커밋 세개만 확인해주시고 문제 없으면 merge하겠습니다

## ✅ 변경로직<!--  고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
- 유저 페이지에 모달 연결
- toast message
- 이미지 alt 수정
 
## 추가 필요한 작업
- [x] 유저가 보는 페이지의 프로필 이미지가 관리자 페이지에서 압축시킨 이미지의 규격에 맞는지 확인 필요
- [x] 토스트 메세지 붙이기
- [x] 207상태를 200상태와 다르게 처리하는 작업 필요
- [x] input의 value가 null일 때 warning이 뜨는 경우 수정 필요
