### PR TITLE
[GGFE-89] 선택한 모드에 따라 배경색 변경하기

### DIFF
--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router';
 import { useRecoilValue } from 'recoil';
+import { colorModeState } from 'utils/recoil/colorMode';
 import { userState } from 'utils/recoil/layout';
 import Statistics from 'pages/statistics';
 import Header from './Header';
@@ -15,7 +16,6 @@ import useLiveCheck from 'hooks/Layout/useLiveCheck';
 import HeaderStateContext from './HeaderContext';
 import StyledButton from 'components/StyledButton';
 
-import useModeToggle from 'hooks/mode/useModeToggle';
 import { useEffect } from 'react';
 type AppLayoutProps = {
   children: React.ReactNode;
@@ -23,9 +23,9 @@ type AppLayoutProps = {
 
 export default function AppLayout({ children }: AppLayoutProps) {
   const user = useRecoilValue(userState);
+  const colorMode = useRecoilValue(colorModeState);
   const presentPath = useRouter().asPath;
   const router = useRouter();
-  const { Mode, setMode } = useModeToggle();
 
   useGetUserSeason();
   useSetAfterGameModal();
@@ -36,9 +36,10 @@ export default function AppLayout({ children }: AppLayoutProps) {
     router.push(`/match`);
   };
 
-  useEffect(() => {
-    setMode('RANK');
-  }, [router]);
+  // NOTE : 어떤 이유로 필요한건지 잘 모르겠어서 일단 주석처리 해 두었습니다!
+  // useEffect(() => {
+  //   setMode('RANK');
+  // }, [router]);
 
   return presentPath.includes('/admin') ? (
     user.isAdmin ? (
@@ -49,7 +50,7 @@ export default function AppLayout({ children }: AppLayoutProps) {
   ) : (
     <div className={styles.appContainer}>
       <div
-        className={`${styles.background} ${Mode === 'NORMAL' && styles.normal}`}
+        className={`${styles.background} ${styles[colorMode.toLowerCase()]}`}
       >
         <div>
           {presentPath === '/statistics' && user.isAdmin ? (

--- a/components/mode/modeWraps/GameModeWrap.tsx
+++ b/components/mode/modeWraps/GameModeWrap.tsx
@@ -1,6 +1,8 @@
 import { useRouter } from 'next/router';
 import React, { useEffect } from 'react';
-import { SeasonMode } from 'types/mainType';
+import { useSetRecoilState } from 'recoil';
+import { SeasonMode, MatchMode } from 'types/mainType';
+import { colorModeState } from 'utils/recoil/colorMode';
 import UserGameSearchBar from 'components/mode/modeItems/UserGameSearchBar';
 import useSeasonDropDown from 'hooks/mode/useSeasonDropDown';
 import SeasonDropDown from 'components/mode/modeItems/SeasonDropDown';
@@ -25,6 +27,7 @@ export default function GameModeWrap({
   const intraId = useRouter().query.intraId;
   const { seasonList, season, seasonDropDownHandler, TitleSeasonHandler } =
     useSeasonDropDown(clickTitle, intraId);
+  const setColorMode = useSetRecoilState(colorModeState);
 
   useEffect(() => {
     setRadioMode('BOTH');
@@ -33,6 +36,7 @@ export default function GameModeWrap({
   }, [clickTitle, intraId]);
 
   const modeChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setColorMode(e.target.value as MatchMode);
     setRadioMode(e.target.value as SeasonMode);
   };
 

--- a/components/mode/modeWraps/MatchModeWrap.tsx
+++ b/components/mode/modeWraps/MatchModeWrap.tsx
@@ -1,8 +1,9 @@
-import React, { SetStateAction, useState } from 'react';
+import React, { SetStateAction, Dispatch } from 'react';
+import { useSetRecoilState } from 'recoil';
 import { MatchMode } from 'types/mainType';
-import { Dispatch } from 'react';
-import ModeRadiobox from '../modeItems/ModeRadiobox';
 import { Match } from 'types/matchTypes';
+import { colorModeState } from 'utils/recoil/colorMode';
+import ModeRadiobox from '../modeItems/ModeRadiobox';
 
 interface MatchModeWrapProps {
   children: React.ReactNode;
@@ -17,7 +18,9 @@ export default function MatchModeWrap({
   match,
   setRadioMode,
 }: MatchModeWrapProps) {
+  const setColorMode = useSetRecoilState(colorModeState);
   const modeChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setColorMode(e.target.value as MatchMode);
     setRadioMode(e.target.value as MatchMode);
   };
 

--- a/hooks/useColorMode.ts
+++ b/hooks/useColorMode.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+import { useSetRecoilState, useResetRecoilState } from 'recoil';
+import { colorModeState } from 'utils/recoil/colorMode';
+
+function useColorMode() {
+  const setColorMode = useSetRecoilState(colorModeState);
+  const resetColorMode = useResetRecoilState(colorModeState);
+
+  useEffect(() => {
+    setColorMode('BOTH');
+    return () => {
+      resetColorMode();
+    };
+  }, []);
+}
+
+export default useColorMode;

--- a/hooks/useColorMode.ts
+++ b/hooks/useColorMode.ts
@@ -2,16 +2,20 @@ import { useEffect } from 'react';
 import { useSetRecoilState, useResetRecoilState } from 'recoil';
 import { colorModeState } from 'utils/recoil/colorMode';
 
-function useColorMode() {
+function useColorMode(page: 'GAME' | 'MATCH' | 'RANK') {
   const setColorMode = useSetRecoilState(colorModeState);
   const resetColorMode = useResetRecoilState(colorModeState);
 
   useEffect(() => {
-    setColorMode('BOTH');
+    if (page === 'RANK') {
+      // TODO : rank page color mode 초기화
+    } else {
+      setColorMode('BOTH');
+    }
     return () => {
       resetColorMode();
     };
-  }, []);
+  }, [page]);
 }
 
 export default useColorMode;

--- a/pages/game.tsx
+++ b/pages/game.tsx
@@ -1,14 +1,17 @@
-import { useState } from 'react';
 import { useRouter } from 'next/router';
+import { useState } from 'react';
 import { SeasonMode } from 'types/mainType';
 import GameResult from 'components/game/GameResult';
 import GameModeWrap from 'components/mode/modeWraps/GameModeWrap';
 import styles from 'styles/game/GameResultItem.module.scss';
+import useColorMode from 'hooks/useColorMode';
 
 export default function Game() {
   const router = useRouter();
   const [clickTitle, setClickTitle] = useState<boolean>(false);
   const [radioMode, setRadioMode] = useState<SeasonMode>('BOTH');
+
+  useColorMode();
 
   const clickTitleHandler = () => {
     router.push(`/game`, undefined, {

--- a/pages/game.tsx
+++ b/pages/game.tsx
@@ -11,7 +11,7 @@ export default function Game() {
   const [clickTitle, setClickTitle] = useState<boolean>(false);
   const [radioMode, setRadioMode] = useState<SeasonMode>('BOTH');
 
-  useColorMode();
+  useColorMode('GAME');
 
   const clickTitleHandler = () => {
     router.push(`/game`, undefined, {

--- a/pages/match.tsx
+++ b/pages/match.tsx
@@ -3,6 +3,7 @@ import { MatchMode } from 'types/mainType';
 import MatchBoard from 'components/match/MatchBoard';
 import MatchModeWrap from 'components/mode/modeWraps/MatchModeWrap';
 import useGetReloadMatchHandler from 'hooks/match/useGetReloadMatchHandler';
+import useColorMode from 'hooks/useColorMode';
 import { Match } from 'types/matchTypes';
 import { stringToHourMin } from 'utils/handleTime';
 import { modalState } from 'utils/recoil/modal';
@@ -27,6 +28,8 @@ export default function MatchPage() {
     setSpinReloadButton,
     radioMode,
   });
+
+  useColorMode('MATCH');
 
   const openManual = () => {
     setModal({ modalName: 'MATCH-MANUAL', manual: { radioMode: radioMode } });

--- a/styles/Layout/Layout.module.scss
+++ b/styles/Layout/Layout.module.scss
@@ -21,6 +21,14 @@
     #481570 58.85%,
     #300e4b 98.44%
   );
+  &.both {
+    background: linear-gradient(
+      180deg,
+      #500247 0%,
+      #480141 21.35%,
+      #40013a 98.44%
+    );
+  }
   &.normal {
     background: linear-gradient(
       180deg,

--- a/styles/main/SearchBar.module.scss
+++ b/styles/main/SearchBar.module.scss
@@ -10,7 +10,7 @@
   margin: 1rem 0.8rem 0;
   padding: 0.8rem 1rem;
   border-radius: $small-radius;
-  background: linear-gradient(90.17deg, #593781 18.13%, #543579 93.7%);
+  background: rgba(255, 255, 255, 0.3);
   font-size: $medium-font;
   color: #1f0b36;
   input {
@@ -40,8 +40,8 @@
     width: 100%;
     padding: 0 0.8rem 0.5rem 0.8rem;
     border-radius: 0 0 $small-radius $small-radius;
-    background: linear-gradient(90.17deg, #593781 18.13%, #543579 93.7%);
-    color: #ffffff;
+    background: #ffffff;
+    color: #1f0b36;
     div {
       padding: 0.5rem 0;
       cursor: pointer;

--- a/utils/recoil/colorMode.ts
+++ b/utils/recoil/colorMode.ts
@@ -1,0 +1,20 @@
+import { MatchMode } from 'types/mainType';
+import { ToggleMode } from 'types/rankTypes';
+import { atom, selector } from 'recoil';
+import { v1 } from 'uuid';
+
+export const colorModeState = atom<MatchMode>({
+  key: `ColorMode/${v1()}`,
+  default: 'RANK',
+});
+
+export const colorToggleSelector = selector<ToggleMode>({
+  key: `ColorToggle/${v1()}`,
+  get: ({ get }) => {
+    const mode = get(colorModeState);
+    return mode === 'NORMAL' ? 'NORMAL' : 'RANK';
+  },
+  set: ({ set }, newMode) => {
+    set(colorModeState, newMode);
+  },
+});

--- a/utils/recoil/toggle.ts
+++ b/utils/recoil/toggle.ts
@@ -2,6 +2,7 @@ import { ToggleMode } from 'types/rankTypes';
 import { atom } from 'recoil';
 import { v1 } from 'uuid';
 
+// TODO : 삭제 예정
 export const toggleState = atom<ToggleMode>({
   key: `Toggle/${v1()}`,
   default: 'RANK',


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - Game페이지와 Match페이지에서 선택한 모드에 따라 배경색이 바뀌도록 했습니다.
 
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->

 - `colorModeState`에서 배경색 상태를 관리합니다! 토글에서 사용할 수 있을 것 같은 selector를 만들어보긴 했는데 잘 동작할지는 모르겠어요..
 - `useColorMode` 훅에서 마운트시에 사용한 페이지에 따라 초기 `colorMode`를 설정해주고 언마운트시에 reset하도록 했습니다. rank페이지 다시 작업할 때 초깃값 설정해주시면 될 것 같아요.
 - 그리고 import 순서가 좀 뒤죽박죽인 부분이 있어서 보이는 것들만 조금 수정했습니다!

 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  - SearchBar 부분이 기존 보라색 배경 기준으로 되어있었어서 season dropdown 배경색과 동일하게 반투명한 배경으로 수정했습니다!
