### PR TITLE
[GGFE-76] Style Play Button 레이아웃 헤더 아래 공간차지 문제 해결

### DIFF
--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -53,9 +53,11 @@ export default function AppLayout({ children }: AppLayoutProps) {
                 </HeaderStateContext>
                 {presentPath !== '/match' && presentPath !== '/manual' && (
                   <div className={styles.buttonContainer}>
-                    <StyledButton onClick={onClickMatch} width={'5.5rem'}>
-                      Play
-                    </StyledButton>
+                    <div className={styles.buttonWrapper}>
+                      <StyledButton onClick={onClickMatch} width={'5.5rem'}>
+                        Play
+                      </StyledButton>
+                    </div>
                   </div>
                 )}
                 {children}

--- a/styles/Layout/Layout.module.scss
+++ b/styles/Layout/Layout.module.scss
@@ -29,7 +29,13 @@
   position: sticky;
   top: 83%;
   margin-left: 75%;
-  border-radius: 3rem;
-  width: 5.7rem;
-  box-shadow: 0 0 2rem 0.5rem rgba(245, 0, 165, 1);
+  .buttonWrapper {
+    position: absolute;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: 3rem;
+    width: 5.7rem;
+    box-shadow: 0 0 2rem 0.5rem rgba(245, 0, 165, 1);
+  }
 }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - Play 버튼이 레이아웃 헤더 아래에 공간 차지하던 문제 해결
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
- 기존에 헤더와 layout의 본문 사이에 존재하던 빈 공간(play button이 차지하던 공간) 없앰
  - div로 button 한 번 더 감싸고 기존 css  적용
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
