### PR TITLE
[GGFE-101] GameResultItem 폰트 크기 수정

### DIFF
--- a/styles/PlayerImage.module.scss
+++ b/styles/PlayerImage.module.scss
@@ -27,7 +27,7 @@
 .gameResultBig {
   @include imageWrap;
   div {
-    @include gameResultImage(2.734rem);
+    @include gameResultImage(2.8rem);
     cursor: pointer;
   }
 }
@@ -35,7 +35,7 @@
 .gameResultSmall {
   @include imageWrap;
   div {
-    @include gameResultImage(1.853rem);
+    @include gameResultImage(2rem);
   }
 }
 

--- a/styles/game/GameResultItem.module.scss
+++ b/styles/game/GameResultItem.module.scss
@@ -24,14 +24,14 @@
   grid-template-columns: 2fr 1fr 2fr;
   align-items: center;
   @if ($type == 'SMALL') {
-    min-width: 18.36rem;
-    border-radius: 0.938rem;
-    height: 2.688rem;
-    padding: 0.505rem 0.954rem;
+    min-width: 18.4rem;
+    border-radius: 1rem;
+    height: 2.8rem;
+    padding: 0.5rem 1rem;
   } @else if ($type == 'BIG') {
-    min-width: 20.438rem;
+    min-width: 20.5rem;
     border-radius: 1.5rem;
-    height: 6.091rem;
+    height: 6rem;
     padding: 0.5rem 0;
   }
 }
@@ -79,7 +79,7 @@
 
 @mixin zIndexItem($type) {
   @if ($type == 'SMALL') {
-    margin: 0 0.978rem;
+    margin: 0 1rem;
   } @else if ($type == 'BIG') {
     position: relative;
     z-index: 1;
@@ -111,8 +111,8 @@
       font-family: Roboto;
       font-size: 0.7rem;
       font-weight: 500;
-      line-height: 0.813rem;
-      letter-spacing: 0.04em;
+      // line-height: 0.813rem;
+      // letter-spacing: 0.04em;
       text-align: center;
     }
   }
@@ -122,8 +122,8 @@
     font-family: Roboto;
     font-size: 1rem;
     font-weight: 600;
-    line-height: 1.853rem;
-    letter-spacing: 0.04em;
+    // line-height: 1.853rem;
+    // letter-spacing: 0.04em;
     text-align: center;
   }
 }
@@ -146,13 +146,13 @@
       font-family: Roboto;
       font-size: 1rem;
       font-weight: 500;
