### PR TITLE
[GGFE-61] Noti Imminent일 때 메세지 파싱 안되던 부분 수정

### DIFF
--- a/components/Layout/NotiBar/NotiElements.tsx
+++ b/components/Layout/NotiBar/NotiElements.tsx
@@ -85,7 +85,6 @@ export const NotiMain = () => {
   if (NotiContext?.noti.length) {
     return <NotiExist />;
   }
-  // return <NotiEmpty />;
   return <NotiExist />;
 };
 

--- a/components/Layout/NotiBar/NotiElements.tsx
+++ b/components/Layout/NotiBar/NotiElements.tsx
@@ -18,6 +18,23 @@ export const NotiCloseButton = () => {
   );
 };
 
+interface NullNotiProps {
+  createdAt: string;
+  isChecked: boolean;
+}
+
+const NullNoti = ({ createdAt, isChecked }: NullNotiProps) => {
+  const date = createdAt.slice(5).replace('T', ' ');
+
+  return (
+    <div className={isChecked ? `${styles.readWrap}` : `${styles.unreadWrap}`}>
+      <span className={styles.title}>실패</span>
+      <div className={styles.content}>알림을 불러올 수 없습니다!</div>
+      <div className={styles.date}>{date}</div>
+    </div>
+  );
+};
+
 export const NotiExist = () => {
   const NotiContext = useContext<NotiContextState | null>(NotiProvider);
 
@@ -31,9 +48,17 @@ export const NotiExist = () => {
         />
       </div>
       <div>
-        {NotiContext?.noti.map((data: Noti) => (
-          <NotiItem key={data.id} data={data} />
-        ))}
+        {NotiContext?.noti.map((data: Noti) =>
+          data.message ? (
+            <NotiItem key={data.id} data={data} />
+          ) : (
+            <NullNoti
+              key={data.id}
+              createdAt={data.createdAt}
+              isChecked={data.isChecked}
+            />
+          )
+        )}
       </div>
     </>
   );
@@ -60,7 +85,8 @@ export const NotiMain = () => {
   if (NotiContext?.noti.length) {
     return <NotiExist />;
   }
-  return <NotiEmpty />;
+  // return <NotiEmpty />;
+  return <NotiExist />;
 };
 
 interface ReloadNotiButtonProps {

--- a/components/Layout/NotiBar/NotiItem.tsx
+++ b/components/Layout/NotiBar/NotiItem.tsx
@@ -13,35 +13,12 @@ export default function NotiItem({ data }: NotiItemProps) {
   const date = data.createdAt.slice(5).replace('T', ' ');
   const { type, message, isChecked } = data;
 
-  const parseEnemyIdMessage = (
-    message: string
-  ): {
-    enemyId: string[];
-    enemyMessage: string;
-  } => {
-    const regList = /<intraId::(.+?)>/;
-    const regId = /^[a-zA-Z0-9]*$/;
-    const parseList = [] || message.split(regList).filter((str) => str !== '');
-    const enemyId = [] || parseList.filter((id) => regId.test(id) !== false);
-    const enemyMessage =
-      '' || parseList.filter((id) => regId.test(id) === false)[0];
-    return { enemyId, enemyMessage };
-  };
-
-  let enemyId: string[] = [];
-  let enemyMessage = '';
-
-  if (type === 'IMMINENT') {
-    enemyId = parseEnemyIdMessage(message).enemyId;
-    enemyMessage = parseEnemyIdMessage(message).enemyMessage;
-  }
-
   const noti: {
     [key: string]: { [key: string]: string | JSX.Element | undefined };
   } = {
     IMMINENT: {
       title: '경기 준비',
-      content: MakeImminentContent(enemyId, enemyMessage),
+      content: MakeImminentContent(message),
     },
     ANNOUNCE: {
       title: '공 지',
@@ -77,8 +54,26 @@ function MakeAnnounceContent(message: string | undefined) {
   );
 }
 
-function MakeImminentContent(enemyTeam: string[], message: string) {
+function MakeImminentContent(message: string) {
   const HeaderState = useContext<HeaderContextState | null>(HeaderContext);
+
+  const parseEnemyIdMessage = (
+    message: string
+  ): {
+    enemyId: string[];
+    enemyMessage: string;
+  } => {
+    const regList = /<intraId::(.+?)>/;
+    const regId = /^[a-zA-Z0-9]*$/;
+    const parseList = message.split(regList).filter((str) => str !== '');
+    const enemyId = parseList.filter((id) => regId.test(id) !== false);
+    const enemyMessage = parseList.filter((id) => regId.test(id) === false)[0];
+    return { enemyId, enemyMessage };
+  };
+
+  const enemyId = parseEnemyIdMessage(message).enemyId;
+  const enemyMessage = parseEnemyIdMessage(message).enemyMessage;
+
   const makeEnemyUsers = (enemyTeam: string[]) => {
     return enemyTeam.map((intraId: string, i: number) => (
       <span key={intraId} onClick={() => HeaderState?.resetOpenNotiBarState()}>
@@ -89,9 +84,10 @@ function MakeImminentContent(enemyTeam: string[], message: string) {
   };
   return (
     <>
-      {enemyTeam.length && (
+      {enemyId.length && (
         <>
-          {makeEnemyUsers(enemyTeam)} {message}
+          {makeEnemyUsers(enemyId)}
+          {enemyMessage}
         </>
       )}
     </>

--- a/components/Layout/NotiBar/NotiItem.tsx
+++ b/components/Layout/NotiBar/NotiItem.tsx
@@ -69,8 +69,7 @@ function MakeImminentContent(message: string) {
     return { enemyId, enemyMessage };
   };
 
-  const enemyId = parseEnemyIdMessage(message).enemyId;
-  const enemyMessage = parseEnemyIdMessage(message).enemyMessage;
+  const { enemyId, enemyMessage } = parseEnemyIdMessage(message);
 
   const makeEnemyUsers = (enemyTeam: string[]) => {
     return enemyTeam.map((intraId: string, i: number) => (

--- a/components/Layout/NotiBar/NotiItem.tsx
+++ b/components/Layout/NotiBar/NotiItem.tsx
@@ -33,9 +33,7 @@ export default function NotiItem({ data }: NotiItemProps) {
   return (
     <div className={isChecked ? `${styles.readWrap}` : `${styles.unreadWrap}`}>
       <span className={styles.title}>{noti[type].title}</span>
-      <div className={styles.content}>
-        {message ? noti[type].content : '알림을 불러올 수 없습니다.'}
-      </div>
+      <div className={styles.content}>{noti[type].content}</div>
       <div className={styles.date}>{date}</div>
     </div>
   );


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - Noti Imminent일 때 메세지 파싱이 안되고 빈 문자열만 반환되던 것 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  -  Noti type에 따라 조건부 파싱하던 것에서 메세지 생성하는 부분에서 파싱하도록 변경
  - message null인 경우 noti item map으로 돌 때 따로 다른 컴포넌트 생성하게 변경
  - 그 외에 noti title style에서 에러나는 것은 지금은 쓰지 않는 canceledbyman같은 타입이 들어오면 없는 타입이라 에러가 뜸
  - 새로 올릴 때는 백에서 기존 사용자들 노티 다 날려달라고 말해놨습니다.
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
