### PR TITLE
[GGFE-59] Match button 스타일 +  headcount 수정

### DIFF
--- a/components/match/MatchBoard.tsx
+++ b/components/match/MatchBoard.tsx
@@ -11,6 +11,7 @@ import { liveState } from 'utils/recoil/layout';
 import { Modal } from 'types/modalTypes';
 import { MatchMode } from 'types/mainType';
 import { currentMatchState } from 'utils/recoil/match';
+import { start } from 'repl';
 
 interface MatchBoardProps {
   type: string;
@@ -163,24 +164,34 @@ export const MatchSlot = ({ toggleMode, slot }: MatchSlotProps) => {
   const buttonStyle: { [key: string]: string } = useMemo(
     () => ({
       mytable: status === 'mytable' ? styles.mytable : styles.disabled,
-      close: styles.disabled,
+      close:
+        event === 'match' && match[0].startTime === startTime
+          ? styles.mytable
+          : styles.disabled,
       open: toggleMode === 'RANK' ? styles.rank : styles.normal,
       match: toggleMode === 'RANK' ? styles.rank : styles.normal,
     }),
     [slot]
   );
 
+  const isDisabled =
+    status === 'close' &&
+    !(event === 'match' && match[0].startTime === startTime)
+      ? true
+      : false;
+
   const isAfterSlot: boolean =
     new Date(startTime).getTime() - new Date().getTime() >= 0;
 
   const headCount =
-    status === 'close' ? 2 : status === ('mytable' || 'match') ? 1 : 0;
+    status === 'close' ? 2 : status === 'mytable' || status === 'match' ? 1 : 0;
 
   return (
     <div className={styles.slotGrid}>
       <button
         className={`${styles.slotButton} ${buttonStyle[status]}`}
-        disabled={status === 'close'}
+        // disabled={status === 'close' && !(match[0].startTime === startTime)}
+        disabled={isDisabled}
         onClick={enrollhandler}
       >
         <span className={styles.time}>

--- a/components/match/MatchBoard.tsx
+++ b/components/match/MatchBoard.tsx
@@ -11,7 +11,6 @@ import { liveState } from 'utils/recoil/layout';
 import { Modal } from 'types/modalTypes';
 import { MatchMode } from 'types/mainType';
 import { currentMatchState } from 'utils/recoil/match';
-import { start } from 'repl';
 
 interface MatchBoardProps {
   type: string;
@@ -190,7 +189,6 @@ export const MatchSlot = ({ toggleMode, slot }: MatchSlotProps) => {
     <div className={styles.slotGrid}>
       <button
         className={`${styles.slotButton} ${buttonStyle[status]}`}
-        // disabled={status === 'close' && !(match[0].startTime === startTime)}
         disabled={isDisabled}
         onClick={enrollhandler}
       >

--- a/components/match/MatchBoard.tsx
+++ b/components/match/MatchBoard.tsx
@@ -163,21 +163,21 @@ export const MatchSlot = ({ toggleMode, slot }: MatchSlotProps) => {
   const buttonStyle: { [key: string]: string } = useMemo(
     () => ({
       mytable: status === 'mytable' ? styles.mytable : styles.disabled,
-      close:
-        event === 'match' && match[0].startTime === startTime
-          ? styles.mytable
-          : styles.disabled,
+      close: styles.disabled,
+      // event === 'match' && match[0].startTime === startTime
+      //   ? styles.mytable
+      //   : styles.disabled, // 나의 매칭 경기가 close일 때 mytable 상태 표시
       open: toggleMode === 'RANK' ? styles.rank : styles.normal,
       match: toggleMode === 'RANK' ? styles.rank : styles.normal,
     }),
     [slot]
   );
 
-  const isDisabled =
-    status === 'close' &&
-    !(event === 'match' && match[0].startTime === startTime)
-      ? true
-      : false;
+  // const isDisabled =
+  //   status === 'close' &&
+  //   !(event === 'match' && match[0].startTime === startTime)
+  //     ? true
+  //     : false; // 나의 매칭 경기가 close일 때 disabled 안 되게
 
   const isAfterSlot: boolean =
     new Date(startTime).getTime() - new Date().getTime() >= 0;
@@ -189,7 +189,8 @@ export const MatchSlot = ({ toggleMode, slot }: MatchSlotProps) => {
     <div className={styles.slotGrid}>
       <button
         className={`${styles.slotButton} ${buttonStyle[status]}`}
-        disabled={isDisabled}
+        // disabled={isDisabled}
+        disabled={status === 'close'}
         onClick={enrollhandler}
       >
         <span className={styles.time}>


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - matchSlot 버튼 스타일 + headCount 잘못나오던 부분 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - matchSlot에서 본인이 잡은 경기를 기존에는 mytable로 받던 것에서 close로 status를 변경되면서 close status의 경우 currentMatch와 startTime을 비교하여 버튼 스타일 적용하는 부분 추가
  ## status 받는 사항 백엔드와 논의 필요
  - headCount는 괄호 수정
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
