### PR TITLE
[GGFE-17] Game - 유저 게임 정보 조회

### DIFF
--- a/components/modal/afterGame/AfterGameModal.tsx
+++ b/components/modal/afterGame/AfterGameModal.tsx
@@ -10,7 +10,7 @@ export default function AfterGameModal() {
 
   if (currentGame.startTime === '2022-07-13 11:50') return null;
 
-  return currentGame.mode === 'normal' ? (
+  return currentGame.mode === 'NORMAL' ? (
     <NormalGame currentGame={currentGame} onSubmit={submitNormalHandler} />
   ) : (
     <RankGame

--- a/hooks/modal/aftergame/useCurrentGame.ts
+++ b/hooks/modal/aftergame/useCurrentGame.ts
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { AxiosResponse } from 'axios';
 import { AfterGame } from 'types/scoreTypes';
+import { MatchMode } from 'types/mainType';
 import { instance } from 'utils/axios';
 import { errorState } from 'utils/recoil/error';
 import { liveState } from 'utils/recoil/layout';
@@ -10,19 +12,24 @@ const useCurrentGame = () => {
   const { currentMatchMode } = useRecoilValue(liveState);
   const [currentGame, setCurrentGame] = useState<AfterGame>({
     gameId: 0,
-    mode: currentMatchMode,
+    mode: currentMatchMode
+      ? (currentMatchMode.toUpperCase() as Uppercase<MatchMode>)
+      : null,
     startTime: '2022-07-13 11:50',
     isScoreExist: false,
+    status: 'LIVE',
     matchTeamsInfo: {
-      myTeam: { teamScore: 0, teams: [] },
-      enemyTeam: { teamScore: 0, teams: [] },
+      myTeam: { teamScore: 0, teamId: 0, players: [] },
+      enemyTeam: { teamScore: 0, teamId: 0, players: [] },
     },
   });
 
   useEffect(() => {
     const getCurrentGameHandler = async () => {
       try {
-        const res = await instance.get(`/pingpong/games/players`);
+        const res: AxiosResponse<AfterGame> = await instance.get(
+          `/pingpong/games/${currentGame.gameId}`
+        );
         setCurrentGame(res.data);
       } catch (e) {
         setError('JH03');

--- a/hooks/modal/aftergame/useSubmitModal.ts
+++ b/hooks/modal/aftergame/useSubmitModal.ts
@@ -3,6 +3,7 @@ import { modalState } from 'utils/recoil/modal';
 import { errorState } from 'utils/recoil/error';
 import { AfterGame, TeamScore } from 'types/scoreTypes';
 import { instance } from 'utils/axios';
+import { MatchMode } from 'types/mainType';
 
 const useSubmitModal = (currentGame: AfterGame) => {
   const setError = useSetRecoilState(errorState);
@@ -51,7 +52,9 @@ const useSubmitModal = (currentGame: AfterGame) => {
       modalName: 'FIXED-STAT',
       exp: {
         gameId: currentGame.gameId,
-        mode: currentGame.mode,
+        mode: currentGame.mode?.toLowerCase() as Lowercase<
+          Uppercase<MatchMode>
+        >,
       },
     });
   };

--- a/types/mainType.ts
+++ b/types/mainType.ts
@@ -11,4 +11,5 @@ export interface Live {
   notiCount: number;
   event: 'match' | 'game' | null;
   currentMatchMode: MatchMode | null;
+  gameId: number | null;
 }

--- a/types/scoreTypes.ts
+++ b/types/scoreTypes.ts
@@ -11,10 +11,12 @@ export interface TeamScore {
 export interface Player {
   intraId: string;
   userImageUri: string;
+  level: number;
 }
 export interface Team {
   teamScore: number;
-  teams: Player[];
+  teamId: number;
+  players: Player[];
 }
 
 export interface Players {
@@ -22,10 +24,11 @@ export interface Players {
   enemyTeam: Team;
 }
 
-export interface AfterGame {
+export type AfterGame = {
+  mode: Uppercase<MatchMode> | null;
   gameId: number;
-  mode: MatchMode | null;
   startTime: string;
   isScoreExist: boolean;
+  status: 'LIVE' | 'WAIT' | 'END';
   matchTeamsInfo: Players;
-}
+};

--- a/utils/recoil/layout.ts
+++ b/utils/recoil/layout.ts
@@ -17,6 +17,7 @@ export const liveState = atom<Live>({
     notiCount: 0,
     event: null,
     currentMatchMode: null,
+    gameId: null,
   },
 });
 


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->

**유저 게임 정보 조회 (게임 종료 후 해당 게임 정보 조회)** api 수정 

 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->

- 전 : /pingpong/games/players
- 후 : /pingpong/games/{gameId}

1. api 호출에 필요한 gameId를 liveState에서 관리하게 되었습니다 
 -> 현재 작업에 필요한 gameId만 Live 타입에 추가했습니다.
2. response body 변경사항에 맞춰서 status 속성을 추가했고 (LIVE : 점수 입력 전, WAIT : 점수 입력 후 대기, END : DB에 저장까지 완료 상태) mode를 기존 소문자에서 대문자로 변경하였습니다.

❗️ ~~점수 입력 확인 및 재입력 요청에 대한 부분은 처리 방법에 대해 논의가 좀 더 필요할 것 같아서 현재는 처리하지 않은 상태이고, 지금은 기존과 동일한 로직입니다.~~ 5/25 회의 결과 재입력 요청 부분 사라지게 되었습니다.

---

**❗️ 위 작업사항 모두 테스트는 match와 live api랑 같이 해야 할 것 같아서 아직 못했습니다! ❗️**

 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
