### PR TITLE
[BUG] [GGFE-136] kakao 연동 이후 ranklist 목록 오류 수정

### DIFF
--- a/hooks/game/useGameResult.ts
+++ b/hooks/game/useGameResult.ts
@@ -16,7 +16,7 @@ const useGameResult = ({ mode, season }: GameResultProps) => {
   useEffect(() => {
     const makePath = () => {
       const basePath = '/pingpong/games';
-      if (asPath === '/' || asPath.includes('token')) {
+      if (asPath === '/') {
         // live 상태 포함 최근 3개의 게임만 가져온다.
         setPath(`${basePath}?size=${3}&status=${'LIVE'}`);
         return;


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 카톡 연동 이후 ranklist 목록 오류 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 카카오톡 연동을 하면 로그인을 새로 시켜서 token을 쿼리에 붙여주는데 
  이때를 main으로 간주해서 프로필에서 전체 최근 목록을 불러오는 현상 수정
- dev.42gg.kr에 수정된 코드 올라와있어서 카카오톡 연동 후에 하단 ranklist 목록이 어떻게 다른지 비교해보시면 될 것 같아요
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
