### PR TITLE
[Fix] 유저 검색 intraID 고정 안되는 에러 수정 #701

### DIFF
--- a/components/admin/common/AdminSearchBar.tsx
+++ b/components/admin/common/AdminSearchBar.tsx
@@ -98,6 +98,7 @@ export default function AdminSearchBar({
               <div
                 key={intraId}
                 onClick={() => {
+                  setKeyword(intraId);
                   initSearch(intraId);
                   setShowDropDown(false);
                 }}


### PR DESCRIPTION
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 유저 검색 기능 intraID 고정 안되는 에러 수정

 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - [X] 관리자 페이지의 알림 관리 카데고리에서 유저 검색할 때 검색된 intraID 클릭 시, 입력창에 intraID가 고정되지 않는 에러 수정
## 확인 방법
1. `npm i && npm run dev` 실행
2. 관리자 페이지의 알림 관리 카데고리로 이동
3. "유저 검색하기" 입력창에 intraID 아무거나 검색
4. 추천 검색어로 뜨는 intraID 중 원하는 intraID 클릭
5. 클릭 시에 유저 검색하는 입력창에 클릭한 intraID가 자동으로 고정이 되는지 확인 
 
## 관련 이슈 
- #701 
