### PR TITLE
[GGFE-64] 게임 매뉴얼 모달 스타일 적용

### DIFF
--- a/components/modal/ModalProvider.tsx
+++ b/components/modal/ModalProvider.tsx
@@ -90,7 +90,6 @@ export default function ModalProvider() {
         id='modalOutside'
         onClick={closeModalHandler}
       >
-        {/* <div className={styles.modalContainer}>{content[modalName]}</div> */}
         {content[modalName]}
       </div>
     )

--- a/components/modal/ModalProvider.tsx
+++ b/components/modal/ModalProvider.tsx
@@ -90,7 +90,8 @@ export default function ModalProvider() {
         id='modalOutside'
         onClick={closeModalHandler}
       >
-        <div className={styles.modalContainer}>{content[modalName]}</div>
+        {/* <div className={styles.modalContainer}>{content[modalName]}</div> */}
+        {content[modalName]}
       </div>
     )
   );

--- a/components/modal/match/MatchManualModal.tsx
+++ b/components/modal/match/MatchManualModal.tsx
@@ -101,7 +101,6 @@ export default function MatchManualModal({ radioMode }: Manual) {
   const [manualMode, setManualMode] = useState<MatchMode>(radioMode);
 
   const modeChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
-    console.log('😆', e.target.value);
     setManualMode(e.target.value as MatchMode);
   };
 

--- a/components/modal/match/MatchManualModal.tsx
+++ b/components/modal/match/MatchManualModal.tsx
@@ -8,8 +8,7 @@ import styles from 'styles/modal/match/MatchManualModal.module.scss';
 import { AiFillQuestionCircle } from 'react-icons/ai';
 
 type contentType = {
-  icon: React.ReactNode;
-  title: string;
+  title: React.ReactNode;
   description: string[];
 };
 
