### PR TITLE
[GGFE-42] 0->-1로 변경 togglemode 타입 변경

### DIFF
--- a/components/mode/modeWraps/RankModeWrap.tsx
+++ b/components/mode/modeWraps/RankModeWrap.tsx
@@ -4,24 +4,25 @@ import useModeToggle from 'hooks/mode/useModeToggle';
 import useSeasonDropDown from 'hooks/mode/useSeasonDropDown';
 import SeasonDropDown from 'components/mode/modeItems/SeasonDropDown';
 import styles from 'styles/mode/ModeWrap.module.scss';
+import { ToggleMode } from 'types/rankTypes';
 
 interface RankModeWrapProps {
   children: React.ReactNode;
-  setMode: React.Dispatch<React.SetStateAction<'normal' | 'rank'>>;
+  setMode: React.Dispatch<React.SetStateAction<ToggleMode>>;
 }
 
 export default function RankModeWrap({ children, setMode }: RankModeWrapProps) {
   const { seasonList, season, seasonDropDownHandler, seasonMode } =
     useSeasonDropDown();
   const { onToggle, Mode } = useModeToggle(
-    seasonMode === 'normal' ? 'normal' : 'rank'
+    seasonMode === 'NORMAL' ? 'NORMAL' : 'RANK'
   );
   const [showSeasons, setShowSeasons] = useState<boolean>(
-    seasonMode !== 'normal'
+    seasonMode !== 'NORMAL'
   );
 
   useEffect(() => {
-    setShowSeasons(Mode === 'rank');
+    setShowSeasons(Mode === 'RANK');
     setMode(Mode);
   }, [Mode]);
 
@@ -29,9 +30,9 @@ export default function RankModeWrap({ children, setMode }: RankModeWrapProps) {
     <div>
       <div className={styles.rankModeWrap}>
         <ModeToggle
-          checked={Mode === 'rank'}
+          checked={Mode === 'RANK'}
           onToggle={onToggle}
-          text={Mode === 'rank' ? '랭크' : '열정'}
+          text={Mode === 'RANK' ? '랭크' : '열정'}
           id={'rankToggle'}
         />
         {showSeasons && seasonList && (

--- a/components/mode/modeWraps/RankModeWrap.tsx
+++ b/components/mode/modeWraps/RankModeWrap.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { MatchMode } from 'types/mainType';
 import ModeToggle from 'components/mode/modeItems/ModeToggle';
 import useModeToggle from 'hooks/mode/useModeToggle';
 import useSeasonDropDown from 'hooks/mode/useSeasonDropDown';
@@ -8,7 +7,7 @@ import styles from 'styles/mode/ModeWrap.module.scss';
 
 interface RankModeWrapProps {
   children: React.ReactNode;
-  setMode: React.Dispatch<React.SetStateAction<MatchMode>>;
+  setMode: React.Dispatch<React.SetStateAction<'normal' | 'rank'>>;
 }
 
 export default function RankModeWrap({ children, setMode }: RankModeWrapProps) {

--- a/components/rank/MyRank.tsx
+++ b/components/rank/MyRank.tsx
@@ -1,17 +1,16 @@
 import { useSetRecoilState, useRecoilValue } from 'recoil';
-import { MatchMode } from 'types/mainType';
 import { myRankState, scrollState } from 'utils/recoil/myRank';
 import styles from 'styles/rank/RankList.module.scss';
 
 interface MyRankProps {
-  toggleMode: MatchMode;
+  toggleMode: 'normal' | 'rank';
 }
 
 export default function MyRank({ toggleMode }: MyRankProps) {
   const myRank = useRecoilValue(myRankState);
   const setIsScroll = useSetRecoilState(scrollState);
   const rankType = toggleMode === 'rank' ? '랭크' : '열정';
-  const isRanked = myRank[toggleMode] === 0 ? 'unrank' : 'rank';
+  const isRanked = myRank[toggleMode] === -1 ? 'unrank' : 'rank';
   const content = {
     unrank: {
       style: '',

--- a/components/rank/MyRank.tsx
+++ b/components/rank/MyRank.tsx
@@ -1,26 +1,23 @@
 import { useSetRecoilState, useRecoilValue } from 'recoil';
 import { myRankState, scrollState } from 'utils/recoil/myRank';
 import styles from 'styles/rank/RankList.module.scss';
+import { ToggleMode } from 'types/rankTypes';
 
-interface MyRankProps {
-  toggleMode: 'normal' | 'rank';
-}
-
-export default function MyRank({ toggleMode }: MyRankProps) {
+export default function MyRank(toggleMode: ToggleMode) {
   const myRank = useRecoilValue(myRankState);
   const setIsScroll = useSetRecoilState(scrollState);
-  const rankType = toggleMode === 'rank' ? '랭크' : '열정';
-  const isRanked = myRank[toggleMode] === -1 ? 'unrank' : 'rank';
+  const rankType = toggleMode === 'RANK' ? '랭크' : '열정';
+  const isRanked = myRank[toggleMode] === -1 ? 'unrank' : 'RANK';
   const content = {
     unrank: {
       style: '',
       message: [
         `💡 나의 ${
-          rankType + (toggleMode === 'rank' ? '가' : '이')
+          rankType + (toggleMode === 'RANK' ? '가' : '이')
         } 정해지지 않았습니다 💡`,
       ],
     },
-    rank: {
+    RANK: {
       style: styles.rank,
       message: [
         `🚀🚀 나의 ${rankType}`,

--- a/components/rank/RankList.tsx
+++ b/components/rank/RankList.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { MatchMode } from 'types/mainType';
 import { RankUser, NormalUser, Rank } from 'types/rankTypes';
 import RankListMain from './topRank/RankListMain';
 import RankListFrame from './RankListFrame';
@@ -8,7 +7,7 @@ import RankListItem from './RankListItem';
 import useRankList from 'hooks/rank/useRankList';
 
 interface RankListProps {
-  toggleMode: MatchMode;
+  toggleMode: 'normal' | 'rank';
   season?: number;
   isMain?: boolean;
 }

--- a/components/rank/RankList.tsx
+++ b/components/rank/RankList.tsx
@@ -1,13 +1,12 @@
 import { useState } from 'react';
-import { RankUser, NormalUser, Rank } from 'types/rankTypes';
+import { RankUser, NormalUser, Rank, ToggleMode } from 'types/rankTypes';
 import RankListMain from './topRank/RankListMain';
 import RankListFrame from './RankListFrame';
 import RankListItem from './RankListItem';
-
 import useRankList from 'hooks/rank/useRankList';
 
 interface RankListProps {
-  toggleMode: 'normal' | 'rank';
+  toggleMode: ToggleMode;
   season?: number;
   isMain?: boolean;
 }
@@ -16,7 +15,7 @@ export default function RankList({
   season,
   isMain = false,
 }: RankListProps) {
-  const seasonMode = 'rank';
+  const seasonMode = 'RANK';
   const [rank, setRank] = useState<Rank>();
   const [page, setPage] = useState<number>(1);
   const pageInfo = {
@@ -27,8 +26,8 @@ export default function RankList({
 
   const makePath = (): string => {
     const modeQuery = (targetMode?: string) =>
-      targetMode !== 'normal' ? 'ranks/single' : 'exp';
-    const seasonQuery = toggleMode === 'rank' ? `&season=${season}` : '';
+      targetMode !== 'NORMAL' ? 'ranks/single' : 'exp';
+    const seasonQuery = toggleMode === 'RANK' ? `&season=${season}` : '';
     return isMain
       ? `/pingpong/${modeQuery(seasonMode)}?page=1&size=3`
       : `/pingpong/${modeQuery(toggleMode)}?page=${page}${seasonQuery}`;

--- a/components/rank/RankListFrame.tsx
+++ b/components/rank/RankListFrame.tsx
@@ -11,7 +11,7 @@ interface PageInfo {
 interface RankListFrameProps {
   children: React.ReactNode;
   pageInfo: PageInfo;
-  toggleMode: MatchMode;
+  toggleMode: 'normal' | 'rank';
 }
 
 export default function RankListFrame({

--- a/components/rank/RankListFrame.tsx
+++ b/components/rank/RankListFrame.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { MatchMode } from 'types/mainType';
+import { ToggleMode } from 'types/rankTypes';
 import PageNation from 'components/Pagination';
 import styles from 'styles/rank/RankList.module.scss';
 
@@ -11,7 +11,7 @@ interface PageInfo {
 interface RankListFrameProps {
   children: React.ReactNode;
   pageInfo: PageInfo;
-  toggleMode: 'normal' | 'rank';
+  toggleMode: ToggleMode;
 }
 
 export default function RankListFrame({
@@ -21,8 +21,8 @@ export default function RankListFrame({
 }: RankListFrameProps) {
   const router = useRouter();
   const division: { [key: string]: string[] } = {
-    rank: ['순위', 'intraId', '상태메시지', '탁구력'],
-    normal: ['순위', 'intraId (Lv)', '상태메시지', '경험치'],
+    RANK: ['순위', 'intraId', '상태메시지', '탁구력'],
+    NORMAL: ['순위', 'intraId (Lv)', '상태메시지', '경험치'],
   };
 
   const pageChangeHandler = (pages: number) => {
@@ -35,7 +35,7 @@ export default function RankListFrame({
       <div className={styles.container}>
         <div
           className={`${styles.division}
-					${toggleMode === 'normal' && styles.normal}`}
+					${toggleMode === 'NORMAL' && styles.normal}`}
         >
           {division[toggleMode].map((item: string) => (
             <div key={item}>{item}</div>

--- a/components/rank/RankListItem.tsx
+++ b/components/rank/RankListItem.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { useRecoilValue } from 'recoil';
 import { userState } from 'utils/recoil/layout';
 import styles from 'styles/rank/RankList.module.scss';
+import { ToggleMode } from 'types/rankTypes';
 
 interface User {
   intraId: string;
@@ -14,7 +15,7 @@ interface User {
 interface RankListItemProps {
   index: number;
   user: User;
-  toggleMode: 'normal' | 'rank';
+  toggleMode: ToggleMode;
 }
 
 export default function RankListItem({

--- a/components/rank/RankListItem.tsx
+++ b/components/rank/RankListItem.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link';
 import { useRecoilValue } from 'recoil';
-import { MatchMode } from 'types/mainType';
 import { userState } from 'utils/recoil/layout';
 import styles from 'styles/rank/RankList.module.scss';
 
@@ -15,7 +14,7 @@ interface User {
 interface RankListItemProps {
   index: number;
   user: User;
-  toggleMode: MatchMode;
+  toggleMode: 'normal' | 'rank';
 }
 
 export default function RankListItem({

--- a/hooks/mode/useModeToggle.ts
+++ b/hooks/mode/useModeToggle.ts
@@ -1,10 +1,11 @@
 import { useState } from 'react';
+import { ToggleMode } from 'types/rankTypes';
 
-const useModeToggle = (toggleMode: 'normal' | 'rank') => {
-  const [Mode, setMode] = useState(toggleMode);
+const useModeToggle = (toggleMode: ToggleMode) => {
+  const [Mode, setMode] = useState<ToggleMode>(toggleMode);
 
   const onToggle = (): void => {
-    setMode(Mode === 'rank' ? 'normal' : 'rank');
+    setMode(Mode === 'RANK' ? 'NORMAL' : 'RANK');
   };
 
   return { onToggle, Mode };

--- a/hooks/mode/useModeToggle.ts
+++ b/hooks/mode/useModeToggle.ts
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 
-const useModeToggle = (toggleMode: 'NORMAL' | 'RANK' | 'BOTH') => {
+const useModeToggle = (toggleMode: 'normal' | 'rank') => {
   const [Mode, setMode] = useState(toggleMode);
 
   const onToggle = (): void => {
-    setMode(Mode === 'RANK' ? 'NORMAL' : 'RANK');
+    setMode(Mode === 'rank' ? 'normal' : 'rank');
   };
 
   return { onToggle, Mode };

--- a/hooks/mode/useSeasonDropDown.ts
+++ b/hooks/mode/useSeasonDropDown.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { seasonListState, latestSeasonIdState } from 'utils/recoil/seasons';
 import { useRecoilValue } from 'recoil';
+import { ToggleMode } from 'types/rankTypes';
 
 const useSeasonDropDown = (
   clickTitle?: boolean,
@@ -8,7 +9,7 @@ const useSeasonDropDown = (
 ) => {
   const latestSeasonId = useRecoilValue(latestSeasonIdState);
   const { seasonList } = useRecoilValue(seasonListState);
-  const seasonMode = 'rank';
+  const seasonMode: ToggleMode = 'RANK';
   const [season, setSeason] = useState<number>(
     useRecoilValue(latestSeasonIdState)
   );

--- a/hooks/rank/useRankList.ts
+++ b/hooks/rank/useRankList.ts
@@ -1,14 +1,13 @@
 import useAxiosGet from 'hooks/useAxiosGet';
 import { useEffect, Dispatch, SetStateAction } from 'react';
 import { useRecoilState } from 'recoil';
-import { MatchMode } from 'types/mainType';
 import { Rank } from 'types/rankTypes';
 import { myRankState, scrollState } from 'utils/recoil/myRank';
 import { MyRank } from 'types/rankTypes';
 
 interface useRankListProps {
   makePath: string;
-  toggleMode: MatchMode;
+  toggleMode: 'normal' | 'rank';
   season: number | undefined;
   setRank: Dispatch<SetStateAction<Rank | undefined>>;
   page: number;

--- a/hooks/rank/useRankList.ts
+++ b/hooks/rank/useRankList.ts
@@ -3,11 +3,10 @@ import { useEffect, Dispatch, SetStateAction } from 'react';
 import { useRecoilState } from 'recoil';
 import { Rank } from 'types/rankTypes';
 import { myRankState, scrollState } from 'utils/recoil/myRank';
-import { MyRank } from 'types/rankTypes';
-
+import { MyRank, ToggleMode } from 'types/rankTypes';
 interface useRankListProps {
   makePath: string;
-  toggleMode: 'normal' | 'rank';
+  toggleMode: ToggleMode;
   season: number | undefined;
   setRank: Dispatch<SetStateAction<Rank | undefined>>;
   page: number;

--- a/pages/rank.tsx
+++ b/pages/rank.tsx
@@ -1,12 +1,11 @@
 import { useState } from 'react';
-import { MatchMode } from 'types/mainType';
 import RankModeWrap from 'components/mode/modeWraps/RankModeWrap';
 import MyRank from 'components/rank/MyRank';
 import RankList from 'components/rank/RankList';
 import styles from 'styles/rank/RankList.module.scss';
 
 export default function Rank() {
-  const [mode, setMode] = useState<MatchMode>('rank');
+  const [mode, setMode] = useState<'normal' | 'rank'>('rank');
   const content = {
     rank: { style: '', title: 'Ranking' },
     normal: { style: styles.vip, title: 'VIP' },

--- a/pages/rank.tsx
+++ b/pages/rank.tsx
@@ -3,12 +3,13 @@ import RankModeWrap from 'components/mode/modeWraps/RankModeWrap';
 import MyRank from 'components/rank/MyRank';
 import RankList from 'components/rank/RankList';
 import styles from 'styles/rank/RankList.module.scss';
+import { ToggleMode } from 'types/rankTypes';
 
 export default function Rank() {
-  const [mode, setMode] = useState<'normal' | 'rank'>('rank');
+  const [mode, setMode] = useState<ToggleMode>('RANK');
   const content = {
-    rank: { style: '', title: 'Ranking' },
-    normal: { style: styles.vip, title: 'VIP' },
+    RANK: { style: '', title: 'Ranking' },
+    NORMAL: { style: styles.vip, title: 'VIP' },
   };
 
   return (

--- a/types/rankTypes.ts
+++ b/types/rankTypes.ts
@@ -1,3 +1,5 @@
+export type ToggleMode = 'NORMAL' | 'RANK';
+
 export interface RankUser {
   rank: number;
   intraId: string;
@@ -15,8 +17,8 @@ export interface NormalUser {
 }
 
 export interface MyRank {
-  rank: number;
-  normal: number;
+  RANK: number;
+  NORMAL: number;
 }
 
 export interface Rank {

--- a/utils/recoil/myRank.ts
+++ b/utils/recoil/myRank.ts
@@ -4,7 +4,7 @@ import { v1 } from 'uuid';
 
 export const myRankState = atom<MyRank>({
   key: `myRankState/${v1()}`,
-  default: { rank: 0, normal: 0 },
+  default: { RANK: 0, NORMAL: 0 },
 });
 
 export const scrollState = atom<boolean>({


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - myrank api가 -1로 변경되어 수정, togglemode 타입 변경 
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - myrank의 시즌에 게임을 한번도 안했다면 주는 값이  0에서 -1로 변경되어 주정했습니다
  - togglemode의 타입을 matchmode로 사용했었는데 toggle특성상 normal, rank두개 만 사용함으로 변경했습니다. 
  - togglemode의 타입을 대문자로 변경하였습니다.
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
