### PR TITLE
[Feat] 승,패가 0일 때 ppp 1000으로 고정 #733

### DIFF
--- a/components/modal/admin/AdminProfileModal.tsx
+++ b/components/modal/admin/AdminProfileModal.tsx
@@ -61,6 +61,12 @@ export default function AdminProfileModal(props: AdminProfileProps) {
     setUserInfo({ ...userInfo, [name]: value });
   };
 
+  useEffect(() => {
+    if (userInfo.wins === 0 && userInfo.losses === 0) {
+      setUserInfo({ ...userInfo, ppp: 1000 });
+    }
+  }, [userInfo.wins, userInfo.losses, userInfo.ppp]);
+
   const inputNumHandler = ({
     target: { name, value },
   }: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 0승 0패일 때 ppp 1000으로 고정. 승 패가 바뀌지 않는데 ppp가 바뀌면 랭크 정렬이 되면서 순위가 -로 뜨는 현상 때문에 예외처리 하였습니다. 나중에 백에서 로직을 바꾸면서 같이 수정될 부분입니다!
 
