### PR TITLE
[GGFE-55] 게임 목록 리스트에서 발생하는 문제 수정

### DIFF
--- a/hooks/game/useGameResult.ts
+++ b/hooks/game/useGameResult.ts
@@ -18,7 +18,7 @@ const useGameResult = ({ mode, season }: GameResultProps) => {
       const basePath = '/pingpong/games';
       if (asPath === '/' || asPath.includes('token')) {
         // live 상태 포함 최근 3개의 게임만 가져온다.
-        setPath(`${basePath}?page=${1}&size=${3}&status=${'LIVE'}`);
+        setPath(`${basePath}?size=${3}&status=${'LIVE'}`);
         return;
       }
       const modePath = mode === 'BOTH' ? '' : `/${mode?.toLowerCase()}`;

--- a/hooks/game/useGameResult.ts
+++ b/hooks/game/useGameResult.ts
@@ -21,7 +21,7 @@ const useGameResult = ({ mode, season }: GameResultProps) => {
         setPath(`${basePath}?size=${3}&status=${'LIVE'}`);
         return;
       }
-      const modePath = mode === 'BOTH' ? '' : `/${mode?.toLowerCase()}`;
+      const modePath = mode === 'BOTH' || !mode ? '' : `/${mode.toLowerCase()}`;
       const userQuery = intraId && `intraId=${intraId}`;
       const seasonQuery = mode === 'RANK' && `seasonId=${season}`;
       const sizeQuery =


### PR DESCRIPTION
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 게임 목록 리스트 요청 시에 발생하는 문제들을 수정했습니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
 - 메인 화면의 최근 게임 3개를 보여주는 부분에서 임의로 첫번째 페이지를 보여주도록 `page=1`을 넣어 주었는데, `InfScroll`에서 초깃값으로 `page=1` 을 넣게 되어 쿼리가 중복되는 문제가 있어서 임의로 `page=1`을 넣어주는 부분을 삭제해주었습니다.
 - `mode`에 대한 예외처리가 덜 되어있어 undefined error가 나는 부분을 수정했습니다.
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 