@@ -19,20 +18,22 @@ type contentsType = Record<MatchMode, contentType[]>;
 const modalContents: contentsType = {
   BOTH: [
     {
-      icon: <span></span>,
-      title: '아직 정해지지 않음',
+      title: <ContentTitle title={'아직 정해지지 않음'} />,
       description: [`아직 정해지지 않음`],
     },
     {
-      icon: <AiFillQuestionCircle />,
-      title: '엄청 긴 제목은 아마도 이렇게 보입니다 ',
+      title: (
+        <ContentTitle
+          title={'엄청 긴 제목은 아마도 이렇게 보입니다'}
+          icon={<AiFillQuestionCircle />}
+        />
+      ),
       description: [`아직 정해지지 않음`],
     },
   ],
   NORMAL: [
     {
-      icon: <span>🔍</span>,
-      title: '매칭',
+      title: <ContentTitle title={'매칭'} icon={'🔍'} />,
       description: [
         '등록한 경기가 끝나야만 다음 경기 등록 가능',
         '상대 팀이 공개되면 경기 취소 불가',
@@ -42,25 +43,21 @@ const modalContents: contentsType = {
       ],
     },
     {
-      icon: <span>📖</span>,
-      title: '일반 경기 규칙',
+      title: <ContentTitle title={'일반 경기 규칙'} icon={'📖'} />,
       description: ['자유 규칙 !'],
     },
     {
-      icon: <span>✅</span>,
-      title: '경기 결과',
+      title: <ContentTitle title={'경기 결과'} icon={'✅'} />,
       description: ['일반 게임 진행 시 점수 입력 없음'],
     },
     {
-      icon: <span>🚨</span>,
-      title: '노쇼',
+      title: <ContentTitle title={'노쇼'} icon={'🚨'} />,
       description: [`노쇼는 건의사항 기능 이용해서 신고`],
     },
   ],
   RANK: [
     {
-      icon: <span>🔍</span>,
-      title: '매칭',
+      title: <ContentTitle title={'매칭'} icon={'🔍'} />,
       description: [
         '등록한 경기가 끝나야만 다음 경기 등록 가능',
         '상대 팀이 공개되면 경기 취소 불가',
@@ -71,8 +68,7 @@ const modalContents: contentsType = {
       ],
     },
     {
-      icon: <span>📖</span>,
-      title: '랭크 경기 규칙',
+      title: <ContentTitle title={'랭크 경기 규칙'} icon={'📖'} />,
       description: [
         '11점 3판 2선승제',
         '경기시간은 슬롯에 표기',
@@ -83,8 +79,7 @@ const modalContents: contentsType = {
       ],
     },
     {
-      icon: <span>🚨</span>,
-      title: '서브 규칙',
+      title: <ContentTitle title={'서브 규칙'} icon={'🚨'} />,
       description: [
         '첫 세트만 서브 게임 진행',
         '서브 게임 승자부터 세트별 교대로 서브',
@@ -94,8 +89,7 @@ const modalContents: contentsType = {
       ],
     },
     {
-      icon: <span>✅</span>,
-      title: '경기 결과',
+      title: <ContentTitle title={'경기 결과'} icon={'✅'} />,
       description: [
         '경기 종료 후 그 자리에서 세트 점수 입력',
         '종료시간에 다음 경기가 있을 시 현재 스코어가 높은 선수가 승리',
@@ -103,8 +97,7 @@ const modalContents: contentsType = {
       ],
     },
     {
-      icon: <span>🚨</span>,
-      title: '노쇼',
+      title: <ContentTitle title={'노쇼'} icon={'🚨'} />,
       description: [
         `매치가 시작 되었으나 상대방이 나오지 않는다면 3분이 지날 때 마다 세트 점수 1점씩 획득`,
         '6분이 지났을 때도 나오지 않았다면 세트 점수 2:0 승리 처리',
@@ -136,17 +129,13 @@ export default function MatchManualModal({ radioMode }: Manual) {
         {modalContents[manualMode].map(
           (
             item: {
-              icon: React.ReactNode;
-              title: string;
+              title: React.ReactNode;
               description: string[];
             },
             index
           ) => (
             <li key={index}>
-              <div className={styles.ruleTitle}>
-                {item.icon}
-                <span>{item.title}</span>
-              </div>
+              {item.title}
               <ul className={styles.ruleDetail}>
                 {item.description.map((e, idx) => (
                   <li key={idx}>{e}</li>
@@ -162,6 +151,24 @@ export default function MatchManualModal({ radioMode }: Manual) {
       >
         확 인
       </button>
+    </div>
+  );
+}
+
+type contentTitleProps = {
+  title: string;
+  icon?: React.ReactNode | string;
+};
+
+function ContentTitle({ title, icon }: contentTitleProps) {
+  icon = typeof icon === 'string' ? <span>{icon}</span> : icon;
+  return (
+    <div
+      className={`${styles.ruleTitle} 
+      ${styles[icon ? 'withIcon' : 'withoutIcon']}`}
+    >
+      {icon ? icon : null}
+      <span>{title}</span>
     </div>
   );
 }

--- a/components/modal/match/MatchManualModal.tsx
+++ b/components/modal/match/MatchManualModal.tsx
@@ -6,11 +6,102 @@ import { modalState } from 'utils/recoil/modal';
 import ModeRadiobox from 'components/mode/modeItems/ModeRadiobox';
 import styles from 'styles/modal/match/MatchManualModal.module.scss';
 
+type contentType = {
+  title: string;
+  description: string[];
+};
+
+type contentsType = Record<MatchMode, contentType[]>;
+
+// TODO : 전체 타입에 대한 설명 추가해야 합니다.
+const modalContents: contentsType = {
+  BOTH: [
+    {
+      title: '😳 아직 정해지지 않음',
+      description: [`아직 정해지지 않음`],
+    },
+  ],
+  NORMAL: [
+    {
+      title: '🔍 매칭',
+      description: [
+        '등록한 경기가 끝나야만 다음 경기 등록 가능',
+        '상대 팀이 공개되면 경기 취소 불가',
+        '매칭 알림은 이메일로 전달',
+        '경기가 매칭된 상태에서 취소 시, 1분간 경기 등록 불가',
+        '상대방이 경기를 취소하면 나의 경기는 매칭 대기 상태로 전환',
+      ],
+    },
+    {
+      title: '📖 일반 경기 규칙',
+      description: ['자유 규칙 !'],
+    },
+    {
+      title: '✅ 경기 결과',
+      description: ['일반 게임 진행 시 점수 입력 없음'],
+    },
+    {
+      title: '🚨 노쇼',
+      description: [`노쇼는 건의사항 기능 이용해서 신고`],
+    },
+  ],
+  RANK: [
+    {
+      title: '🔍 매칭',
+      description: [
+        '등록한 경기가 끝나야만 다음 경기 등록 가능',
+        '상대 팀이 공개되면 경기 취소 불가',
+        '매칭 알림은 이메일로 전달',
+        '경기가 매칭된 상태에서 취소 시, 1분간 경기 등록 불가',
+        '상대방이 경기를 취소하면 나의 경기는 매칭 대기 상태로 전환',
+        '일정 점수 이상 차이 나는 상대와 랭크 경기 불가',
+      ],
+    },
+    {
+      title: '📖 랭크 경기 규칙',
+      description: [
+        '11점 3판 2선승제',
+        '경기시간은 슬롯에 표기',
+        '점수가 10:10 인 경우 듀스',
+        '듀스인 경우, 2점 차가 나면 경기 종료',
+        '탁구채를 잡지 않은 손으로 탁구대를 짚으면 실점',
+        '탁구대 및 네트가 아닌 곳에 공이 맞을 시 실점',
+      ],
+    },
+    {
+      title: '🏓 서브 규칙',
+      description: [
+        '첫 세트만 서브 게임 진행',
+        '서브 게임 승자부터 세트별 교대로 서브',
+        '서브는 2점마다 교대하며, 듀스일 때는 1점마다 교대',
+        '서브 시작 시 상대방에게 신호 (e.g. 서브하겠습니다.)',
+        '서브 시 공이 네트에 맞고 넘어가면 다시 서브',
+      ],
+    },
+    {
+      title: '✅ 경기 결과',
+      description: [
+        '경기 종료 후 그 자리에서 세트 점수 입력',
+        '종료시간에 다음 경기가 있을 시 현재 스코어가 높은 선수가 승리',
+        '다음 경기가 없을 시 계속 진행 가능',
+      ],
+    },
+    {
+      title: '🚨 노쇼',
+      description: [
+        `매치가 시작 되었으나 상대방이 나오지 않는다면 3분이 지날 때 마다 세트 점수 1점씩 획득`,
+        '6분이 지났을 때도 나오지 않았다면 세트 점수 2:0 승리 처리',
+      ],
+    },
+  ],
+};
+
 export default function MatchManualModal({ radioMode }: Manual) {
   const setModal = useSetRecoilState(modalState);
   const [manualMode, setManualMode] = useState<MatchMode>(radioMode);
 
   const modeChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+    console.log('😆', e.target.value);
     setManualMode(e.target.value as MatchMode);
   };
 
@@ -26,7 +117,7 @@ export default function MatchManualModal({ radioMode }: Manual) {
         />
       </div>
       <ul className={styles.ruleList}>
-        {manualSelect(radioMode).map(
+        {modalContents[manualMode].map(
           (item: { title: string; description: string[] }, index) => (
             <li key={index}>
               {item.title}
@@ -48,81 +139,3 @@ export default function MatchManualModal({ radioMode }: Manual) {
     </div>
   );
 }
-
-const modalContentsNormal: { title: string; description: string[] }[] = [
-  {
-    title: '🔍 매칭',
-    description: [
-      '등록한 경기가 끝나야만 다음 경기 등록 가능',
-      '상대 팀이 공개되면 경기 취소 불가',
-      '매칭 알림은 이메일로 전달',
-      '경기가 매칭된 상태에서 취소 시, 1분간 경기 등록 불가',
-      '상대방이 경기를 취소하면 나의 경기는 매칭 대기 상태로 전환',
-    ],
-  },
-  {
-    title: '📖 일반 경기 규칙',
-    description: ['자유 규칙 !'],
-  },
-  {
-    title: '✅ 경기 결과',
-    description: ['일반 게임 진행 시 점수 입력 없음'],
-  },
-  {
-    title: '🚨 노쇼',
-    description: [`노쇼는 건의사항 기능 이용해서 신고`],
-  },
-];
-
-const modalContentsRank: { title: string; description: string[] }[] = [
-  {
-    title: '🔍 매칭',
-    description: [
-      '등록한 경기가 끝나야만 다음 경기 등록 가능',
-      '상대 팀이 공개되면 경기 취소 불가',
-      '매칭 알림은 이메일로 전달',
-      '경기가 매칭된 상태에서 취소 시, 1분간 경기 등록 불가',
-      '상대방이 경기를 취소하면 나의 경기는 매칭 대기 상태로 전환',
-      '일정 점수 이상 차이 나는 상대와 랭크 경기 불가',
-    ],
-  },
-  {
-    title: '📖 랭크 경기 규칙',
-    description: [
-      '11점 3판 2선승제',
-      '경기시간은 슬롯에 표기',
-      '점수가 10:10 인 경우 듀스',
-      '듀스인 경우, 2점 차가 나면 경기 종료',
-      '탁구채를 잡지 않은 손으로 탁구대를 짚으면 실점',
-      '탁구대 및 네트가 아닌 곳에 공이 맞을 시 실점',
-    ],
-  },
-  {
-    title: '🏓 서브 규칙',
-    description: [
-      '첫 세트만 서브 게임 진행',
-      '서브 게임 승자부터 세트별 교대로 서브',
-      '서브는 2점마다 교대하며, 듀스일 때는 1점마다 교대',
-      '서브 시작 시 상대방에게 신호 (e.g. 서브하겠습니다.)',
-      '서브 시 공이 네트에 맞고 넘어가면 다시 서브',
-    ],
-  },
-  {
-    title: '✅ 경기 결과',
-    description: [
-      '경기 종료 후 그 자리에서 세트 점수 입력',
-      '종료시간에 다음 경기가 있을 시 현재 스코어가 높은 선수가 승리',
-      '다음 경기가 없을 시 계속 진행 가능',
-    ],
-  },
-  {
-    title: '🚨 노쇼',
-    description: [
-      `매치가 시작 되었으나 상대방이 나오지 않는다면 3분이 지날 때 마다 세트 점수 1점씩 획득`,
-      '6분이 지났을 때도 나오지 않았다면 세트 점수 2:0 승리 처리',
-    ],
-  },
-];
-
-const manualSelect = (radioMode: MatchMode) =>
-  radioMode === ('RANK' || 'BOTH') ? modalContentsRank : modalContentsNormal;

--- a/components/modal/match/MatchManualModal.tsx
+++ b/components/modal/match/MatchManualModal.tsx
@@ -41,11 +41,12 @@ export default function MatchManualModal({ radioMode }: Manual) {
           )
         )}
       </ul>
-      <div className={styles.buttons}>
-        <div className={styles.positive}>
-          <input onClick={onReturn} type='button' value={'확 인'} />
-        </div>
-      </div>
+      <button
+        className={`${styles['modalButton']}`}
+        onClick={() => setModal({ modalName: null })}
+      >
+        확 인
+      </button>
     </div>
   );
 }

--- a/components/modal/match/MatchManualModal.tsx
+++ b/components/modal/match/MatchManualModal.tsx
@@ -20,15 +20,13 @@ export default function MatchManualModal({ radioMode }: Manual) {
 
   return (
     <div className={styles.container}>
-      <div className={styles.title}>Please!!</div>
-      <div className={styles.toggleContainer}>
-        <ModeRadiobox
-          mode={manualMode}
-          page='MANUAL'
-          onChange={modeChangeHandler}
-          zIndexList={false}
-        />
-      </div>
+      <div className={styles.title}>Important</div>
+      <ModeRadiobox
+        mode={manualMode}
+        page='MANUAL'
+        onChange={modeChangeHandler}
+        zIndexList={false}
+      />
       <ul className={styles.ruleList}>
         {manualSelect(radioMode).map(
           (item: { title: string; description: string[] }, index) => (

--- a/components/modal/match/MatchManualModal.tsx
+++ b/components/modal/match/MatchManualModal.tsx
@@ -10,10 +10,6 @@ export default function MatchManualModal({ radioMode }: Manual) {
   const setModal = useSetRecoilState(modalState);
   const [manualMode, setManualMode] = useState<MatchMode>(radioMode);
 
-  const onReturn = () => {
-    setModal({ modalName: null });
-  };
-
   const modeChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
     setManualMode(e.target.value as MatchMode);
   };
@@ -21,12 +17,14 @@ export default function MatchManualModal({ radioMode }: Manual) {
   return (
     <div className={styles.container}>
       <div className={styles.title}>Important</div>
-      <ModeRadiobox
-        mode={manualMode}
-        page='MANUAL'
-        onChange={modeChangeHandler}
-        zIndexList={false}
-      />
+      <div className={styles.matchRadioBoxWrap}>
+        <ModeRadiobox
+          mode={manualMode}
+          page='MANUAL'
+          onChange={modeChangeHandler}
+          zIndexList={false}
+        />
+      </div>
       <ul className={styles.ruleList}>
         {manualSelect(radioMode).map(
           (item: { title: string; description: string[] }, index) => (

--- a/components/modal/match/MatchManualModal.tsx
+++ b/components/modal/match/MatchManualModal.tsx
@@ -3,7 +3,7 @@ import { useSetRecoilState } from 'recoil';
 import { MatchMode } from 'types/mainType';
 import { Manual } from 'types/modalTypes';
 import { modalState } from 'utils/recoil/modal';
-import ModeToggle from 'components/mode/modeItems/ModeToggle';
+import ModeRadiobox from 'components/mode/modeItems/ModeRadiobox';
 import styles from 'styles/modal/match/MatchManualModal.module.scss';
 
 export default function MatchManualModal({ radioMode }: Manual) {
@@ -14,19 +14,19 @@ export default function MatchManualModal({ radioMode }: Manual) {
     setModal({ modalName: null });
   };
 
-  const onToggle = () => {
-    setManualMode(manualMode === ('RANK' || 'BOTH') ? 'NORMAL' : 'RANK');
+  const modeChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setManualMode(e.target.value as MatchMode);
   };
 
   return (
     <div className={styles.container}>
       <div className={styles.title}>Please!!</div>
       <div className={styles.toggleContainer}>
-        <ModeToggle
-          checked={manualMode === 'RANK'}
-          onToggle={onToggle}
-          id={'manualToggle'}
-          text={manualMode === 'RANK' ? '랭크' : '일반'}
+        <ModeRadiobox
+          mode={manualMode}
+          page='MANUAL'
+          onChange={modeChangeHandler}
+          zIndexList={false}
         />
       </div>
       <ul className={styles.ruleList}>

--- a/components/modal/match/MatchManualModal.tsx
+++ b/components/modal/match/MatchManualModal.tsx
@@ -5,8 +5,10 @@ import { Manual } from 'types/modalTypes';
 import { modalState } from 'utils/recoil/modal';
 import ModeRadiobox from 'components/mode/modeItems/ModeRadiobox';
 import styles from 'styles/modal/match/MatchManualModal.module.scss';
+import { AiFillQuestionCircle } from 'react-icons/ai';
 
 type contentType = {
+  icon: React.ReactNode;
   title: string;
   description: string[];
 };
@@ -17,13 +19,20 @@ type contentsType = Record<MatchMode, contentType[]>;
 const modalContents: contentsType = {
   BOTH: [
     {
-      title: '😳 아직 정해지지 않음',
+      icon: <span></span>,
+      title: '아직 정해지지 않음',
+      description: [`아직 정해지지 않음`],
+    },
+    {
+      icon: <AiFillQuestionCircle />,
+      title: '엄청 긴 제목은 아마도 이렇게 보입니다 ',
       description: [`아직 정해지지 않음`],
     },
   ],
   NORMAL: [
     {
-      title: '🔍 매칭',
+      icon: <span>🔍</span>,
+      title: '매칭',
       description: [
         '등록한 경기가 끝나야만 다음 경기 등록 가능',
         '상대 팀이 공개되면 경기 취소 불가',
@@ -33,21 +42,25 @@ const modalContents: contentsType = {
       ],
     },
     {
-      title: '📖 일반 경기 규칙',
+      icon: <span>📖</span>,
+      title: '일반 경기 규칙',
       description: ['자유 규칙 !'],
     },
     {
-      title: '✅ 경기 결과',
+      icon: <span>✅</span>,
+      title: '경기 결과',
       description: ['일반 게임 진행 시 점수 입력 없음'],
     },
     {
-      title: '🚨 노쇼',
+      icon: <span>🚨</span>,
+      title: '노쇼',
       description: [`노쇼는 건의사항 기능 이용해서 신고`],
     },
   ],
   RANK: [
     {
-      title: '🔍 매칭',
+      icon: <span>🔍</span>,
+      title: '매칭',
       description: [
         '등록한 경기가 끝나야만 다음 경기 등록 가능',
         '상대 팀이 공개되면 경기 취소 불가',
@@ -58,7 +71,8 @@ const modalContents: contentsType = {
       ],
     },
     {
-      title: '📖 랭크 경기 규칙',
+      icon: <span>📖</span>,
+      title: '랭크 경기 규칙',
       description: [
         '11점 3판 2선승제',
         '경기시간은 슬롯에 표기',
@@ -69,7 +83,8 @@ const modalContents: contentsType = {
       ],
     },
     {
-      title: '🏓 서브 규칙',
+      icon: <span>🚨</span>,
+      title: '서브 규칙',
       description: [
         '첫 세트만 서브 게임 진행',
         '서브 게임 승자부터 세트별 교대로 서브',
@@ -79,7 +94,8 @@ const modalContents: contentsType = {
       ],
     },
     {
-      title: '✅ 경기 결과',
+      icon: <span>✅</span>,
+      title: '경기 결과',
       description: [
         '경기 종료 후 그 자리에서 세트 점수 입력',
         '종료시간에 다음 경기가 있을 시 현재 스코어가 높은 선수가 승리',
@@ -87,7 +103,8 @@ const modalContents: contentsType = {
       ],
     },
     {
-      title: '🚨 노쇼',
+      icon: <span>🚨</span>,
+      title: '노쇼',
       description: [
         `매치가 시작 되었으나 상대방이 나오지 않는다면 3분이 지날 때 마다 세트 점수 1점씩 획득`,
         '6분이 지났을 때도 나오지 않았다면 세트 점수 2:0 승리 처리',
@@ -117,9 +134,19 @@ export default function MatchManualModal({ radioMode }: Manual) {
       </div>
       <ul className={styles.ruleList}>
         {modalContents[manualMode].map(
-          (item: { title: string; description: string[] }, index) => (
+          (
+            item: {
+              icon: React.ReactNode;
+              title: string;
+              description: string[];
+            },
+            index
+          ) => (
             <li key={index}>
-              {item.title}
+              <div className={styles.ruleTitle}>
+                {item.icon}
+                <span>{item.title}</span>
+              </div>
               <ul className={styles.ruleDetail}>
                 {item.description.map((e, idx) => (
                   <li key={idx}>{e}</li>

--- a/components/mode/modeItems/ModeRadiobox.tsx
+++ b/components/mode/modeItems/ModeRadiobox.tsx
@@ -27,7 +27,7 @@ export default function ModeRadiobox({
       ${zIndexList && styles['zIndexListButton']}`}
     >
       {modes.map(({ type, name }) => (
-        <label key={type} htmlFor={type}>
+        <label key={type}>
           <input
             type='radio'
             id={type}

--- a/components/mode/modeItems/ModeRadiobox.tsx
+++ b/components/mode/modeItems/ModeRadiobox.tsx
@@ -3,12 +3,14 @@ import styles from 'styles/mode/ModeRadiobox.module.scss';
 
 interface ModeRadioboxProps {
   mode: SeasonMode;
+  page: 'GAME' | 'MATCH' | 'MANUAL';
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   zIndexList?: boolean;
 }
 
 export default function ModeRadiobox({
   mode,
+  page,
   onChange,
   zIndexList,
 }: ModeRadioboxProps) {
@@ -21,6 +23,7 @@ export default function ModeRadiobox({
   return (
     <div
       className={`${styles.modeButtons} 
+      ${styles[page.toLowerCase()]}
       ${zIndexList && styles['zIndexListButton']}`}
     >
       {modes.map(({ type, name }) => (

--- a/components/mode/modeWraps/GameModeWrap.tsx
+++ b/components/mode/modeWraps/GameModeWrap.tsx
@@ -52,6 +52,7 @@ export default function GameModeWrap({
       </div>
       <ModeRadiobox
         mode={radioMode}
+        page='GAME'
         onChange={modeChangeHandler}
         zIndexList={!isGamePage}
       />

--- a/components/mode/modeWraps/MatchModeWrap.tsx
+++ b/components/mode/modeWraps/MatchModeWrap.tsx
@@ -20,7 +20,12 @@ export default function MatchModeWrap({
 
   return (
     <div>
-      <ModeRadiobox mode={radioMode} onChange={modeChangeHandler} />
+      <ModeRadiobox
+        mode={radioMode}
+        page='MATCH'
+        onChange={modeChangeHandler}
+        zIndexList={false}
+      />
       {React.cloneElement(children as React.ReactElement, {
         mode: radioMode,
       })}

--- a/stories/game/ModeRadiobox.stories.tsx
+++ b/stories/game/ModeRadiobox.stories.tsx
@@ -7,6 +7,7 @@ const meta: Meta<typeof ModeRadiobox> = {
   tags: ['autodocs'],
   argTypes: {
     mode: ['BOTH', 'NORMAL', 'RANK'],
+    page: ['GAME', 'MATCH', 'MANUAL'],
     zIndexList: Boolean,
   },
 };
@@ -14,23 +15,32 @@ const meta: Meta<typeof ModeRadiobox> = {
 export default meta;
 type Story = StoryObj<typeof ModeRadiobox>;
 
-export const Both: Story = {
+export const GameRadio: Story = {
   args: {
     mode: 'BOTH',
+    page: 'GAME',
     zIndexList: false,
   },
 };
 
-export const Normal: Story = {
+export const MatchRadio: Story = {
   args: {
-    mode: 'NORMAL',
+    mode: 'BOTH',
+    page: 'MATCH',
     zIndexList: false,
   },
 };
 
-export const Rank: Story = {
+export const ManualRadio: Story = {
   args: {
-    mode: 'RANK',
+    mode: 'BOTH',
+    page: 'MANUAL',
     zIndexList: false,
+  },
+  parameters: {
+    backgrounds: {
+      default: 'ManualModal',
+      values: [{ name: 'ManualModal', value: '#775189' }],
+    },
   },
 };

--- a/stories/modal/MatchManualModal.stories.tsx
+++ b/stories/modal/MatchManualModal.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import MatchManualModal from 'components/modal/match/MatchManualModal';
+
+const meta: Meta<typeof MatchManualModal> = {
+  title: 'Modal/MatchManualModal',
+  component: MatchManualModal,
+  tags: ['autodocs'],
+  argTypes: {
+    radioMode: ['BOTH', 'NORMAL', 'RANK'],
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MatchManualModal>;
+
+export const BothMode: Story = {
+  args: {
+    radioMode: 'BOTH',
+  },
+};
+
+export const NormalMode: Story = {
+  args: {
+    radioMode: 'NORMAL',
+  },
+};
+
+export const RankMode: Story = {
+  args: {
+    radioMode: 'RANK',
+  },
+};

--- a/styles/common.scss
+++ b/styles/common.scss
@@ -183,7 +183,27 @@ $text-shadow-blue: 2px 2px 0px $pp-blue;
   margin-bottom: 2rem;
 }
 
-@mixin modal-container {
+// TODO: 다른 것들도 이름 변경
+@mixin modalContainer($type) {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  align-items: center;
+  margin: 2rem 1.5rem;
+  padding: 2rem 1rem;
+  border-radius: 1rem;
+  @if ($type == 'DARKPURPLE') {
+    background: linear-gradient(
+      180deg,
+      #7f5792 0%,
+      #1d0b25 48.44%,
+      #775189 95.91%
+    );
+  }
+}
+
+// TODO: 충돌로 인해 삭제하지 못함. 나중에 삭제할 것
+@mixin modal-container() {
   display: flex;
   flex-direction: column;
   justify-content: space-evenly;

--- a/styles/modal/match/MatchManualModal.module.scss
+++ b/styles/modal/match/MatchManualModal.module.scss
@@ -1,13 +1,16 @@
 @import 'styles/common.scss';
 
 .container {
-  @include modal-container;
+  @include modalContainer('DARKPURPLE');
   width: 80vw;
   max-width: 20rem;
 }
 
 .title {
-  @include modalTitle;
+  font-size: 2.25rem;
+  font-family: 'Lexend';
+  color: #f8f8ff;
+  text-shadow: 0px 0px 12px #ffffff;
 }
 
 .toggleContainer {

--- a/styles/modal/match/MatchManualModal.module.scss
+++ b/styles/modal/match/MatchManualModal.module.scss
@@ -7,19 +7,16 @@
 }
 
 .title {
+  margin: 2.75rem 0;
   font-size: 2.25rem;
   font-family: 'Lexend';
   color: #f8f8ff;
   text-shadow: 0px 0px 12px #ffffff;
 }
 
-.toggleContainer {
+.matchRadioBoxWrap {
   width: 100%;
-  display: flex;
-  flex-direction: row-reverse;
-  padding-top: 0.5rem;
-  padding-right: 1rem;
-  margin-bottom: 0.1rem;
+  box-sizing: border-box;
 }
 
 .ruleList {

--- a/styles/modal/match/MatchManualModal.module.scss
+++ b/styles/modal/match/MatchManualModal.module.scss
@@ -21,9 +21,9 @@
 
 .ruleList {
   list-style: none;
-  width: auto;
+  width: 100%;
   height: 60vh;
-  max-height: 437px;
+  max-height: 285px;
   margin: 0 0.6rem 1.75rem;
   padding: 1rem;
   background: #ffffff;
@@ -68,6 +68,7 @@
   border-radius: 10px;
   padding: 0.75rem 2.25rem;
   color: #ffffff;
+  cursor: pointer;
   @if ($color == 'DARKPURPLE') {
     background: linear-gradient(
       180deg,

--- a/styles/modal/match/MatchManualModal.module.scss
+++ b/styles/modal/match/MatchManualModal.module.scss
@@ -26,8 +26,11 @@
   list-style: none;
   width: auto;
   height: 60vh;
-  max-height: 60vh;
-  margin: 0 0.6rem 0.5rem;
+  max-height: 437px;
+  margin: 0 0.6rem 1.75rem;
+  padding: 1rem;
+  background: #ffffff;
+  border-radius: 0px 0px 10px 10px;
   color: black;
   font-size: 1.2rem;
   font-weight: 700;
@@ -41,6 +44,7 @@
 
 .ruleDetail {
   margin-left: 0.8rem;
+  padding: 0.5rem 0.5em 0.5rem 1.5rem;
   font-size: 0.9rem;
   font-weight: 400;
 
@@ -53,15 +57,30 @@
 
 .ruleList::-webkit-scrollbar {
   display: inherit;
-  width: 5px;
+  width: 6px;
   height: 1rem;
 }
 
 .ruleList::-webkit-scrollbar-thumb {
-  border-radius: 10px;
-  background: white;
+  border-radius: 6px;
+  background: #c6c4c4;
 }
 
-.buttons {
-  @include select-buttons;
+@mixin modalButton($color) {
+  border: none;
+  border-radius: 10px;
+  padding: 0.75rem 2.25rem;
+  color: #ffffff;
+  @if ($color == 'DARKPURPLE') {
+    background: linear-gradient(
+      180deg,
+      #c66bf2 0%,
+      rgba(96, 6, 138, 0.52) 100%
+    );
+  }
+}
+
+.modalButton {
+  @include modalButton('DARKPURPLE');
+  margin: 0 0.5rem;
 }

--- a/styles/modal/match/MatchManualModal.module.scss
+++ b/styles/modal/match/MatchManualModal.module.scss
@@ -39,6 +39,21 @@
   }
 }
 
+.ruleTitle {
+  display: flex;
+  align-items: center;
+  vertical-align: middle;
+  :first-child {
+    min-width: 1.5rem;
+    max-width: 1.5rem;
+    min-height: 1.5rem;
+    max-height: 1.5rem;
+  }
+  :last-child {
+    margin-left: 0.5rem;
+  }
+}
+
 .ruleDetail {
   margin-left: 0.8rem;
   padding: 0.5rem 0.5em 0.5rem 1.5rem;

--- a/styles/modal/match/MatchManualModal.module.scss
+++ b/styles/modal/match/MatchManualModal.module.scss
@@ -43,13 +43,18 @@
   display: flex;
   align-items: center;
   vertical-align: middle;
-  :first-child {
-    min-width: 1.5rem;
-    max-width: 1.5rem;
-    min-height: 1.5rem;
-    max-height: 1.5rem;
+  &.withIcon {
+    :first-child {
+      min-width: 1.5rem;
+      max-width: 1.5rem;
+      min-height: 1.5rem;
+      max-height: 1.5rem;
+    }
+    :last-child {
+      margin-left: 0.5rem;
+    }
   }
-  :last-child {
+  &.withoutIcon {
     margin-left: 0.5rem;
   }
 }

--- a/styles/mode/ModeRadiobox.module.scss
+++ b/styles/mode/ModeRadiobox.module.scss
@@ -17,7 +17,7 @@
       background: #000000;
     }
   } @else if ($page == 'MATCH') {
-    // 매치 슬롯에서 쓰이는 모드 버튼 추가할 것
+    // TODO 매치 슬롯에서 쓰이는 모드 버튼 추가할 것
   } @else if ($page == 'MANUAL') {
     :checked + .modeButton {
       background: #380052;
@@ -31,6 +31,7 @@
 .modeButtons {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
+  column-gap: 0.25rem;
   justify-items: stretch;
   align-items: stretch;
   margin: 0 1.25rem;
@@ -51,7 +52,7 @@
   }
   &.manual {
     @include ButtonBackground('MANUAL');
-    margin: 0 0.48rem;
+    margin: 0;
   }
   .modeButton {
     display: flex;
@@ -59,8 +60,6 @@
     justify-content: center;
     align-items: center;
     height: 2.063rem;
-    margin: 0 0.125rem;
-    // background: #0e0518;
     border-radius: 0.625rem 0.625rem 0 0;
     font-size: 0.9rem;
     letter-spacing: 2px;

--- a/styles/mode/ModeRadiobox.module.scss
+++ b/styles/mode/ModeRadiobox.module.scss
@@ -1,5 +1,33 @@
 @import '../common.scss';
 
+@mixin ButtonBackground($page) {
+  @if ($page == 'GAME') {
+    :checked + .modeButton {
+      &.both {
+        background: #f82f9a;
+      }
+      &.normal {
+        background: #3270cd;
+      }
+      &.rank {
+        background: #a06cbf;
+      }
+    }
+    .modeButton {
+      background: #000000;
+    }
+  } @else if ($page == 'MATCH') {
+    // 매치 슬롯에서 쓰이는 모드 버튼 추가할 것
+  } @else if ($page == 'MANUAL') {
+    :checked + .modeButton {
+      background: #380052;
+    }
+    .modeButton {
+      background: #98819b;
+    }
+  }
+}
+
 .modeButtons {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
@@ -14,16 +42,15 @@
     position: absolute;
     opacity: 0;
   }
-  :checked + .modeButton {
-    &.both {
-      background: #f82f9a;
-    }
-    &.normal {
-      background: #3270cd;
-    }
-    &.rank {
-      background: #a06cbf;
-    }
+  // 사용되는 페이지별로 다른 background 적용
+  &.game {
+    @include ButtonBackground('GAME');
+  }
+  &.match {
+    @include ButtonBackground('MATCH');
+  }
+  &.manual {
+    @include ButtonBackground('MANUAL');
   }
   .modeButton {
     display: flex;
@@ -32,7 +59,7 @@
     align-items: center;
     height: 2.063rem;
     margin: 0 0.125rem;
-    background: #0e0518;
+    // background: #0e0518;
     border-radius: 0.625rem 0.625rem 0 0;
     font-size: 0.9rem;
     letter-spacing: 2px;

--- a/styles/mode/ModeRadiobox.module.scss
+++ b/styles/mode/ModeRadiobox.module.scss
@@ -51,6 +51,7 @@
   }
   &.manual {
     @include ButtonBackground('MANUAL');
+    margin: 0 0.48rem;
   }
   .modeButton {
     display: flex;


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - Match 페이지의 게임 매뉴얼 모달 디자인 적용
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
 
**ModeRadioBox 사용 때문에 46번 브랜치에서 분기해서 작업했습니다!!!**

- 게임 매뉴얼 모달 디자인 적용했습니다. 
- 매뉴얼 모달의 라디오 버튼과 Match 페이지의 라디오 버튼의 id가 겹쳐서 label 태그가 동작하지 않는 문제가 있어서 label 태그의 for 속성을 제거했습니다.
- Modal 디자인에서 자주 쓰일 것으로 보이는 CSS들을 mixin으로 분리했습니다.

**❗️ 기존과 겹치는 Mixin들이 있어 완전히 정리하지 못했습니다..!
❗️ "전체" 매치 모드에 대한 매뉴얼 작성 필요합니다!!**

 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  
