### PR TITLE
[GGFE-65] 점수 중복 제출시 에러 해결

### DIFF
--- a/components/modal/afterGame/Guide.tsx
+++ b/components/modal/afterGame/Guide.tsx
@@ -2,7 +2,7 @@ import styles from 'styles/modal/afterGame/AfterGameModal.module.scss';
 
 interface GuideProps {
   condition: boolean;
-  modalMode: 'NORMAL' | 'RANK';
+  modalMode: 'NORMAL' | 'RANK' | 'CONFIRM';
 }
 
 export default function Guide({ condition, modalMode }: GuideProps) {
@@ -17,12 +17,11 @@ export default function Guide({ condition, modalMode }: GuideProps) {
       after: '경기 결과 확인',
       explains: '💡 3판 2선승제!\n💡 동점은 1점 내기로 승부를 결정!',
     },
-    // NOTE : 이전부터 사용이 안되던 부분인 것 같아서 일단 주석으로 남겨두었습니다.
-    // CONFIRM: {
-    //   before: '경기 결과!',
-    //   after: '경기 결과!',
-    //   explains: '이미 입력된 경기입니다. 점수를 확인하세요!\n',
-    // },
+    CONFIRM: {
+      before: '경기 결과!',
+      after: '경기 결과!',
+      explains: '이미 입력된 경기입니다. 점수를 확인하세요!\n',
+    },
   };
 
   return (

--- a/components/modal/afterGame/RankGame.tsx
+++ b/components/modal/afterGame/RankGame.tsx
@@ -24,7 +24,11 @@ export default function RankGame({ currentGame, onSubmit }: RankGameProps) {
 
   return (
     <div className={styles.container}>
-      <Guide condition={onCheck} modalMode='RANK' />
+      {isScoreExist ? (
+        <Guide condition={onCheck} modalMode='CONFIRM' />
+      ) : (
+        <Guide condition={onCheck} modalMode='RANK' />
+      )}
       <div className={styles.resultContainer}>
         <MatchTeams matchTeams={matchTeamsInfo} />
         <Score

--- a/hooks/modal/aftergame/useSubmitModal.ts
+++ b/hooks/modal/aftergame/useSubmitModal.ts
@@ -20,7 +20,7 @@ type normalRequest = {
   enemyTeamId: number;
 };
 
-type responseTypes = Record<'SUCCESS' | 'GM202' | 'GM204', string>;
+type responseTypes = Record<'SUCCESS' | 'DUPLICATED', string>;
 
 type errorResponse = {
   status: number;
@@ -36,8 +36,7 @@ const useSubmitModal = (currentGame: AfterGame) => {
 
   const rankResponse: responseTypes = {
     SUCCESS: '결과 입력이 완료되었습니다.',
-    GM202: '입력한 점수가 저장된 점수와 다릅니다.',
-    GM204: '상대가 이미 점수를 입력했습니다.',
+    DUPLICATED: '상대가 이미 점수를 입력했습니다.',
   };
 
   const submitRankHandler = async (result: TeamScore) => {
@@ -55,7 +54,8 @@ const useSubmitModal = (currentGame: AfterGame) => {
       if (axios.isAxiosError(e) && e.response) {
         const { code } = e.response.data as unknown as errorResponse;
         if (code == 'GM202' || code == 'GM204') {
-          alert(rankResponse[code]);
+          alert(rankResponse['DUPLICATED']);
+          location.reload(); // 현재 유저 event 상태 재확인
         }
       } else {
         setError('JH04');

--- a/hooks/modal/aftergame/useSubmitModal.ts
+++ b/hooks/modal/aftergame/useSubmitModal.ts
@@ -52,8 +52,8 @@ const useSubmitModal = (currentGame: AfterGame) => {
       await instance.post(`/pingpong/games/rank`, requestBody);
       alert(rankResponse['SUCCESS']);
     } catch (e) {
-      if (axios.isAxiosError(e)) {
-        const { code } = e.response as unknown as errorResponse;
+      if (axios.isAxiosError(e) && e.response) {
+        const { code } = e.response.data as unknown as errorResponse;
         if (code == 'GM202' || code == 'GM204') {
           alert(rankResponse[code]);
         }

--- a/hooks/modal/aftergame/useSubmitModal.ts
+++ b/hooks/modal/aftergame/useSubmitModal.ts
@@ -1,10 +1,10 @@
-import { useSetRecoilState } from 'recoil';
 import axios from 'axios';
+import { useSetRecoilState } from 'recoil';
+import { reloadMatchState } from 'utils/recoil/match';
 import { modalState } from 'utils/recoil/modal';
 import { errorState } from 'utils/recoil/error';
 import { AfterGame, TeamScore } from 'types/scoreTypes';
 import { instance } from 'utils/axios';
-import { MatchMode } from 'types/mainType';
 
 type rankRequest = {
   gameId: number;
@@ -31,6 +31,7 @@ type errorResponse = {
 const useSubmitModal = (currentGame: AfterGame) => {
   const setError = useSetRecoilState(errorState);
   const setModal = useSetRecoilState(modalState);
+  const setReloadMatch = useSetRecoilState(reloadMatchState);
   const { gameId, matchTeamsInfo, mode } = currentGame;
   const { myTeam, enemyTeam } = matchTeamsInfo;
 
@@ -55,12 +56,12 @@ const useSubmitModal = (currentGame: AfterGame) => {
         const { code } = e.response.data as unknown as errorResponse;
         if (code == 'GM202' || code == 'GM204') {
           alert(rankResponse['DUPLICATED']);
-          location.reload(); // 현재 유저 event 상태 재확인
+          setReloadMatch(true); // 현재 유저 event 상태 재확인
         }
       } else {
         setError('JH04');
+        return;
       }
-      return;
     }
     openStatChangeModal();
   };

--- a/stories/modal/AfterGameModalNormal.stories.tsx
+++ b/stories/modal/AfterGameModalNormal.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import NormalGame from 'components/modal/afterGame/NormalGame';
+
+const meta: Meta<typeof NormalGame> = {
+  title: 'Modal/AfterGameModalNormal',
+  component: NormalGame,
+  tags: ['autodocs'],
+  argTypes: {
+    currentGame: {
+      gameId: Number,
+      mode: ['NORMAL', 'RANK', 'BOTH'],
+      startTime: String,
+      isScoreExist: Boolean,
+      status: ['WAIT', 'LIVE', 'END'],
+      matchTeamsInfo: {
+        myTeam: {
+          teamScore: Number,
+          teamId: Number,
+          players: [
+            {
+              intraId: String,
+              userImageUri: String,
+              level: Number,
+            },
+          ],
+        },
+        enemyTeam: {
+          teamScore: Number,
+          teamId: Number,
+          players: [
+            {
+              intraId: String,
+              userImageUri: String,
+              level: Number,
+            },
+          ],
+        },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof NormalGame>;
+
+const gameInfo = {
+  gameId: 1,
+  mode: 'NORMAL' as const,
+  startTime: '2022-07-13 11:50',
+  isScoreExist: false,
+  status: 'WAIT' as const,
+  matchTeamsInfo: {
+    myTeam: {
+      teamScore: 1,
+      teamId: 1,
+      players: [
+        {
+          intraId: 'tak',
+          userImageUri:
+            'https://images.unsplash.com/photo-1638643391904-9b551ba91eaa?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1974&q=80',
+          level: 1,
+        },
+      ],
+    },
+    enemyTeam: {
+      teamScore: 1,
+      teamId: 2,
+      players: [
+        {
+          intraId: 'gu',
+          userImageUri:
+            'https://images.unsplash.com/photo-1628260412297-a3377e45006f?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1074&q=80',
+          level: 1,
+        },
+      ],
+    },
+  },
+};
+
+const normalGameInfo = {
+  ...gameInfo,
+  isScoreExist: false,
+};
+
+export const NormalGameDefault: Story = {
+  args: {
+    currentGame: normalGameInfo,
+  },
+};

--- a/stories/modal/AfterGameModalRank.stories.tsx
+++ b/stories/modal/AfterGameModalRank.stories.tsx
@@ -1,0 +1,100 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import RankGame from 'components/modal/afterGame/RankGame';
+
+const meta: Meta<typeof RankGame> = {
+  title: 'Modal/AfterGameModalRank',
+  component: RankGame,
+  tags: ['autodocs'],
+  argTypes: {
+    currentGame: {
+      gameId: Number,
+      mode: ['NORMAL', 'RANK', 'BOTH'],
+      startTime: String,
+      isScoreExist: Boolean,
+      status: ['WAIT', 'LIVE', 'END'],
+      matchTeamsInfo: {
+        myTeam: {
+          teamScore: Number,
+          teamId: Number,
+          players: [
+            {
+              intraId: String,
+              userImageUri: String,
+              level: Number,
+            },
+          ],
+        },
+        enemyTeam: {
+          teamScore: Number,
+          teamId: Number,
+          players: [
+            {
+              intraId: String,
+              userImageUri: String,
+              level: Number,
+            },
+          ],
+        },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RankGame>;
+
+const gameInfo = {
+  gameId: 1,
+  mode: 'RANK' as const,
+  startTime: '2022-07-13 11:50',
+  isScoreExist: false,
+  status: 'WAIT' as const,
+  matchTeamsInfo: {
+    myTeam: {
+      teamScore: 1,
+      teamId: 1,
+      players: [
+        {
+          intraId: 'tak',
+          userImageUri:
+            'https://images.unsplash.com/photo-1638643391904-9b551ba91eaa?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1974&q=80',
+          level: 1,
+        },
+      ],
+    },
+    enemyTeam: {
+      teamScore: 1,
+      teamId: 2,
+      players: [
+        {
+          intraId: 'gu',
+          userImageUri:
+            'https://images.unsplash.com/photo-1628260412297-a3377e45006f?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1074&q=80',
+          level: 1,
+        },
+      ],
+    },
+  },
+};
+
+const rankGameBeforeInfo = {
+  ...gameInfo,
+  isScoreExist: false,
+};
+
+const rankGameAfterInfo = {
+  ...gameInfo,
+  isScoreExist: true,
+};
+
+export const RankGameBefore: Story = {
+  args: {
+    currentGame: rankGameBeforeInfo,
+  },
+};
+
+export const RankGameAfter: Story = {
+  args: {
+    currentGame: rankGameAfterInfo,
+  },
+};


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->

- 랭크 게임의 결과를 중복으로 제출했을 때 에러로 처리되던 부분을 수정했습니다.

 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->

- 기존과 중복된 제출을 처리하는 방식이 달라져서 alert을 띄우는 방식을 수정했습니다.
- 중복된 제출시에 발생하는 에러 코드는 2개인데 (저장된 점수와 입력한 점수가 다름, 이미 저장된 점수가 있음) 동일한 의미라 생각해서 같은 메시지를 띄우게 했습니다.
- 사용하고 있지 않던 `CONFIRM` 가이드를 점수가 존재하는 경우에 보여주게 수정했습니다.
- 저장된 점수가 존재하는 경우에는 한번 더 모달을 띄워서 점수를 확인할 수 있게 했습니다.

❗️ 일반게임의 경우에는 제출한 뒤에 한번 더 모달이 뜨는 문제가 있는데, users/live의 응답이 맞지 않는 문제라 나중에 확인 필요합니다!

 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
