### PR TITLE
[GGFE-143] 상점 페이지 레이아웃

### DIFF
--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -62,15 +62,17 @@ export default function AppLayout({ children }: AppLayoutProps) {
                 <HeaderStateContext>
                   <Header />
                 </HeaderStateContext>
-                {presentPath !== '/match' && presentPath !== '/manual' && (
-                  <div className={styles.buttonContainer}>
-                    <div className={styles.buttonWrapper}>
-                      <StyledButton onClick={onClickMatch} width={'5.5rem'}>
-                        Play
-                      </StyledButton>
+                {presentPath !== '/match' &&
+                  presentPath !== '/manual' &&
+                  presentPath !== '/store' && (
+                    <div className={styles.buttonContainer}>
+                      <div className={styles.buttonWrapper}>
+                        <StyledButton onClick={onClickMatch} width={'5.5rem'}>
+                          Play
+                        </StyledButton>
+                      </div>
                     </div>
-                  </div>
-                )}
+                  )}
                 <div className={styles.topInfo}>
                   {openCurrentMatch && <CurrentMatch />}
                   {presentPath === '/' && <MainPageProfile />}

--- a/components/Layout/MenuBar/MenuBarElement.tsx
+++ b/components/Layout/MenuBar/MenuBarElement.tsx
@@ -29,6 +29,11 @@ interface menuItemProps {
 
 const MenuItem = ({ itemName, onClick }: menuItemProps) => {
   const menuList: { [key: string]: { [key: string]: string | JSX.Element } } = {
+    Store: {
+      name: '상점',
+      // TODO : 이미지 변경할 것
+      svg: <RankingEmoji />,
+    },
     Ranking: {
       name: '랭킹',
       svg: <RankingEmoji />,
@@ -93,6 +98,11 @@ export const MainMenu = () => {
 
   return (
     <nav className={styles.mainMenu}>
+      <MenuLink
+        link='/store'
+        itemName='Store'
+        onClick={HeaderState?.resetOpenMenuBarState}
+      />
       <MenuLink
         link='/rank'
         itemName='Ranking'

--- a/components/mode/modeItems/ModeRadiobox.tsx
+++ b/components/mode/modeItems/ModeRadiobox.tsx
@@ -1,5 +1,6 @@
 import { SeasonMode } from 'types/mainType';
 import styles from 'styles/mode/ModeRadiobox.module.scss';
+import { RadioBoxWrapper } from './RadioBoxWrapper';
 
 interface ModeRadioboxProps {
   mode: SeasonMode;
@@ -21,11 +22,7 @@ export default function ModeRadiobox({
   ];
 
   return (
-    <div
-      className={`${styles.modeButtons} 
-      ${styles[page.toLowerCase()]}
-      ${zIndexList && styles['zIndexListButton']}`}
-    >
+    <RadioBoxWrapper page={page} zIndexList={zIndexList}>
       {modes.map(({ type, name }) => (
         <label key={type}>
           <input
@@ -40,6 +37,6 @@ export default function ModeRadiobox({
           </div>
         </label>
       ))}
-    </div>
+    </RadioBoxWrapper>
   );
 }

--- a/components/mode/modeItems/RadioBoxWrapper.tsx
+++ b/components/mode/modeItems/RadioBoxWrapper.tsx
@@ -11,8 +11,6 @@ export function RadioBoxWrapper({
   page,
   zIndexList,
 }: RadioBoxWrapperProps) {
-  console.log('RadioBoxWrapper: ', page);
-
   return (
     <div
       className={`${styles[page === 'STORE' ? 'twoButtons' : 'threeButtons']}

--- a/components/mode/modeItems/RadioBoxWrapper.tsx
+++ b/components/mode/modeItems/RadioBoxWrapper.tsx
@@ -1,0 +1,25 @@
+import styles from 'styles/mode/ModeRadiobox.module.scss';
+
+type RadioBoxWrapperProps = {
+  children: React.ReactNode;
+  page: 'GAME' | 'MATCH' | 'MANUAL' | 'STORE';
+  zIndexList?: boolean;
+};
+
+export function RadioBoxWrapper({
+  children,
+  page,
+  zIndexList,
+}: RadioBoxWrapperProps) {
+  console.log('RadioBoxWrapper: ', page);
+
+  return (
+    <div
+      className={`${styles[page === 'STORE' ? 'twoButtons' : 'threeButtons']}
+      ${styles[page.toLowerCase()]}
+      ${zIndexList && styles['zIndexListButton']}`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/components/mode/modeItems/StoreModeRadioBox.tsx
+++ b/components/mode/modeItems/StoreModeRadioBox.tsx
@@ -1,0 +1,40 @@
+import { RadioBoxWrapper } from 'components/mode/modeItems/RadioBoxWrapper';
+import { useEffect } from 'react';
+import styles from 'styles/mode/ModeRadiobox.module.scss';
+import { StoreMode } from 'types/storeTypes';
+
+type StoreModeRadioBoxProps = {
+  mode: StoreMode;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+};
+
+export default function StoreModeRadioBox({
+  mode,
+  onChange,
+}: StoreModeRadioBoxProps) {
+  const modes: { type: StoreMode; name: string }[] = [
+    { type: 'BUY', name: '상점' },
+    { type: 'INVENTORY', name: '보관함' },
+  ];
+
+  useEffect(() => {
+    console.log('StoreModeRadioBox: ', mode);
+  }, [mode]);
+
+  return (
+    <RadioBoxWrapper page='STORE'>
+      {modes.map(({ type, name }) => (
+        <label key={type}>
+          <input
+            type='radio'
+            id={type}
+            value={type}
+            onChange={onChange}
+            checked={mode === type}
+          />
+          <div className={`${styles.modeButton}`}>{name}</div>
+        </label>
+      ))}
+    </RadioBoxWrapper>
+  );
+}

--- a/components/mode/modeItems/StoreModeRadioBox.tsx
+++ b/components/mode/modeItems/StoreModeRadioBox.tsx
@@ -17,10 +17,6 @@ export default function StoreModeRadioBox({
     { type: 'INVENTORY', name: '보관함' },
   ];
 
-  useEffect(() => {
-    console.log('StoreModeRadioBox: ', mode);
-  }, [mode]);
-
   return (
     <RadioBoxWrapper page='STORE'>
       {modes.map(({ type, name }) => (

--- a/components/mode/modeWraps/StoreModeWrap.tsx
+++ b/components/mode/modeWraps/StoreModeWrap.tsx
@@ -1,0 +1,23 @@
+import { Dispatch, SetStateAction } from 'react';
+import { StoreMode } from 'types/storeTypes';
+import StoreModeRadioBox from 'components/mode/modeItems/StoreModeRadioBox';
+
+type StoreModeWrapProps = {
+  currentMode: StoreMode;
+  setStoreMode: Dispatch<SetStateAction<StoreMode>>;
+};
+
+export function StoreModeWrap({
+  currentMode,
+  setStoreMode,
+}: StoreModeWrapProps) {
+  console.log('StoreModeWrap: ', currentMode);
+
+  return (
+    // TODO: 매뉴얼 모달 띄우기
+    <StoreModeRadioBox
+      mode={currentMode}
+      onChange={(e) => setStoreMode(e.target.value as StoreMode)}
+    />
+  );
+}

--- a/components/mode/modeWraps/StoreModeWrap.tsx
+++ b/components/mode/modeWraps/StoreModeWrap.tsx
@@ -1,5 +1,7 @@
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { StoreMode } from 'types/storeTypes';
+import { ICoin } from 'types/userTypes';
+import { useMockAxiosGet } from 'hooks/useAxiosGet';
 import StoreModeRadioBox from 'components/mode/modeItems/StoreModeRadioBox';
 
 type StoreModeWrapProps = {
@@ -11,11 +13,24 @@ export function StoreModeWrap({
   currentMode,
   setStoreMode,
 }: StoreModeWrapProps) {
+  const [coin, setCoin] = useState<ICoin>({ coin: 0 });
+  const getCoin = useMockAxiosGet({
+    url: '/users/coin',
+    setState: setCoin,
+    err: 'JY01',
+    type: 'setError',
+  });
+  useEffect(() => {
+    getCoin();
+    // TODO : 코인이 바뀔 때 마다 다시 불러와야 한다.
+  }, []);
   return (
-    // TODO: 매뉴얼 모달 띄우기
-    <StoreModeRadioBox
-      mode={currentMode}
-      onChange={(e) => setStoreMode(e.target.value as StoreMode)}
-    />
+    <div>
+      <div>보유 코인: {coin.coin}</div>
+      <StoreModeRadioBox
+        mode={currentMode}
+        onChange={(e) => setStoreMode(e.target.value as StoreMode)}
+      />
+    </div>
   );
 }

--- a/components/mode/modeWraps/StoreModeWrap.tsx
+++ b/components/mode/modeWraps/StoreModeWrap.tsx
@@ -11,8 +11,6 @@ export function StoreModeWrap({
   currentMode,
   setStoreMode,
 }: StoreModeWrapProps) {
-  console.log('StoreModeWrap: ', currentMode);
-
   return (
     // TODO: 매뉴얼 모달 띄우기
     <StoreModeRadioBox

--- a/components/mode/modeWraps/StoreModeWrap.tsx
+++ b/components/mode/modeWraps/StoreModeWrap.tsx
@@ -1,8 +1,10 @@
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { FaCoins } from 'react-icons/fa';
 import { StoreMode } from 'types/storeTypes';
 import { ICoin } from 'types/userTypes';
 import { useMockAxiosGet } from 'hooks/useAxiosGet';
 import StoreModeRadioBox from 'components/mode/modeItems/StoreModeRadioBox';
+import styles from 'styles/mode/StoreModeWrap.module.scss';
 
 type StoreModeWrapProps = {
   currentMode: StoreMode;
@@ -14,19 +16,25 @@ export function StoreModeWrap({
   setStoreMode,
 }: StoreModeWrapProps) {
   const [coin, setCoin] = useState<ICoin>({ coin: 0 });
+  useEffect(() => {
+    getCoin();
+    // TODO : 코인이 바뀔 때 마다 다시 불러와야 한다.
+  }, []);
   const getCoin = useMockAxiosGet({
     url: '/users/coin',
     setState: setCoin,
     err: 'JY01',
     type: 'setError',
   });
-  useEffect(() => {
-    getCoin();
-    // TODO : 코인이 바뀔 때 마다 다시 불러와야 한다.
-  }, []);
   return (
     <div>
-      <div>보유 코인: {coin.coin}</div>
+      <div className={styles.topMenu}>
+        <button>매뉴얼</button>
+        <div className={styles.coins}>
+          {coin.coin}
+          <FaCoins />
+        </div>
+      </div>
       <StoreModeRadioBox
         mode={currentMode}
         onChange={(e) => setStoreMode(e.target.value as StoreMode)}

--- a/hooks/useAxiosGet.ts
+++ b/hooks/useAxiosGet.ts
@@ -2,6 +2,7 @@ import { Dispatch, SetStateAction } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { errorState } from 'utils/recoil/error';
 import { instance } from 'utils/axios';
+import { mockInstance } from 'utils/mockAxios';
 
 interface useAxiosGetProps<T> {
   url: string;
@@ -29,6 +30,29 @@ const useAxiosGet = <T>({
         console.log(err);
       } else if (type === 'setError') {
         setError(err);
+      }
+    }
+  };
+  return axiosGet;
+};
+
+export const useMockAxiosGet = <T>({
+  url,
+  setState,
+  err,
+  type,
+}: useAxiosGetProps<T>): (() => void) => {
+  const axiosGet = async () => {
+    try {
+      console.log('mockInstance', mockInstance);
+      const res = await mockInstance.get(url);
+      console.log('res', res);
+      setState(res?.data);
+    } catch (e) {
+      if (type === 'alert') {
+        alert(e);
+      } else if (type === 'console') {
+        console.log(err);
       }
     }
   };

--- a/hooks/useAxiosGet.ts
+++ b/hooks/useAxiosGet.ts
@@ -44,9 +44,7 @@ export const useMockAxiosGet = <T>({
 }: useAxiosGetProps<T>): (() => void) => {
   const axiosGet = async () => {
     try {
-      console.log('mockInstance', mockInstance);
       const res = await mockInstance.get(url);
-      console.log('res', res);
       setState(res?.data);
     } catch (e) {
       if (type === 'alert') {

--- a/hooks/useAxiosGet.ts
+++ b/hooks/useAxiosGet.ts
@@ -42,6 +42,7 @@ export const useMockAxiosGet = <T>({
   err,
   type,
 }: useAxiosGetProps<T>): (() => void) => {
+  const setError = useSetRecoilState<string>(errorState);
   const axiosGet = async () => {
     try {
       const res = await mockInstance.get(url);
@@ -51,6 +52,8 @@ export const useMockAxiosGet = <T>({
         alert(e);
       } else if (type === 'console') {
         console.log(err);
+      } else if (type === 'setError') {
+        setError(err);
       }
     }
   };

--- a/pages/api/pingpong/users/coin.ts
+++ b/pages/api/pingpong/users/coin.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { ICoin } from 'types/userTypes';
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ICoin>
+) {
+  const coin = 100;
+
+  const coinData: ICoin = {
+    coin: coin,
+  };
+
+  res.status(200).json(coinData);
+}

--- a/pages/store.tsx
+++ b/pages/store.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import styles from 'styles/store/StoreContainer.module.scss';
+import { StoreMode } from 'types/storeTypes';
+import { StoreModeWrap } from 'components/mode/modeWraps/StoreModeWrap';
+import { useRouter } from 'next/router';
+
+export default function Store() {
+  const [mode, setMode] = useState<StoreMode>('BUY');
+  const router = useRouter();
+
+  const clickTitleHandler = () => {
+    router.push(`/store`, undefined, {
+      shallow: true,
+    });
+  };
+
+  useEffect(() => {
+    console.log(mode);
+  }, [mode]);
+
+  return (
+    <div className={styles.pageWrap}>
+      <h1 className={styles.title} onClick={clickTitleHandler}>
+        GG Store
+      </h1>
+      <StoreModeWrap currentMode={mode} setStoreMode={setMode} />
+    </div>
+  );
+}

--- a/pages/store.tsx
+++ b/pages/store.tsx
@@ -14,10 +14,6 @@ export default function Store() {
     });
   };
 
-  useEffect(() => {
-    console.log(mode);
-  }, [mode]);
-
   return (
     <div className={styles.pageWrap}>
       <h1 className={styles.title} onClick={clickTitleHandler}>

--- a/pages/store.tsx
+++ b/pages/store.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from 'react';
-import styles from 'styles/store/StoreContainer.module.scss';
+import { useState } from 'react';
+import { useRouter } from 'next/router';
 import { StoreMode } from 'types/storeTypes';
 import { StoreModeWrap } from 'components/mode/modeWraps/StoreModeWrap';
-import { useRouter } from 'next/router';
+import styles from 'styles/store/StoreContainer.module.scss';
 
 export default function Store() {
   const [mode, setMode] = useState<StoreMode>('BUY');
@@ -20,6 +20,9 @@ export default function Store() {
         GG Store
       </h1>
       <StoreModeWrap currentMode={mode} setStoreMode={setMode} />
+      <div className={styles.storeContainer}>
+        {mode === 'BUY' ? <div>BUY</div> : <div>INVENTORY</div>}
+      </div>
     </div>
   );
 }

--- a/styles/mode/ModeRadiobox.module.scss
+++ b/styles/mode/ModeRadiobox.module.scss
@@ -23,34 +23,26 @@
     .modeButton {
       background: #98819b;
     }
+  } @else if ($page == 'STORE') {
+    :checked + .modeButton {
+      background: #a06cbf;
+    }
+    .modeButton {
+      background: #000000;
+    }
   }
 }
 
-.modeButtons {
+@mixin Buttons {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
   column-gap: 0.25rem;
   justify-items: stretch;
   align-items: stretch;
   margin: 0 1.25rem;
   color: #ffffff;
-  &.zIndexListButton {
-    margin: 0 1.916rem;
-  }
   input[type='radio'] {
     position: absolute;
     opacity: 0;
-  }
-  // 사용되는 페이지별로 다른 background 적용
-  &.game {
-    @include ButtonBackground('GAME');
-  }
-  &.match {
-    @include ButtonBackground('MATCH');
-  }
-  &.manual {
-    @include ButtonBackground('MANUAL');
-    margin: 0;
   }
   .modeButton {
     display: flex;
@@ -63,5 +55,35 @@
     letter-spacing: 2px;
     text-align: center;
     cursor: pointer;
+  }
+}
+
+.threeButtons {
+  @include Buttons;
+  grid-template-columns: 1fr 1fr 1fr;
+  &.zIndexListButton {
+    margin: 0 1.916rem;
+  }
+  // 사용되는 페이지별로 다른 background 적용
+  &.game {
+    @include ButtonBackground('GAME');
+  }
+  &.match {
+    @include ButtonBackground('MATCH');
+  }
+  &.manual {
+    @include ButtonBackground('MANUAL');
+    margin: 0;
+  }
+}
+
+.twoButtons {
+  @include Buttons;
+  grid-template-columns: 1fr 1fr;
+  &.zIndexListButton {
+    margin: 0 1.916rem;
+  }
+  &.store {
+    @include ButtonBackground('STORE');
   }
 }

--- a/styles/mode/StoreModeWrap.module.scss
+++ b/styles/mode/StoreModeWrap.module.scss
@@ -1,0 +1,15 @@
+.topMenu {
+  display: flex;
+  justify-content: end;
+  margin-bottom: 1rem;
+  * {
+    margin-right: 0.5rem;
+  }
+}
+
+.coins {
+  color: #fbbc66;
+  svg {
+    margin-left: 0.5rem;
+  }
+}

--- a/styles/mode/StoreModeWrap.module.scss
+++ b/styles/mode/StoreModeWrap.module.scss
@@ -1,6 +1,6 @@
 .topMenu {
   display: flex;
-  justify-content: end;
+  justify-content: flex-end;
   margin-bottom: 1rem;
   * {
     margin-right: 0.5rem;

--- a/styles/store/StoreContainer.module.scss
+++ b/styles/store/StoreContainer.module.scss
@@ -1,0 +1,13 @@
+@import 'styles/common.scss';
+
+// ANCHOR : page
+
+.pageWrap {
+  @include pageWrap;
+}
+
+.title {
+  @include pageTitle;
+  width: fit-content;
+  cursor: pointer;
+}

--- a/styles/store/StoreContainer.module.scss
+++ b/styles/store/StoreContainer.module.scss
@@ -11,3 +11,12 @@
   width: fit-content;
   cursor: pointer;
 }
+
+.storeContainer {
+  height: 60vh;
+  padding: 1rem;
+  margin-block: 0 1rem;
+  border-radius: $small-radius;
+  background: rgba(255, 255, 255, 0.2);
+  overflow-y: scroll;
+}

--- a/types/storeTypes.ts
+++ b/types/storeTypes.ts
@@ -1,0 +1,1 @@
+export type StoreMode = 'BUY' | 'INVENTORY';

--- a/types/userTypes.ts
+++ b/types/userTypes.ts
@@ -27,3 +27,7 @@ export const racketTypes = [
   { id: 'SHAKEHAND' },
   { id: 'DUAL' },
 ];
+
+export interface ICoin {
+  coin: number;
+}

--- a/utils/mockAxios.ts
+++ b/utils/mockAxios.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+const baseURL = `${process.env.NEXT_PUBLIC_MOCK_ENDPOINT}`;
+
+const mockInstance = axios.create({ baseURL });
+
+mockInstance.interceptors.request.use(
+  function setConfig(config) {
+    config.headers = {
+      'Content-Type': 'application/json',
+    };
+    return config;
+  },
+  function getError(error) {
+    return Promise.reject(error);
+  }
+);
+
+export { mockInstance };


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 상점 페이지에 필요한 레이아웃을 구현하고, mock api를 사용하기 위한 설정을 추가했습니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 상점 페이지 레이아웃
    - 상점 페이지 이동은 현재 새로고침시에 로그인이 풀리는 문제가 있어서 사이드바 버튼으로 이동해야 로그인 페이지로 리다이렉트되지 않습니다.. (대충 만든거라 이미지는 랭크와 동일해요)
    - `/store` 안에서 state에 따라 상점, 구매 컴포넌트를 보여주는 방식입니다.
    - 디자인은 대부분 다른 페이지에서 사용된 디자인을 가져왔습니다... (대부분 match 페이지) 이후에 구현하실 때 적절하게 수정해주시면 될 듯 합니다.
  - useMockAxiosGet
    - api 폴더에 정의된 api들을 불러오기 위한 훅입니다.
    - useAxiosGet이랑 완전히 동일하게 동작하도록 했어요.
    - get 외에 다른 메소드를 사용할 때에는 mockInstance 를 사용해서 기존 instance와 동일하게 사용하면 됩니다.
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
