### PR TITLE
[GGFE-16] Game - 게임 결과 등록과 조회

### DIFF
--- a/components/modal/statChange/StatChangeModal.tsx
+++ b/components/modal/statChange/StatChangeModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { Exp } from 'types/modalTypes';
+import { GameResult } from 'types/gameTypes';
 import { modalState } from 'utils/recoil/modal';
 import { reloadMatchState } from 'utils/recoil/match';
 import ExpStat from './ExpStat';
@@ -11,17 +12,14 @@ import useAxiosGet from 'hooks/useAxiosGet';
 export default function StatChangeModal({ gameId, mode }: Exp) {
   const setModal = useSetRecoilState(modalState);
   const setReloadMatch = useSetRecoilState(reloadMatchState);
-  const [stat, setStat] = useState();
-
+  const [stat, setStat] = useState<GameResult | undefined>();
   useEffect(() => {
     getExpHandler();
   }, []);
 
   const getExpHandler = useAxiosGet({
     url: `/pingpong/games/${gameId}/result/${mode}`,
-    setState: (data) => {
-      setStat({ ...data });
-    },
+    setState: setStat,
     err: 'KP03',
     type: 'setError',
   });

--- a/hooks/modal/aftergame/useCurrentGame.ts
+++ b/hooks/modal/aftergame/useCurrentGame.ts
@@ -14,8 +14,8 @@ const useCurrentGame = () => {
     startTime: '2022-07-13 11:50',
     isScoreExist: false,
     matchTeamsInfo: {
-      myTeam: { teamScore: 0, teams: [] },
-      enemyTeam: { teamScore: 0, teams: [] },
+      myTeam: { teamScore: 0, teamId: 0, players: [] },
+      enemyTeam: { teamScore: 0, teamId: 0, players: [] },
     },
   });
 

--- a/hooks/modal/aftergame/useSubmitModal.ts
+++ b/hooks/modal/aftergame/useSubmitModal.ts
@@ -12,6 +12,12 @@ type rankRequest = {
   enemyTeamScore: number | '';
 };
 
