### PR TITLE
[GGFE-104] main Searchbar-ranking 간격 수정

### DIFF
--- a/components/main/Section.tsx
+++ b/components/main/Section.tsx
@@ -20,7 +20,7 @@ export default function Section({ sectionTitle, path }: SectionProps) {
   };
 
   return (
-    <div className={path === 'rank' ? `${styles['sectionWrap']} ${styles['mainRank']}` : styles['sectionWrap']}>
+    <div className={`${styles['sectionWrap']} ${path === 'rank' ? styles['mainRank'] : styles['sectionWrap']}`}>
       <div className={styles['titleWrap']}>
         <span>{sectionTitle}</span>
         <button onClick={() => router.push(`/${path}`)}>

--- a/components/main/Section.tsx
+++ b/components/main/Section.tsx
@@ -20,7 +20,7 @@ export default function Section({ sectionTitle, path }: SectionProps) {
   };
 
   return (
-    <div className={styles['sectionWrap']}>
+    <div className={path === 'rank' ? `${styles['sectionWrap']} ${styles['mainRank']}` : styles['sectionWrap']}>
       <div className={styles['titleWrap']}>
         <span>{sectionTitle}</span>
         <button onClick={() => router.push(`/${path}`)}>

--- a/styles/Layout/CurrentMatchInfo.module.scss
+++ b/styles/Layout/CurrentMatchInfo.module.scss
@@ -8,6 +8,8 @@ $message-color: rgba(39, 10, 70, 1);
 .currentMatchWrapper {
   width: 100%;
   max-width: 28rem;
+  position: relative;
+  z-index: 2;
 }
 
 .currentMatchBanner {

--- a/styles/Layout/CurrentMatchInfo.module.scss
+++ b/styles/Layout/CurrentMatchInfo.module.scss
@@ -198,6 +198,7 @@ $message-color: rgba(39, 10, 70, 1);
     border: 0;
     padding: 0;
     font-size: 0.7rem;
+    cursor: pointer;
     &.dropup {
       &.two {
         animation: twoDropdown 0.4s ease;

--- a/styles/main/Section.module.scss
+++ b/styles/main/Section.module.scss
@@ -4,6 +4,9 @@
   position: relative;
   z-index: 1;
   margin-top: 2.5rem;
+  &.mainRank {
+    margin-top: 1rem;
+  }
   > .titleWrap {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - main Searchbar-ranking 간격 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - sectionWrap에서 ranking 일 때만 margin-top 크기 줄였습니다
  - currentMatch 3개 잡았을 때 드롭다운이 클릭이 안되는 경우가 있어서 z-index를 searchbar와 동일한 2로 부여해줬습니다.
  - 추가로 currentMatch 드롭다운 버튼에 cursor: pointer 추가했습니다
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
