### PR TITLE
[GGFE-20] 현재 매치 정보 조회 + 매칭 슬롯 취소

### DIFF
--- a/components/Layout/CurrentMatch.tsx
+++ b/components/Layout/CurrentMatch.tsx
@@ -8,7 +8,7 @@ import styles from 'styles/Layout/CurrentMatchInfo.module.scss';
 import useGetCurrentMatch from 'hooks/Layout/useGetCurrentMatch';
 
 export default function CurrentMatch() {
-  const { isMatched, enemyTeam, time, slotId, isImminent } =
+  const { startTime, endTime, isMatched, enemyTeam, isImminent } =
     useRecoilValue(currentMatchState);
   const setModal = useSetRecoilState(modalState);
   const matchingMessage = time && makeMessage(time, isMatched);
@@ -48,6 +48,47 @@ export default function CurrentMatch() {
     </>
   );
 }
+// export default function CurrentMatch() {
+//   const { isMatched, enemyTeam, time, slotId, isImminent } =
+//     useRecoilValue(currentMatchState);
+//   const setModal = useSetRecoilState(modalState);
+//   const matchingMessage = time && makeMessage(time, isMatched);
+//   const blockCancelButton = isImminent && enemyTeam.length;
+
+//   useGetCurrentMatch();
+
+//   const onCancel = () => {
+//     setModal({
+//       modalName: 'MATCH-CANCEL',
+//       cancel: { isMatched, slotId, time },
+//     });
+//   };
+
+//   return (
+//     <>
+//       <div className={styles.container}>
+//         <div className={styles.stringWrapper}>
+//           <div className={styles.icon}>⏰</div>
+//           <div className={styles.messageWrapper}>
+//             {matchingMessage}
+//             <EnemyTeam enemyTeam={enemyTeam} isImminent={isImminent} />
+//           </div>
+//         </div>
+//         <div
+//           className={
+//             blockCancelButton ? styles.blockCancelButton : styles.cancelButton
+//           }
+//         >
+//           <input
+//             type='button'
+//             onClick={onCancel}
+//             value={blockCancelButton ? '취소불가' : '취소하기'}
+//           />
+//         </div>
+//       </div>
+//     </>
+//   );
+// }
 
 function makeMessage(time: string, isMatched: boolean) {
   const formattedTime = gameTimeToString(time);

--- a/components/Layout/CurrentMatch.tsx
+++ b/components/Layout/CurrentMatch.tsx
@@ -8,10 +8,10 @@ import styles from 'styles/Layout/CurrentMatchInfo.module.scss';
 import useGetCurrentMatch from 'hooks/Layout/useGetCurrentMatch';
 
 export default function CurrentMatch() {
-  const { startTime, endTime, isMatched, enemyTeam, isImminent } =
+  const { startTime, isMatched, enemyTeam, isImminent } =
     useRecoilValue(currentMatchState);
   const setModal = useSetRecoilState(modalState);
-  const matchingMessage = time && makeMessage(time, isMatched);
+  const matchingMessage = startTime && makeMessage(startTime, isMatched);
   const blockCancelButton = isImminent && enemyTeam.length;
 
   useGetCurrentMatch();
@@ -19,7 +19,7 @@ export default function CurrentMatch() {
   const onCancel = () => {
     setModal({
       modalName: 'MATCH-CANCEL',
-      cancel: { isMatched, slotId, time },
+      cancel: { startTime: startTime, isMatched: isMatched },
     });
   };
 
@@ -90,7 +90,7 @@ export default function CurrentMatch() {
 //   );
 // }
 
-function makeMessage(time: string, isMatched: boolean) {
+function makeMessage(time: Date, isMatched: boolean) {
   const formattedTime = gameTimeToString(time);
   return (
     <div className={styles.message}>

--- a/components/Layout/CurrentMatch.tsx
+++ b/components/Layout/CurrentMatch.tsx
@@ -6,20 +6,35 @@ import { gameTimeToString } from 'utils/handleTime';
 import styles from 'styles/Layout/CurrentMatchInfo.module.scss';
 
 import useGetCurrentMatch from 'hooks/Layout/useGetCurrentMatch';
+import { CurrentMatchList } from 'types/matchTypes';
+import { Modal } from 'types/modalTypes';
 
 export default function CurrentMatch() {
-  const { startTime, isMatched, enemyTeam, isImminent } =
-    useRecoilValue(currentMatchState);
-  const setModal = useSetRecoilState(modalState);
-  const matchingMessage = startTime && makeMessage(startTime, isMatched);
-  const blockCancelButton = isImminent && enemyTeam.length;
+  const myMatchList = useRecoilValue<CurrentMatchList>(currentMatchState);
+  const setModal = useSetRecoilState<Modal>(modalState);
+
+  const getMyMatch = (myMatchList: CurrentMatchList) => {
+    for (const myMatch of myMatchList) {
+      if (myMatch.isMatched === true) {
+        return myMatch;
+      }
+    }
+    return myMatchList[0];
+  };
+
+  const myMatch = getMyMatch(myMatchList);
+  const matchingMessage =
+    myMatch && makeMessage(myMatch.startTime, myMatch.isMatched);
+
+  const blockCancelButton =
+    myMatch && myMatch.isImminent && myMatch.enemyTeam.length;
 
   useGetCurrentMatch();
 
   const onCancel = () => {
     setModal({
       modalName: 'MATCH-CANCEL',
-      cancel: { startTime: startTime, isMatched: isMatched },
+      cancel: { startTime: myMatch.startTime, isMatched: myMatch.isMatched },
     });
   };
 
@@ -30,7 +45,10 @@ export default function CurrentMatch() {
           <div className={styles.icon}>⏰</div>
           <div className={styles.messageWrapper}>
             {matchingMessage}
-            <EnemyTeam enemyTeam={enemyTeam} isImminent={isImminent} />
+            <EnemyTeam
+              enemyTeam={myMatch.enemyTeam}
+              isImminent={myMatch.isImminent}
+            />
           </div>
         </div>
         <div

--- a/components/Layout/CurrentMatch.tsx
+++ b/components/Layout/CurrentMatch.tsx
@@ -90,7 +90,7 @@ export default function CurrentMatch() {
 //   );
 // }
 
-function makeMessage(time: Date, isMatched: boolean) {
+function makeMessage(time: string, isMatched: boolean) {
   const formattedTime = gameTimeToString(time);
   return (
     <div className={styles.message}>

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -16,6 +16,7 @@ import useSetAfterGameModal from 'hooks/Layout/useSetAfterGameModal';
 import useGetUserSeason from 'hooks/Layout/useGetUserSeason';
 import useLiveCheck from 'hooks/Layout/useLiveCheck';
 import HeaderStateContext from './HeaderContext';
+import { gameTimeToString } from 'utils/handleTime';
 
 type AppLayoutProps = {
   children: React.ReactNode;

--- a/components/match/MatchSlot.tsx
+++ b/components/match/MatchSlot.tsx
@@ -1,12 +1,13 @@
 import React, { useMemo } from 'react';
 import { useRecoilValue, useRecoilState, useSetRecoilState } from 'recoil';
-import { MatchMode } from 'types/mainType';
-import { Slot } from 'types/matchTypes';
+import { Live, MatchMode } from 'types/mainType';
+import { CurrentMatchList, Slot } from 'types/matchTypes';
 import { liveState } from 'utils/recoil/layout';
 import { modalState } from 'utils/recoil/modal';
 import { fillZero } from 'utils/handleTime';
 import { currentMatchState } from 'utils/recoil/match';
 import styles from 'styles/match/MatchSlot.module.scss';
+import { Modal } from 'types/modalTypes';
 
 interface MatchSlotProps {
   type: string;
@@ -15,9 +16,9 @@ interface MatchSlotProps {
 }
 
 function MatchSlot({ type, slot, toggleMode }: MatchSlotProps) {
-  const setModal = useSetRecoilState(modalState);
-  const [currentMatch] = useRecoilState(currentMatchState);
-  const { event } = useRecoilValue(liveState);
+  const setModal = useSetRecoilState<Modal>(modalState);
+  const myMatchList = useRecoilValue<CurrentMatchList>(currentMatchState);
+  const { event } = useRecoilValue<Live>(liveState);
   const { headCount, slotId, status, time, endTime, mode } = slot;
   const headMax = type === 'single' ? 2 : 4;
   const slotStartTime = new Date(time);
@@ -37,14 +38,23 @@ function MatchSlot({ type, slot, toggleMode }: MatchSlotProps) {
     [slot]
   );
 
+  const getMyMatch = (myMatchList: CurrentMatchList) => {
+    for (const myMatch of myMatchList) {
+      if (myMatch.isMatched === true) {
+        return myMatch;
+      }
+    }
+    return myMatchList[0];
+  };
+  const myMatch = getMyMatch(myMatchList);
+
   const enrollHandler = async () => {
     if (status === 'mytable') {
       setModal({
         modalName: 'MATCH-CANCEL',
         cancel: {
-          isMatched: currentMatch.isMatched,
-          slotId: currentMatch.slotId,
-          time: currentMatch.time,
+          startTime: myMatch.startTime,
+          isMatched: myMatch.isMatched,
         },
       });
     } else if (event === 'match') {

--- a/components/modal/match/MatchCancelModal.tsx
+++ b/components/modal/match/MatchCancelModal.tsx
@@ -2,22 +2,33 @@ import { Cancel } from 'types/modalTypes';
 import styles from 'styles/modal/match/MatchCancelModal.module.scss';
 import useMatchCancelModal from 'hooks/modal/match/useMatchCancelModal';
 
-export default function MatchCancelModal({ isMatched, slotId, time }: Cancel) {
+export default function MatchCancelModal({ startTime, isMatched }: Cancel) {
   const {
     content,
     contentType,
     rejectCancel,
     onCancel,
-    currentMatch,
+    currentMatchList,
     onReturn,
-  } = useMatchCancelModal({ isMatched, slotId, time });
+  } = useMatchCancelModal({ startTime, isMatched });
+
+  const getCurrentMatch = () => {
+    for (const currentMatch of currentMatchList) {
+      if (currentMatch.startTime === startTime) {
+        return currentMatch;
+      }
+      return currentMatchList[0];
+    }
+  };
+
+  const currentMatch = getCurrentMatch();
 
   return (
     <div className={styles.container}>
       <div className={styles.phrase}>
         <div className={styles.emoji}>{content[contentType].emoji}</div>
         {content[contentType].main}
-        {(rejectCancel || (!rejectCancel && currentMatch.isMatched)) && (
+        {(rejectCancel || (!rejectCancel && currentMatch?.isMatched)) && (
           <div className={styles.subContent}>{content[contentType].sub}</div>
         )}
       </div>

--- a/hooks/Layout/useGetCurrentMatch.ts
+++ b/hooks/Layout/useGetCurrentMatch.ts
@@ -12,7 +12,7 @@ const useGetCurrentMatch = () => {
   const presentPath: string = useRouter().asPath;
 
   const getCurrentMatchHandler = useAxiosGet({
-    url: '/pingpong/match/current',
+    url: '/pingpong/match',
     setState: setCurrentMatch,
     err: 'JB01',
     type: 'setError',

--- a/hooks/Layout/useGetCurrentMatch.ts
+++ b/hooks/Layout/useGetCurrentMatch.ts
@@ -2,11 +2,12 @@ import useAxiosGet from 'hooks/useAxiosGet';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { useRecoilState, useSetRecoilState } from 'recoil';
-import { CurrentMatch } from 'types/matchTypes';
+import { CurrentMatchList } from 'types/matchTypes';
 import { currentMatchState, reloadMatchState } from 'utils/recoil/match';
 
 const useGetCurrentMatch = () => {
-  const setCurrentMatch = useSetRecoilState<CurrentMatch>(currentMatchState);
+  const setCurrentMatch =
+    useSetRecoilState<CurrentMatchList>(currentMatchState);
   const [reloadMatch, setReloadMatch] =
     useRecoilState<boolean>(reloadMatchState);
   const presentPath: string = useRouter().asPath;

--- a/hooks/Layout/useGetCurrentMatch.ts
+++ b/hooks/Layout/useGetCurrentMatch.ts
@@ -6,7 +6,7 @@ import { CurrentMatchList } from 'types/matchTypes';
 import { currentMatchState, reloadMatchState } from 'utils/recoil/match';
 
 const useGetCurrentMatch = () => {
-  const setCurrentMatch =
+  const setCurrentMatchList =
     useSetRecoilState<CurrentMatchList>(currentMatchState);
   const [reloadMatch, setReloadMatch] =
     useRecoilState<boolean>(reloadMatchState);
@@ -14,7 +14,7 @@ const useGetCurrentMatch = () => {
 
   const getCurrentMatchHandler = useAxiosGet({
     url: '/pingpong/match',
-    setState: setCurrentMatch,
+    setState: setCurrentMatchList,
     err: 'JB01',
     type: 'setError',
   });

--- a/hooks/modal/match/useMatchCancelModal.ts
+++ b/hooks/modal/match/useMatchCancelModal.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 import { Cancel } from 'types/modalTypes';
 import { instance } from 'utils/axios';
+import { getFormattedDateToPattern } from 'utils/handleTime';
 import { errorState } from 'utils/recoil/error';
 import {
   currentMatchState,
@@ -10,7 +11,7 @@ import {
 } from 'utils/recoil/match';
 import { modalState } from 'utils/recoil/modal';
 
-const useMatchCancelModal = ({ isMatched, slotId, time }: Cancel) => {
+const useMatchCancelModal = ({ startTime, isMatched }: Cancel) => {
   const setOpenCurrentMatch = useSetRecoilState(openCurrentMatchState);
   const setReloadMatch = useSetRecoilState(reloadMatchState);
   const setError = useSetRecoilState(errorState);
@@ -19,6 +20,9 @@ const useMatchCancelModal = ({ isMatched, slotId, time }: Cancel) => {
   const cancelLimitTime = currentMatch.isImminent;
   const rejectCancel = cancelLimitTime && isMatched;
   const contentType: 'reject' | 'cancel' = rejectCancel ? 'reject' : 'cancel';
+
+  const dateToPattern = getFormattedDateToPattern(startTime);
+
   const content = {
     cancel: {
       emoji: '🤔',
@@ -43,7 +47,7 @@ const useMatchCancelModal = ({ isMatched, slotId, time }: Cancel) => {
 
   const onCancel = async () => {
     try {
-      await instance.delete(`/pingpong/match/slots/${slotId}`);
+      await instance.delete(`/pingpong/match?/startTime=${dateToPattern}`);
       alert(cancelResponse.SUCCESS);
     } catch (e: any) {
       if (e.response.data.code in cancelResponse)
@@ -62,7 +66,7 @@ const useMatchCancelModal = ({ isMatched, slotId, time }: Cancel) => {
 
   const getCurrentMatchHandler = async () => {
     try {
-      const res = await instance.get('/pingpong/match/current');
+      const res = await instance.get('/pingpong/match');
       setCurrentMatch(res.data);
     } catch (e) {
       setError('JH08');
@@ -83,5 +87,78 @@ const useMatchCancelModal = ({ isMatched, slotId, time }: Cancel) => {
     onReturn,
   };
 };
+// const useMatchCancelModal = ({ isMatched, slotId, time }: Cancel) => {
+//   const setOpenCurrentMatch = useSetRecoilState(openCurrentMatchState);
+//   const setReloadMatch = useSetRecoilState(reloadMatchState);
+//   const setError = useSetRecoilState(errorState);
+//   const setModal = useSetRecoilState(modalState);
+//   const [currentMatch, setCurrentMatch] = useRecoilState(currentMatchState);
+//   const cancelLimitTime = currentMatch.isImminent;
+//   const rejectCancel = cancelLimitTime && isMatched;
+//   const contentType: 'reject' | 'cancel' = rejectCancel ? 'reject' : 'cancel';
+//   const content = {
+//     cancel: {
+//       emoji: '🤔',
+//       main: '해당 경기를\n취소하시겠습니까?',
+//       sub: '⚠︎ 매칭이 완료된 경기를 취소하면\n1분 간 새로운 예약이 불가합니다!',
+//     },
+//     reject: {
+//       emoji: '😰',
+//       main: '매칭이 완료되어\n경기를 취소할 수 없습니다!!',
+//       sub: `상대방이 공개된 이후부터는\n경기를 취소할 수 없습니다..`,
+//     },
+//   };
+//   const cancelResponse: { [key: string]: string } = {
+//     SUCCESS: '경기가 성공적으로 취소되었습니다.',
+//     SD001: '이미 지난 경기입니다.',
+//     SD002: '이미 매칭이 완료된 경기입니다.',
+//   };
+
+//   useEffect(() => {
+//     getCurrentMatchHandler();
+//   }, []);
+
+//   const onCancel = async () => {
+//     try {
+//       await instance.delete(`/pingpong/match/slots/${slotId}`);
+//       alert(cancelResponse.SUCCESS);
+//     } catch (e: any) {
+//       if (e.response.data.code in cancelResponse)
+//         alert(cancelResponse[e.response.data.code]);
+//       else {
+//         setModal({ modalName: null });
+//         setOpenCurrentMatch(false);
+//         setError('JH01');
+//         return;
+//       }
+//     }
+//     setModal({ modalName: null });
+//     setOpenCurrentMatch(false);
+//     setReloadMatch(true);
+//   };
+
+//   const getCurrentMatchHandler = async () => {
+//     try {
+//       const res = await instance.get('/pingpong/match/current');
+//       setCurrentMatch(res.data);
+//     } catch (e) {
+//       setError('JH08');
+//     }
+//   };
+
+//   const onReturn = () => {
+//     setModal({ modalName: null });
+//     setReloadMatch(true);
+//   };
+
+//   return {
+//     content,
+//     contentType,
+//     rejectCancel,
+//     onCancel,
+//     currentMatch,
+//     onReturn,
+//   };
+// };
 
 export default useMatchCancelModal;

--- a/hooks/modal/match/useMatchCancelModal.ts
+++ b/hooks/modal/match/useMatchCancelModal.ts
@@ -15,8 +15,16 @@ const useMatchCancelModal = ({ startTime, isMatched }: Cancel) => {
   const setReloadMatch = useSetRecoilState(reloadMatchState);
   const setError = useSetRecoilState(errorState);
   const setModal = useSetRecoilState(modalState);
-  const [currentMatch, setCurrentMatch] = useRecoilState(currentMatchState);
-  const cancelLimitTime = currentMatch.isImminent;
+  const [currentMatchList, setCurrentMatchList] =
+    useRecoilState(currentMatchState);
+
+  let cancelLimitTime = false;
+  for (const currentMatch of currentMatchList) {
+    if (currentMatch.startTime === startTime) {
+      cancelLimitTime = currentMatch.isImminent;
+    }
+  }
+
   const rejectCancel = cancelLimitTime && isMatched;
   const contentType: 'reject' | 'cancel' = rejectCancel ? 'reject' : 'cancel';
 
@@ -64,7 +72,7 @@ const useMatchCancelModal = ({ startTime, isMatched }: Cancel) => {
   const getCurrentMatchHandler = async () => {
     try {
       const res = await instance.get('/pingpong/match');
-      setCurrentMatch(res.data);
+      setCurrentMatchList(res.data);
     } catch (e) {
       setError('JH08');
     }
@@ -80,7 +88,7 @@ const useMatchCancelModal = ({ startTime, isMatched }: Cancel) => {
     contentType,
     rejectCancel,
     onCancel,
-    currentMatch,
+    currentMatchList,
     onReturn,
   };
 };

--- a/hooks/modal/match/useMatchCancelModal.ts
+++ b/hooks/modal/match/useMatchCancelModal.ts
@@ -2,7 +2,6 @@ import { useEffect } from 'react';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 import { Cancel } from 'types/modalTypes';
 import { instance } from 'utils/axios';
-import { getFormattedDateToPattern } from 'utils/handleTime';
 import { errorState } from 'utils/recoil/error';
 import {
   currentMatchState,
@@ -20,8 +19,6 @@ const useMatchCancelModal = ({ startTime, isMatched }: Cancel) => {
   const cancelLimitTime = currentMatch.isImminent;
   const rejectCancel = cancelLimitTime && isMatched;
   const contentType: 'reject' | 'cancel' = rejectCancel ? 'reject' : 'cancel';
-
-  const dateToPattern = getFormattedDateToPattern(startTime);
 
   const content = {
     cancel: {
@@ -47,7 +44,7 @@ const useMatchCancelModal = ({ startTime, isMatched }: Cancel) => {
 
   const onCancel = async () => {
     try {
-      await instance.delete(`/pingpong/match?/startTime=${dateToPattern}`);
+      await instance.delete(`/pingpong/match?/startTime=${startTime}`);
       alert(cancelResponse.SUCCESS);
     } catch (e: any) {
       if (e.response.data.code in cancelResponse)

--- a/hooks/useAxiosGet.ts
+++ b/hooks/useAxiosGet.ts
@@ -3,7 +3,7 @@ import { SetterOrUpdater, useSetRecoilState } from 'recoil';
 import { errorState } from 'utils/recoil/error';
 import { instance } from 'utils/axios';
 import { Noti } from 'types/notiTypes';
-import { CurrentMatch, Match } from 'types/matchTypes';
+import { CurrentMatchList, Match } from 'types/matchTypes';
 import { SeasonList } from 'types/seasonTypes';
 import { Live, User } from 'types/mainType';
 import { PppChart, ProfileBasic, ProfileRank } from 'types/userTypes';
@@ -27,9 +27,8 @@ interface useAxiosGetProps {
     | Dispatch<SetStateAction<undefined>>
     | SetterOrUpdater<User>
     | SetterOrUpdater<SeasonList>
-    | SetterOrUpdater<CurrentMatch>
     | SetterOrUpdater<Live>
-    | SetterOrUpdater<CurrentMatch>
+    | SetterOrUpdater<CurrentMatchList>
     | SetterOrUpdater<ProfileBasic>;
   err: string;
   type: null | string;

--- a/types/matchTypes.ts
+++ b/types/matchTypes.ts
@@ -8,7 +8,9 @@ export interface Slot {
 }
 
 export type Slots = Slot[];
-
+export interface Match {
+  matchBoards: Slots[];
+}
 export interface CurrentMatch {
   startTime: string;
   endTime: string;
@@ -18,9 +20,8 @@ export interface CurrentMatch {
   isImminent: boolean;
 }
 
-export interface Match {
-  matchBoards: Slots[];
-}
+export type CurrentMatchList = CurrentMatch[];
+
 // export interface Slot {
 //   slotId: number;
 //   status: string;

--- a/types/matchTypes.ts
+++ b/types/matchTypes.ts
@@ -7,10 +7,8 @@ export interface Slot {
   mode: string;
 }
 
-export type Slots = Slot[];
-export interface Match {
-  matchBoards: Slots[];
-}
+export type Match = Slot[];
+
 export interface CurrentMatch {
   startTime: string;
   endTime: string;

--- a/types/matchTypes.ts
+++ b/types/matchTypes.ts
@@ -10,8 +10,8 @@ export interface Slot {
 export type Slots = Slot[];
 
 export interface CurrentMatch {
-  startTime: 'yyyy-mm-ddThh:mm';
-  endTime: 'yyyy-mm-ddThh:mm';
+  startTime: Date;
+  endTime: Date;
   isMatched: boolean;
   myTeam: string[];
   enemyTeam: string[];

--- a/types/matchTypes.ts
+++ b/types/matchTypes.ts
@@ -10,8 +10,8 @@ export interface Slot {
 export type Slots = Slot[];
 
 export interface CurrentMatch {
-  startTime: Date;
-  endTime: Date;
+  startTime: string;
+  endTime: string;
   isMatched: boolean;
   myTeam: string[];
   enemyTeam: string[];

--- a/types/matchTypes.ts
+++ b/types/matchTypes.ts
@@ -10,8 +10,8 @@ export interface Slot {
 export type Slots = Slot[];
 
 export interface CurrentMatch {
-  slotId: number;
-  time: string;
+  startTime: 'yyyy-mm-ddThh:mm';
+  endTime: 'yyyy-mm-ddThh:mm';
   isMatched: boolean;
   myTeam: string[];
   enemyTeam: string[];
@@ -21,3 +21,26 @@ export interface CurrentMatch {
 export interface Match {
   matchBoards: Slots[];
 }
+// export interface Slot {
+//   slotId: number;
+//   status: string;
+//   headCount: number;
+//   time: string;
+//   endTime: string;
+//   mode: string;
+// }
+
+// export type Slots = Slot[];
+
+// export interface CurrentMatch {
+//   slotId: number;
+//   time: string;
+//   isMatched: boolean;
+//   myTeam: string[];
+//   enemyTeam: string[];
+//   isImminent: boolean;
+// }
+
+// export interface Match {
+//   matchBoards: Slots[];
+// }

--- a/types/modalTypes.ts
+++ b/types/modalTypes.ts
@@ -31,7 +31,7 @@ type ModalName =
   | `FIXED-${FixedModal}`
   | `ADMIN-${AdminModal}`;
 export interface Cancel {
-  startTime: Date;
+  startTime: string;
   isMatched: boolean;
 }
 // export interface Cancel {

--- a/types/modalTypes.ts
+++ b/types/modalTypes.ts
@@ -31,10 +31,14 @@ type ModalName =
   | `FIXED-${FixedModal}`
   | `ADMIN-${AdminModal}`;
 export interface Cancel {
+  startTime: Date;
   isMatched: boolean;
-  slotId: number;
-  time: string;
 }
+// export interface Cancel {
+//   isMatched: boolean;
+//   slotId: number;
+//   time: string;
+// }
 
 export interface Enroll {
   slotId: number;

--- a/utils/handleTime.ts
+++ b/utils/handleTime.ts
@@ -125,9 +125,3 @@ export const getFormattedDateToString = (
     d.getMinutes() < 10 ? `0${d.getMinutes()}` : d.getMinutes().toString();
   return { year, month, date, hour, min };
 };
-
-export const getFormattedDateToPattern = (d: Date): string => {
-  const dateToString = getFormattedDateToString(d);
-
-  return `${dateToString.year}-${dateToString.month}-${dateToString.date}T${dateToString.hour}-${dateToString.min}`;
-};

--- a/utils/handleTime.ts
+++ b/utils/handleTime.ts
@@ -125,3 +125,9 @@ export const getFormattedDateToString = (
     d.getMinutes() < 10 ? `0${d.getMinutes()}` : d.getMinutes().toString();
   return { year, month, date, hour, min };
 };
+
+export const getFormattedDateToPattern = (d: Date): string => {
+  const dateToString = getFormattedDateToString(d);
+
+  return `${dateToString.year}-${dateToString.month}-${dateToString.date}T${dateToString.hour}-${dateToString.min}`;
+};

--- a/utils/recoil/match.ts
+++ b/utils/recoil/match.ts
@@ -1,6 +1,6 @@
 import { atom } from 'recoil';
 import { v1 } from 'uuid';
-import { CurrentMatch } from 'types/matchTypes';
+import { CurrentMatchList } from 'types/matchTypes';
 
 export const openCurrentMatchState = atom<boolean>({
   key: `openCurrentMatchState/${v1()}`,
@@ -12,14 +12,16 @@ export const reloadMatchState = atom<boolean>({
   default: false,
 });
 
-export const currentMatchState = atom<CurrentMatch>({
+export const currentMatchState = atom<CurrentMatchList>({
   key: `currentMatchState/${v1()}`,
-  default: {
-    slotId: 0,
-    time: '',
-    isMatched: false,
-    myTeam: [],
-    enemyTeam: [],
-    isImminent: false,
-  },
+  default: [
+    {
+      startTime: '0000-00-00T00:00',
+      endTime: '0000-00-00T00:00',
+      isMatched: false,
+      myTeam: [],
+      enemyTeam: [],
+      isImminent: false,
+    },
+  ],
 });


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - currentMatch api 변경 및 받는 타입이 배열로 변경됨 + 슬롯 취소 api 변경 
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
### 현재 매치 정보 조회
- api 변경: /pingpong/match/current ⇒ **/pingpong/match**
- 데이터 형식 변경 전
```
{
  slotId: integer
  time: dateTime
  isMatched : boolean
  myTeam : string[]
  enemyTeam : string[]
  isImminent : boolean
}
```
- 변경 후
```
{
  match: [
  {
    startTime: 'yyyy-mm-ddThh:mm',
    endTime: 'yyyy-mm-ddThh:mm',
    isMatched : boolean,
    myTeam : string[],
    enemyTeam : string[],
    isImminent : boolean
  },
...
]
}
```
- slotId, time 삭제 -> startTime, endTime 추가
- startTime으로 슬롯 확인
- CurrentMatch 타입 변경 -> 경기를 동시에 3개 잡을 수 있게 되면서 배열 형식으로 변경
- 일단 CurrentMatch 위에 뜨는 UI는 가장 빠른 시간의 것이 나타나게 해놓음(수정필요)

### 매칭 슬롯 취소
- api 변경: /pingpong/match/slots/{slotId} -> **/pingpong/match?startTime=’yyyy-mm-ddThh:mm’**

 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
