### PR TITLE
[GGFE-100] 점수 입력 NaN 에러

### DIFF
--- a/components/modal/afterGame/InputScore.tsx
+++ b/components/modal/afterGame/InputScore.tsx
@@ -27,6 +27,8 @@ export default function InputScore({
           name='myTeamScore'
           type='number'
           value={result.myTeamScore}
+          min={0}
+          max={2}
           onChange={onChange}
           onKeyDown={keyPressHandler}
         />
@@ -38,6 +40,8 @@ export default function InputScore({
           name='enemyTeamScore'
           type='number'
           value={result.enemyTeamScore}
+          min={0}
+          max={2}
           onChange={onChange}
           onKeyDown={keyPressHandler}
         />

--- a/hooks/modal/aftergame/useRankGame.ts
+++ b/hooks/modal/aftergame/useRankGame.ts
@@ -17,9 +17,10 @@ const useRankGame = ({ currentGame, onSubmit }: UseRankGameProps) => {
     target: { name, value },
   }: React.ChangeEvent<HTMLInputElement>) => {
     const intValue = parseInt(value);
+    const score: number | '' = isNaN(intValue) ? '' : (intValue > 2 || intValue < 0 ? '' : intValue);
     setResult((prev) => ({
       ...prev,
-      [name]: intValue > 2 || intValue < 0 ? '' : intValue,
+      [name]: score,
     }));
   };
 


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->

점수를 입력했다 지우면 `NaN`이 되는 문제를 수정했습니다

 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->

fix #768 

- input의 값이  `''`가 된 경우에 `intValue`의 값이 `NaN`이 되어서 발생했던 문제라 `intValue`가 `NaN`인 경우에는 `''`로 `value`를 설정하는 조건을 추가했습니다.
- input 옆의 화살표를 눌렀을 때 입력할 수 있는 값의 범위를 추가했습니다.

 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 