+type normalRequest = {
+  gameId: number;
+  myTeamId: number;
+  enemyTeamId: number;
+};
+
 const useSubmitModal = (currentGame: AfterGame) => {
   const setError = useSetRecoilState(errorState);
   const setModal = useSetRecoilState(modalState);
@@ -41,8 +47,13 @@ const useSubmitModal = (currentGame: AfterGame) => {
   };
 
   const submitNormalHandler = async () => {
+    const requestBody: normalRequest = {
+      gameId: currentGame.gameId,
+      myTeamId: currentGame.matchTeamsInfo.myTeam.teamId,
+      enemyTeamId: currentGame.matchTeamsInfo.enemyTeam.teamId,
+    };
     try {
-      await instance.post(`/pingpong/games/result/normal`);
+      await instance.post(`/pingpong/games/normal`, requestBody);
       await instance.put(`/pingpong/match/current`);
     } catch (e) {
       setError('KP04');

--- a/hooks/modal/aftergame/useSubmitModal.ts
+++ b/hooks/modal/aftergame/useSubmitModal.ts
@@ -21,6 +21,8 @@ type normalRequest = {
 const useSubmitModal = (currentGame: AfterGame) => {
   const setError = useSetRecoilState(errorState);
   const setModal = useSetRecoilState(modalState);
+  const { gameId, matchTeamsInfo, mode } = currentGame;
+  const { myTeam, enemyTeam } = matchTeamsInfo;
 
   const rankResponse: { [key: string]: string } = {
     '201': '결과 입력이 완료되었습니다.',
@@ -30,10 +32,10 @@ const useSubmitModal = (currentGame: AfterGame) => {
   const submitRankHandler = async (result: TeamScore) => {
     try {
       const requestBody: rankRequest = {
-        gameId: currentGame.gameId,
-        myTeamId: currentGame.matchTeamsInfo.myTeam.teamId,
+        gameId: gameId,
+        myTeamId: myTeam.teamId,
         myTeamScore: result.myTeamScore,
-        enemyTeamId: currentGame.matchTeamsInfo.enemyTeam.teamId,
+        enemyTeamId: enemyTeam.teamId,
         enemyTeamScore: result.enemyTeamScore,
       };
       const res = await instance.post(`/pingpong/games/rank`, requestBody);
@@ -48,9 +50,9 @@ const useSubmitModal = (currentGame: AfterGame) => {
 
   const submitNormalHandler = async () => {
     const requestBody: normalRequest = {
-      gameId: currentGame.gameId,
-      myTeamId: currentGame.matchTeamsInfo.myTeam.teamId,
-      enemyTeamId: currentGame.matchTeamsInfo.enemyTeam.teamId,
+      gameId: gameId,
+      myTeamId: myTeam.teamId,
+      enemyTeamId: enemyTeam.teamId,
     };
     try {
       await instance.post(`/pingpong/games/normal`, requestBody);
@@ -76,8 +78,8 @@ const useSubmitModal = (currentGame: AfterGame) => {
     setModal({
       modalName: 'FIXED-STAT',
       exp: {
-        gameId: currentGame.gameId,
-        mode: currentGame.mode,
+        gameId: gameId,
+        mode: mode,
       },
     });
   };

--- a/hooks/modal/aftergame/useSubmitModal.ts
+++ b/hooks/modal/aftergame/useSubmitModal.ts
@@ -4,6 +4,14 @@ import { errorState } from 'utils/recoil/error';
 import { AfterGame, TeamScore } from 'types/scoreTypes';
 import { instance } from 'utils/axios';
 
+type rankRequest = {
+  gameId: number;
+  myTeamId: number;
+  myTeamScore: number | '';
+  enemyTeamId: number;
+  enemyTeamScore: number | '';
+};
+
 const useSubmitModal = (currentGame: AfterGame) => {
   const setError = useSetRecoilState(errorState);
   const setModal = useSetRecoilState(modalState);
@@ -15,7 +23,14 @@ const useSubmitModal = (currentGame: AfterGame) => {
 
   const submitRankHandler = async (result: TeamScore) => {
     try {
-      const res = await instance.post(`/pingpong/games/result/rank`, result);
+      const requestBody: rankRequest = {
+        gameId: currentGame.gameId,
+        myTeamId: currentGame.matchTeamsInfo.myTeam.teamId,
+        myTeamScore: result.myTeamScore,
+        enemyTeamId: currentGame.matchTeamsInfo.enemyTeam.teamId,
+        enemyTeamScore: result.enemyTeamScore,
+      };
+      const res = await instance.post(`/pingpong/games/rank`, requestBody);
       alert(rankResponse[`${res?.status}`]);
       await instance.put(`/pingpong/match/current`);
     } catch (e) {

--- a/hooks/useAxiosGet.ts
+++ b/hooks/useAxiosGet.ts
@@ -10,6 +10,7 @@ import { PppChart, ProfileBasic, ProfileRank } from 'types/userTypes';
 import { UserInfo } from 'types/admin/adminUserTypes';
 import { EditedSchedule } from 'types/admin/adminSlotTypes';
 import { AfterGame } from 'types/scoreTypes';
+import { GameResult } from 'types/gameTypes';
 
 interface useAxiosGetProps {
   url: string;
@@ -24,6 +25,7 @@ interface useAxiosGetProps {
     | Dispatch<SetStateAction<string>>
     | Dispatch<SetStateAction<EditedSchedule>>
     | Dispatch<SetStateAction<AfterGame>>
+    | Dispatch<SetStateAction<GameResult | undefined>>
     | Dispatch<SetStateAction<undefined>>
     | SetterOrUpdater<User>
     | SetterOrUpdater<SeasonList>

--- a/types/gameTypes.ts
+++ b/types/gameTypes.ts
@@ -28,3 +28,14 @@ export interface Game {
   status: string;
   time: string;
 }
+
+export type GameResult = {
+  beforeExp: number;
+  beforeMaxExp: number;
+  beforeLevel: number;
+  increasedExp: number;
+  increasedLevel: number;
+  afterMaxExp: number;
+  changedPpp?: number;
+  beforePpp?: number;
+};

--- a/types/scoreTypes.ts
+++ b/types/scoreTypes.ts
@@ -11,10 +11,12 @@ export interface TeamScore {
 export interface Player {
   intraId: string;
   userImageUri: string;
+  level: number;
 }
 export interface Team {
   teamScore: number;
-  teams: Player[];
+  teamId: number;
+  players: Player[];
 }
 
 export interface Players {


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->

**게임 종료 후 결과 등록**과 **게임 결과 조회** api 수정

 ## 💻 작업사항 

<!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
 
### 🛠 랭크 게임 결과 등록 🛠

- 전 : /pingpong/games/result/rank
- 후 : /pingpong/games/rank

request body가 본인/상대 점수만 보내주던 방식에서 **본인/상대 점수 포함 게임 ID와 본인 팀/상대 팀 ID까지 보내주는 것으로 변경**되어 해당 부분 수정하였습니다.
관련된 타입의 속성명들을 api 명세와 동일하게 수정하였습니다 (teams -> players)

### 🛠 일반 게임 결과 등록 🛠

- 전 : /pingpong/games/result/normal
- 후 : /pingpong/games/normal

request body가 기존 아무것도 보내지 않던 것에서 **게임 ID와 본인 팀/상대 팀 ID 보내주는 것으로 변경** 되어 해당 부분 수정하였습니다.

❗️추가되는 팀 ID는 이후에 작업할 API에서 새로 받아오게 되어 현재는 타입만 (`types/scoreTypes.ts` 의 `Team`) 추가해두었습니다.

### 🛠 일반/랭크게임 결과 조회 🛠

api 변경사항은 없고 `GameResult` 타입으로 response body에 대한 타입만 지정해주었습니다.

---

**❗️ 백에 아직 해결되지 않은 이슈가 있어서 테스트 전입니다 ❗️**

 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
