### PR TITLE
[Feat] 관리자 전체 알림 모달 API 추가 #713

### DIFF
--- a/components/modal/admin/AdminNotiAllModal.tsx
+++ b/components/modal/admin/AdminNotiAllModal.tsx
@@ -7,16 +7,11 @@ import instance from 'utils/axios';
 import styles from 'styles/admin/modal/AdminNoti.module.scss';
 
 export default function AdminNotiAllModal() {
-  const [notiAllInfo, setNotiAllInfo] = useState<NotiAllInfo>({
-    message: '',
-    sendMail: false,
-  });
-
   const setModal = useSetRecoilState(modalState);
   const setSnackBar = useSetRecoilState(toastState);
   const notiContent = useRef<HTMLTextAreaElement>(null);
 
-  const sendNotificationHandler = async (sendMail: boolean) => {
+  const sendNotificationHandler = async () => {
     if (notiContent.current?.value === '') {
       setSnackBar({
         toastName: 'noti all',
@@ -35,12 +30,28 @@ export default function AdminNotiAllModal() {
       setModal({ modalName: null });
     }
     try {
-      await instance.post(`pingpong/admin/notifications/`, {
+      const res = await instance.post(`pingpong/admin/notifications/`, {
         message: notiContent.current?.value
           ? notiContent.current?.value
           : '알림 전송 실패',
-        sendMail: false,
       });
+      if (res.status === 200) {
+        setSnackBar({
+          toastName: 'noti all',
+          severity: 'success',
+          message: `성공적으로 전송되었습니다!`,
+          clicked: true,
+        });
+        setModal({ modalName: null });
+      } else {
+        setSnackBar({
+          toastName: 'noti all',
+          severity: 'error',
+          message: `전송에 실패하였습니다!`,
+          clicked: true,
+        });
+        setModal({ modalName: null });
+      }
     } catch (e) {
       setSnackBar({
         toastName: 'noti all',
@@ -71,7 +82,7 @@ export default function AdminNotiAllModal() {
         <div className={styles.btns}>
           <button
             onClick={() => {
-              sendNotificationHandler(true);
+              sendNotificationHandler();
             }}
             className={styles.btn1}
           >

--- a/types/admin/adminNotiAllTypes.ts
+++ b/types/admin/adminNotiAllTypes.ts
@@ -1,4 +1,3 @@
 export type NotiAllInfo = {
   message: string;
-  sendMail: boolean;
 };

--- a/types/admin/adminNotiAllTypes.ts
+++ b/types/admin/adminNotiAllTypes.ts
@@ -1,0 +1,4 @@
+export type NotiAllInfo = {
+  message: string;
+  sendMail: boolean;
+};


### PR DESCRIPTION
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 관리자 전체 알림 모달에 API 추가하기
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
- [X]  관리자 전체 알림 모달 API 추가
## 확인 방법
1. `npm i && npm run dev` 실행
2. "알림 관리" 페이지로 이동
3. 우측 상단에 있는 [All] 버튼 클릭
4. 전체에게 알릴 내용을 작성하고 전송
5. 전송 버튼을 눌렀을 때에 정확한 토스트 메시지가 띄워지는지 확인
6. 새로고침하고 나서 "알림 관리" 페이지를 통해 전체에게 알림이 전송 되었는지 확인

## 관련 이슈
- #713 
 
