### PR TITLE
[GGFE-139] husky prepare-commit-msg 추가

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,9 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+if [ $(git rev-parse --abbrev-ref HEAD) = 'deploy' ]; then
+    echo 'You cannot commit directly to the deploy branch'
+    exit 1
+fi
+
+npx lint-staged

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# get current branch name
+branch_name=$(git symbolic-ref --short HEAD)
+exclude_branch_list=("main" "dev" "deploy")
+
+# if current branch name is in exclude_branch_list, exit
+for exclude_branch in "${exclude_branch_list[@]}"; do
+    if [[ "$branch_name" == "$exclude_branch" ]]; then
+        exit 0
+    fi
+done
+
+# if branch name is not valid, exit
+contains_issue_key=$(echo $branch_name | grep -c "GGFE-")
+if [[ $contains_issue_key -eq 0 ]]; then
+    echo "브랜치명에 이슈 키를 포함해주세요."
+    exit 1
+fi
+
+# get issue key from branch name
+issue_key=$(echo $branch_name | grep -o "GGFE-[0-9]*")
+
+# if issue key is not valid, exit
+if ! [[ $issue_key =~ ^GGFE-[0-9]+$ ]]; then
+    echo "브랜치명의 이슈 키가 올바른 형식이 아닙니다."
+    exit 1
+fi
+
+# get commit message
+commit_msg_title=$(head -n 1 $1)
+commit_msg_body=$(tail -n +2 $1)
+# get issue key from commit message
+issue_key_from_commit_msg=$(echo $commit_msg_title | grep -o "\[GGFE-[0-9]*\]") # [GGFE-1234]
+
+# if this commit is merge commit, exit 0
+if [[ $commit_msg_title =~ ^Merge ]]; then
+    exit 0
+fi
+
+# if there is issue key in commit message but not equal to issue key from branch name, exit
+if [[ -n $issue_key_from_commit_msg ]] && [[ "$issue_key_from_commit_msg" != "[$issue_key]" ]]; then
+    echo "커밋 메시지의 이슈 키가 브랜치명의 이슈 키와 일치하지 않습니다."
+    exit 1
+fi
+
+# if issue key from commit message is equal to issue key from branch name, exit
+if [[ -n $issue_key_from_commit_msg ]]; then
+    exit 0
+fi
+
+# make commit message [{commit_action}] [{issue_key}] {commit_title_msg}
+commit_title_action=$(echo $commit_msg_title | awk '{ print $1 }') # [Feat]
+commit_title_msg=${commit_msg_title#"$commit_title_action "} # commit message
+
+echo "$commit_title_action [$issue_key] $commit_title_msg" > $1
+if [[ -n $commit_msg_body ]]; then
+    echo "$commit_msg_body" >> $1
+fi
+
+exit 0


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 배포하면서 사라졌던 husky 설정을 복구하고 지라 이슈 키를 커밋메시지에 포함시키는 스크립트를 추가했습니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
prepare-commit-msg 내용
  - main, dev,(저흰 dev 브랜치가 없지만 혹시 몰라 추가해뒀습니다), deploy를 제외한 브랜치명은 GGFE-숫자 로 시작해야 합니다. (지라에서 브랜치 만들면 규칙대로 만들어집니다)
  - [Feat] [issue_key] commit message 형식으로 커밋 메시지를 만들어줍니다.
  - 만약에 커밋 메시지에 이슈 키가 있으면 브랜치명의 이슈 키와 비교해서 동일하면 바로 커밋하고, 아닌 경우에는 에러를 띄웁니다.

 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
