### PR TITLE
[Fix] 관리자 특정 유저 알림 모달 내 유저 검색하기 기능 에러 수정 #669

### DIFF
--- a/components/admin/notification/CreateNotiButton.tsx
+++ b/components/admin/notification/CreateNotiButton.tsx
@@ -16,7 +16,9 @@ export default function CreateNotiButton() {
         </button>
         <button
           className={style.createSomeoneButton}
-          onClick={() => setModal({ modalName: 'ADMIN-NOTI_USER' })}
+          onClick={() =>
+            setModal({ modalName: 'ADMIN-NOTI_USER', intraId: 'test' })
+          }
         >
           User
         </button>

--- a/components/admin/notification/CreateNotiButton.tsx
+++ b/components/admin/notification/CreateNotiButton.tsx
@@ -16,9 +16,7 @@ export default function CreateNotiButton() {
         </button>
         <button
           className={style.createSomeoneButton}
-          onClick={() =>
-            setModal({ modalName: 'ADMIN-NOTI_USER', intraId: 'test' })
-          }
+          onClick={() => setModal({ modalName: 'ADMIN-NOTI_USER' })}
         >
           User
         </button>

--- a/components/modal/ModalProvider.tsx
+++ b/components/modal/ModalProvider.tsx
@@ -53,7 +53,7 @@ export default function ModalProvider() {
     'ADMIN-PROFILE': userId ? <AdminProfileModal value={userId} /> : null,
     'ADMIN-PENALTY': intraId ? <AdminPenaltyModal value={intraId} /> : null,
     'ADMIN-NOTI_ALL': <AdminNotiAllModal />,
-    'ADMIN-NOTI_USER': intraId ? <AdminNotiUserModal value={intraId} /> : null,
+    'ADMIN-NOTI_USER': <AdminNotiUserModal />,
     'ADMIN-CHECK_FEEDBACK': feedback ? (
       <AdminCheckFeedback {...feedback} />
     ) : null,

--- a/components/modal/admin/AdminNotiAllModal.tsx
+++ b/components/modal/admin/AdminNotiAllModal.tsx
@@ -22,7 +22,7 @@ export default function AdminNotiAllModal() {
   return (
     <div className={styles.whole}>
       <div className={styles.title}>
-        <div className={styles.titleText}>모두에게 적용</div>
+        <div className={styles.titleText}>전체 알림</div>
         <hr className={styles.hr} />
       </div>
       <label className={styles.body}>

--- a/components/modal/admin/AdminNotiUserModal.tsx
+++ b/components/modal/admin/AdminNotiUserModal.tsx
@@ -96,7 +96,6 @@ export default function AdminNotiUserModal(props: any) {
                   <span
                     className={styles.reset}
                     onClick={() => {
-                      // setKeyword;
                       setKeyword('');
                     }}
                   >
@@ -105,7 +104,6 @@ export default function AdminNotiUserModal(props: any) {
                 ) : (
                   <span
                     onClick={() => {
-                      // initSearch();
                       setKeyword('');
                       setShowDropDown(false);
                     }}

--- a/components/modal/admin/AdminNotiUserModal.tsx
+++ b/components/modal/admin/AdminNotiUserModal.tsx
@@ -1,17 +1,66 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSetRecoilState } from 'recoil';
+import instance from 'utils/axios';
 import { modalState } from 'utils/recoil/modal';
 import { toastState } from 'utils/recoil/toast';
-import instance from 'utils/axios';
-import { finished } from 'stream';
+import { errorState } from 'utils/recoil/error';
+import { GoSearch } from 'react-icons/go';
+import { IoIosCloseCircle } from 'react-icons/io';
 import styles from 'styles/admin/modal/AdminNoti.module.scss';
+import { finished } from 'stream';
 
-//noti가 비어있을 때 적용안되게 수정필요
+let timer: ReturnType<typeof setTimeout>;
+
+const MAX_SEARCH_LENGTH = 15;
 
 export default function AdminNotiUserModal(props: any) {
   const setModal = useSetRecoilState(modalState);
   const setSnackBar = useSetRecoilState(toastState);
   const notiContent = useRef<HTMLTextAreaElement>(null);
+
+  const [keyword, setKeyword] = useState<string>('');
+  const [showDropDown, setShowDropDown] = useState<boolean>(false);
+  const [searchResult, setSearchResult] = useState<string[]>([]);
+  const setError = useSetRecoilState(errorState);
+  const searchBarRef = useRef<HTMLDivElement>(null);
+
+  const getSearchResultHandler = useCallback(async () => {
+    try {
+      const res = await instance.get(`/pingpong/users/searches?q=${keyword}`);
+      setSearchResult(res?.data.users);
+    } catch (e) {
+      setError('MS02');
+    }
+  }, [keyword, setError]);
+
+  useEffect(() => {
+    const checkId = /^[a-z|A-Z|0-9|-]+$/;
+    if (keyword === '' || (keyword.length && !checkId.test(keyword))) {
+      clearTimeout(timer);
+      setSearchResult([]);
+    } else if (checkId.test(keyword)) {
+      debounce(getSearchResultHandler, 500)();
+    }
+  }, [keyword, getSearchResultHandler]);
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (
+      searchBarRef.current &&
+      !searchBarRef.current.contains(event.target as Node)
+    )
+      setShowDropDown(false);
+  };
+
+  const keywordHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setKeyword(event.target.value);
+  };
 
   const handleClick = useCallback(() => {
     setSnackBar({
@@ -33,11 +82,63 @@ export default function AdminNotiUserModal(props: any) {
         <div className={styles.bodyWrap}>
           <div className={styles.intraWrap}>
             <div className={styles.bodyText}>intra ID</div>
-            <textarea
+            <div className={styles.adminSearchBar} ref={searchBarRef}>
+              <input
+                type='text'
+                onChange={keywordHandler}
+                onFocus={() => setShowDropDown(true)}
+                placeholder='유저 검색하기'
+                maxLength={MAX_SEARCH_LENGTH}
+                value={keyword}
+              />
+              <div className={styles.icons}>
+                {keyword ? (
+                  <span
+                    className={styles.reset}
+                    onClick={() => {
+                      // setKeyword;
+                      setKeyword('');
+                    }}
+                  >
+                    <IoIosCloseCircle />
+                  </span>
+                ) : (
+                  <span
+                    onClick={() => {
+                      // initSearch();
+                      setKeyword('');
+                      setShowDropDown(false);
+                    }}
+                  >
+                    <GoSearch />
+                  </span>
+                )}
+              </div>
+              {showDropDown && keyword && (
+                <div className={styles.dropdown}>
+                  {searchResult.length ? (
+                    searchResult.map((intraId: string) => (
+                      <div
+                        key={intraId}
+                        onClick={() => {
+                          setKeyword(intraId);
+                          setShowDropDown(false);
+                        }}
+                      >
+                        {intraId}
+                      </div>
+                    ))
+                  ) : (
+                    <div className={styles.noneText}>검색 결과가 없습니다.</div>
+                  )}
+                </div>
+              )}
+            </div>
+            {/* <textarea
               className={styles.intraBlank}
               name='intraID'
               placeholder={'intra ID를 입력하세요'}
-            />
+            /> */}
           </div>
           <div className={styles.messageWrap}>
             <div className={styles.bodyText}>message</div>
@@ -69,4 +170,13 @@ export default function AdminNotiUserModal(props: any) {
       </label>
     </div>
   );
+}
+
+function debounce(callback: () => void, timeout: number) {
+  return () => {
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      callback();
+    }, timeout);
+  };
 }

--- a/components/modal/admin/AdminNotiUserModal.tsx
+++ b/components/modal/admin/AdminNotiUserModal.tsx
@@ -3,7 +3,6 @@ import { useSetRecoilState } from 'recoil';
 import instance from 'utils/axios';
 import { modalState } from 'utils/recoil/modal';
 import { toastState } from 'utils/recoil/toast';
-import { errorState } from 'utils/recoil/error';
 import { GoSearch } from 'react-icons/go';
 import { IoIosCloseCircle } from 'react-icons/io';
 import styles from 'styles/admin/modal/AdminNoti.module.scss';
@@ -21,7 +20,6 @@ export default function AdminNotiUserModal(props: any) {
   const [keyword, setKeyword] = useState<string>('');
   const [showDropDown, setShowDropDown] = useState<boolean>(false);
   const [searchResult, setSearchResult] = useState<string[]>([]);
-  const setError = useSetRecoilState(errorState);
   const searchBarRef = useRef<HTMLDivElement>(null);
 
   const getSearchResultHandler = useCallback(async () => {
@@ -29,9 +27,14 @@ export default function AdminNotiUserModal(props: any) {
       const res = await instance.get(`/pingpong/users/searches?q=${keyword}`);
       setSearchResult(res?.data.users);
     } catch (e) {
-      setError('MS02');
+      setSnackBar({
+        toastName: 'noti user',
+        severity: 'error',
+        message: `MS02`,
+        clicked: true,
+      });
     }
-  }, [keyword, setError]);
+  }, [keyword, setSnackBar]);
 
   useEffect(() => {
     const checkId = /^[a-z|A-Z|0-9|-]+$/;
@@ -64,7 +67,7 @@ export default function AdminNotiUserModal(props: any) {
 
   const handleClick = useCallback(() => {
     setSnackBar({
-      toastName: 'noti all',
+      toastName: 'noti user',
       severity: 'success',
       message: `성공적으로 전송되었습니다! ${notiContent.current?.value}`,
       clicked: true,

--- a/components/modal/admin/AdminNotiUserModal.tsx
+++ b/components/modal/admin/AdminNotiUserModal.tsx
@@ -135,11 +135,6 @@ export default function AdminNotiUserModal(props: any) {
                 </div>
               )}
             </div>
-            {/* <textarea
-              className={styles.intraBlank}
-              name='intraID'
-              placeholder={'intra ID를 입력하세요'}
-            /> */}
           </div>
           <div className={styles.messageWrap}>
             <div className={styles.bodyText}>message</div>

--- a/components/modal/admin/AdminNotiUserModal.tsx
+++ b/components/modal/admin/AdminNotiUserModal.tsx
@@ -12,7 +12,7 @@ let timer: ReturnType<typeof setTimeout>;
 
 const MAX_SEARCH_LENGTH = 15;
 
-export default function AdminNotiUserModal(props: any) {
+export default function AdminNotiUserModal() {
   const setModal = useSetRecoilState(modalState);
   const setSnackBar = useSetRecoilState(toastState);
   const notiContent = useRef<HTMLTextAreaElement>(null);

--- a/components/modal/admin/AdminNotiUserModal.tsx
+++ b/components/modal/admin/AdminNotiUserModal.tsx
@@ -81,7 +81,7 @@ export default function AdminNotiUserModal(props: any) {
         <div className={styles.titleText}>특정 유저 알림</div>
         <hr className={styles.hr} />
       </div>
-      <label className={styles.body}>
+      <div className={styles.body}>
         <div className={styles.bodyWrap}>
           <div className={styles.intraWrap}>
             <div className={styles.bodyText}>intra ID</div>
@@ -168,7 +168,7 @@ export default function AdminNotiUserModal(props: any) {
             취소
           </button>
         </div>
-      </label>
+      </div>
     </div>
   );
 }

--- a/components/modal/admin/AdminNotiUserModal.tsx
+++ b/components/modal/admin/AdminNotiUserModal.tsx
@@ -26,7 +26,7 @@ export default function AdminNotiUserModal(props: any) {
   return (
     <div className={styles.whole}>
       <div className={styles.title}>
-        <div className={styles.titleText}>Noti For {props.value}</div>
+        <div className={styles.titleText}>특정 유저 알림</div>
         <hr className={styles.hr} />
       </div>
       <label className={styles.body}>

--- a/styles/admin/modal/AdminNoti.module.scss
+++ b/styles/admin/modal/AdminNoti.module.scss
@@ -70,17 +70,6 @@
   margin-bottom: 10px;
 }
 
-// .intraBlank {
-//   display: flex;
-//   width: 275px;
-//   height: 33px;
-//   resize: none;
-//   box-sizing: border-box;
-//   background: #f9fafb;
-//   border: 0.5px solid #ced4da;
-//   border-radius: 1px;
-// }
-
 .messageWrap {
   padding: 0rem 0rem;
 }

--- a/styles/admin/modal/AdminNoti.module.scss
+++ b/styles/admin/modal/AdminNoti.module.scss
@@ -1,3 +1,5 @@
+@import 'styles/common.scss';
+
 .whole {
   display: flex;
   flex-direction: column;
@@ -68,16 +70,16 @@
   margin-bottom: 10px;
 }
 
-.intraBlank {
-  display: flex;
-  width: 275px;
-  height: 33px;
-  resize: none;
-  box-sizing: border-box;
-  background: #f9fafb;
-  border: 0.5px solid #ced4da;
-  border-radius: 1px;
-}
+// .intraBlank {
+//   display: flex;
+//   width: 275px;
+//   height: 33px;
+//   resize: none;
+//   box-sizing: border-box;
+//   background: #f9fafb;
+//   border: 0.5px solid #ced4da;
+//   border-radius: 1px;
+// }
 
 .messageWrap {
   padding: 0rem 0rem;
@@ -134,4 +136,54 @@
   visibility: hidden;
   margin-left: auto;
   margin-right: auto;
+}
+
+.adminSearchBar {
+  display: flex;
+  flex-wrap: wrap;
+  width: 275px;
+  height: 33px;
+  background: white;
+  border: 0.5px solid #ced4da;
+  border-radius: 1px;
+  cursor: text;
+
+  input {
+    padding: 0.5rem 0.8rem;
+    all: unset;
+    margin-left: 0.5rem;
+    width: calc(100% - 4rem);
+    color: black;
+  }
+  .icons {
+    span {
+      margin-left: 30px;
+      height: 33px;
+      display: flex;
+      align-items: center;
+      font-size: 1.2rem;
+    }
+    .reset {
+      height: 33px;
+      color: gray;
+      cursor: pointer;
+    }
+  }
+  .dropdown {
+    width: 275px;
+    width: 100%;
+    z-index: 999;
+    padding: 0 0.8rem 0.5rem 0.5rem;
+    color: black;
+    border: 1px solid #ced4da;
+    border-radius: 0 0 $small-radius $small-radius;
+    background: white;
+    div {
+      padding: 0.5rem 0;
+      cursor: pointer;
+    }
+    .noneText {
+      color: black;
+    }
+  }
 }


### PR DESCRIPTION
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 관리자 페이지의 특정 유저 알림 모달 내의 "유저 검색하기" 기능의 에러를 수정하였습니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  **Before** 
<img width="502" alt="스크린샷 2023-03-02 오후 3 55 23" src="https://user-images.githubusercontent.com/95270655/222353639-923f6135-44a8-45a4-b64e-310f1ebaf31e.png">

Before 사진에서는 일치하는 intra ID를 클릭하고 나서도 하단의 dropDown 부분이 사라지지 않는 상태인 것을 확인할 수 있습니다

**After**
<img width="499" alt="스크린샷 2023-03-02 오후 3 55 58" src="https://user-images.githubusercontent.com/95270655/222353757-92e65e13-e34b-46f4-b0ce-88fe8c7f3aef.png">

코드를 수정한 뒤 정상적으로 dropDown 부분이 사라진 것을 확인할 수 있습니다

label로 감싸져 있었던 부분을 div 태그로 변경해주었습니다.
**Before**
<img width="478" alt="스크린샷 2023-03-02 오후 3 59 15" src="https://user-images.githubusercontent.com/95270655/222354340-b3a828e3-56f3-4458-ab78-ab3a36e57515.png">

**After**
<img width="487" alt="스크린샷 2023-03-02 오후 4 00 22" src="https://user-images.githubusercontent.com/95270655/222354568-5fcaa0e5-6cf3-4697-854e-0639d7ddb71a.png">#705 

## Etc
- #669 