-      letter-spacing: 0.04em;
+      // letter-spacing: 0.04em;
       text-align: center;
       color: #ffffff;
       cursor: pointer;
     }
     .winRate {
-      min-width: 3.729rem;
+      min-width: 3.8rem;
       padding: 0.15rem 0.5rem;
       box-sizing: border-box;
       font-family: 'Roboto';
@@ -160,10 +160,10 @@
       font-weight: 350;
       font-size: 0.6rem;
       text-align: center;
-      letter-spacing: 0.04em;
+      // letter-spacing: 0.04em;
       color: #000000;
       background: #ffffff;
-      border-radius: 0.188rem;
+      border-radius: 0.2rem;
       &.zIndexWinRate {
         background: rgba(0, 0, 0, 0.33);
         color: #ffffff;
@@ -174,7 +174,7 @@
   // score
   @mixin gameStatus() {
     min-width: 2rem;
-    border-radius: 0.188rem;
+    border-radius: 0.2rem;
     color: white;
     font-size: 0.6rem;
     text-align: center;
@@ -241,15 +241,15 @@
 
 .getButton {
   display: block;
-  width: 2.125rem;
-  height: 2.125rem;
-  margin: 0.688rem auto 0 auto;
+  width: 2.2rem;
+  height: 2.2rem;
+  margin: 0.8rem auto 0 auto;
   background: none;
   border: none;
   color: #ffffff;
   cursor: pointer;
   svg {
-    height: 1.183rem;
+    height: 1.2rem;
   }
 }
 

--- a/styles/game/GameResultItem.module.scss
+++ b/styles/game/GameResultItem.module.scss
@@ -23,15 +23,16 @@
   display: grid;
   grid-template-columns: 2fr 1fr 2fr;
   align-items: center;
+  box-sizing: border-box;
   @if ($type == 'SMALL') {
     min-width: 18.4rem;
+    min-height: 2.8rem;
     border-radius: 1rem;
-    height: 2.8rem;
     padding: 0.5rem 1rem;
   } @else if ($type == 'BIG') {
     min-width: 20.5rem;
+    min-height: 6rem;
     border-radius: 1.5rem;
-    height: 6rem;
     padding: 0.5rem 0;
   }
 }

--- a/styles/game/GameResultItem.module.scss
+++ b/styles/game/GameResultItem.module.scss
@@ -109,7 +109,7 @@
     span {
       margin: 0 0.5rem;
       font-family: Roboto;
-      font-size: 0.688rem;
+      font-size: 0.7rem;
       font-weight: 500;
       line-height: 0.813rem;
       letter-spacing: 0.04em;
@@ -120,7 +120,7 @@
   .smallScoreBoard {
     color: #ffffff;
     font-family: Roboto;
-    font-size: 0.875rem;
+    font-size: 1rem;
     font-weight: 600;
     line-height: 1.853rem;
     letter-spacing: 0.04em;
@@ -144,7 +144,7 @@
     .userId {
       margin: 0.1rem 0;
       font-family: Roboto;
-      font-size: 0.688rem;
+      font-size: 1rem;
       font-weight: 500;
       letter-spacing: 0.04em;
       text-align: center;
@@ -158,7 +158,7 @@
       font-family: 'Roboto';
       font-style: normal;
       font-weight: 350;
-      font-size: 0.56rem;
+      font-size: 0.6rem;
       text-align: center;
       letter-spacing: 0.04em;
       color: #000000;
@@ -176,7 +176,7 @@
     min-width: 2rem;
     border-radius: 0.188rem;
     color: white;
-    font-size: 0.35rem;
+    font-size: 0.6rem;
     text-align: center;
     padding: 0.2rem 0.3rem;
     margin-bottom: 0.4rem;
@@ -231,7 +231,7 @@
     .gameScore {
       font-family: Roboto;
       color: white;
-      font-size: 1.25rem;
+      font-size: 1.5rem;
       font-weight: 700;
       text-align: center;
       // letter-spacing: 0.3rem;

--- a/styles/game/GameResultItem.module.scss
+++ b/styles/game/GameResultItem.module.scss
@@ -112,8 +112,6 @@
       font-family: Roboto;
       font-size: 0.7rem;
       font-weight: 500;
-      // line-height: 0.813rem;
-      // letter-spacing: 0.04em;
       text-align: center;
     }
   }
@@ -123,8 +121,6 @@
     font-family: Roboto;
     font-size: 1rem;
     font-weight: 600;
-    // line-height: 1.853rem;
-    // letter-spacing: 0.04em;
     text-align: center;
   }
 }
@@ -147,7 +143,6 @@
       font-family: Roboto;
       font-size: 1rem;
       font-weight: 500;
-      // letter-spacing: 0.04em;
       text-align: center;
       color: #ffffff;
       cursor: pointer;
@@ -161,7 +156,6 @@
       font-weight: 350;
       font-size: 0.6rem;
       text-align: center;
-      // letter-spacing: 0.04em;
       color: #000000;
       background: #ffffff;
       border-radius: 0.2rem;
@@ -235,7 +229,6 @@
       font-size: 1.5rem;
       font-weight: 700;
       text-align: center;
-      // letter-spacing: 0.3rem;
     }
   }
 }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->

  - GameResultItem 속 글자들의 크기를 수정했습니다.
 
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->

- 큰 화면(ex: 클러스터 맥)에서 봤을 때 `GameResultItem` 속 글자들이 너무 작게 보여서 전반적으로 크기를 수정했습니다.
- 추가로  figma의 px을 그대로 rem으로 변환하느라 소수점 자릿수가 지저분한 값들을 수정했고
- 불필요해보이는 `line-height` 설정과 `letter-spacing` 설정을 삭제하고
- `GameResultBigItem` 의 `height`로 설정해둔 값이 내부 컴포넌트보다 작아서 정렬이 잘 안되는 문제가 있어 `min-height`로 수정했습니다.


 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
