### PR TITLE
[GGFE-144] 상점 아이템 보관함 페이지

### DIFF
--- a/components/mode/modeWraps/StoreModeWrap.tsx
+++ b/components/mode/modeWraps/StoreModeWrap.tsx
@@ -7,25 +7,16 @@ import StoreModeRadioBox from 'components/mode/modeItems/StoreModeRadioBox';
 import styles from 'styles/mode/StoreModeWrap.module.scss';
 
 type StoreModeWrapProps = {
+  coin: ICoin;
   currentMode: StoreMode;
   setStoreMode: Dispatch<SetStateAction<StoreMode>>;
 };
 
 export function StoreModeWrap({
+  coin,
   currentMode,
   setStoreMode,
 }: StoreModeWrapProps) {
-  const [coin, setCoin] = useState<ICoin>({ coin: 0 });
-  useEffect(() => {
-    getCoin();
-    // TODO : 코인이 바뀔 때 마다 다시 불러와야 한다.
-  }, []);
-  const getCoin = useMockAxiosGet({
-    url: '/users/coin',
-    setState: setCoin,
-    err: 'JY01',
-    type: 'setError',
-  });
   return (
     <div>
       <div className={styles.topMenu}>

--- a/components/store/InfiniteScrollComponent.tsx
+++ b/components/store/InfiniteScrollComponent.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from 'react';
+import { RiPingPongFill } from 'react-icons/ri';
+import styles from 'styles/store/Inventory.module.scss';
+
+type InfiniteScrollComponentProps = {
+  fetchNextPage: () => void;
+  hasNextPage?: boolean;
+};
+
+export function InfiniteScrollComponent({
+  fetchNextPage,
+  hasNextPage,
+}: InfiniteScrollComponentProps) {
+  const interactionObserverRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!interactionObserverRef.current || !hasNextPage) return;
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting) {
+        fetchNextPage();
+      }
+    });
+    observer.observe(interactionObserverRef.current);
+    return () => observer.disconnect();
+  }, [fetchNextPage, hasNextPage]);
+
+  if (!hasNextPage) return null;
+  return (
+    <div className={styles.loadIcon} ref={interactionObserverRef}>
+      <RiPingPongFill />
+    </div>
+  );
+}

--- a/components/store/Inventory.tsx
+++ b/components/store/Inventory.tsx
@@ -1,0 +1,7 @@
+// import { useState } from 'react';
+import InfScroll from 'utils/infinityScroll';
+// import { InventoryData } from 'types/storeTypes';
+
+export function Inventory() {
+  return <div>Inventory</div>;
+}

--- a/components/store/Inventory.tsx
+++ b/components/store/Inventory.tsx
@@ -1,7 +1,12 @@
-// import { useState } from 'react';
-import InfScroll from 'utils/infinityScroll';
-// import { InventoryData } from 'types/storeTypes';
+import { QueryClientProvider, QueryClient } from 'react-query';
+import { InventoryList } from './InventoryList';
 
 export function Inventory() {
-  return <div>Inventory</div>;
+  const queryClient = new QueryClient();
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <InventoryList />{' '}
+    </QueryClientProvider>
+  );
 }

--- a/components/store/InventoryItem.tsx
+++ b/components/store/InventoryItem.tsx
@@ -12,7 +12,19 @@ type inventoryItemProps = {
 
 export function InvetoryItem({ item }: inventoryItemProps) {
   const user = useRecoilValue(userState);
+
   const { itemId, name, imageUrl, purchaserIntra, itemStatus } = item;
+
+  function handleUseItem(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) {
+    e.preventDefault();
+    console.log(`use item ${itemId}`);
+  }
+
+  function handleEditItem(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) {
+    e.preventDefault;
+    console.log(`edit item ${itemId}`);
+  }
+
   return (
     <div key={itemId} className={styles.inventoryItem}>
       <div className={styles.topBadgeContainer}>
@@ -33,9 +45,9 @@ export function InvetoryItem({ item }: inventoryItemProps) {
       </div>
       <div className={styles.overlay}>
         {itemStatus === 'USING' ? (
-          <button>편집하기</button>
+          <button onClick={handleEditItem}>편집하기</button>
         ) : (
-          <button>사용하기</button>
+          <button onClick={handleUseItem}>사용하기</button>
         )}
       </div>
       <div className={styles.imgContainer}>

--- a/components/store/InventoryItem.tsx
+++ b/components/store/InventoryItem.tsx
@@ -1,0 +1,34 @@
+import Image from 'next/image';
+import { useRecoilValue } from 'recoil';
+import { BsGiftFill, BsCircleFill } from 'react-icons/bs';
+import { InventoryItem } from 'types/storeTypes';
+import { userState } from 'utils/recoil/layout';
+import styles from 'styles/store/Inventory.module.scss';
+
+type inventoryItemProps = {
+  item: InventoryItem;
+};
+
+export function InvetoryItem({ item }: inventoryItemProps) {
+  const user = useRecoilValue(userState);
+  const { itemId, name, imageUrl, purchaserIntra, itemStatus } = item;
+  return (
+    <div key={itemId} className={styles.inventoryItem}>
+      <div className={styles.overlay}>
+        {itemStatus === 'USING' ? (
+          <button>편집하기</button>
+        ) : (
+          <button>사용하기</button>
+        )}
+      </div>
+      {user.intraId !== purchaserIntra && <BsGiftFill />}
+      {itemStatus === 'USING' && (
+        <div>
+          <BsCircleFill /> 사용중
+        </div>
+      )}
+      <Image src={imageUrl} alt={name} width={100} height={100} />
+      <div>{name}</div>
+    </div>
+  );
+}

--- a/components/store/InventoryItem.tsx
+++ b/components/store/InventoryItem.tsx
@@ -16,13 +16,17 @@ export function InvetoryItem({ item }: inventoryItemProps) {
   return (
     <div key={itemId} className={styles.inventoryItem}>
       <div className={styles.topBadgeContainer}>
-        {user.intraId !== purchaserIntra && (
+        {user.intraId !== purchaserIntra ? (
           <Tooltip title={`from ${purchaserIntra}`}>
-            <BsGiftFill />
+            <button>
+              <BsGiftFill />
+            </button>
           </Tooltip>
+        ) : (
+          <div></div>
         )}
         {itemStatus === 'USING' && (
-          <div>
+          <div className={styles.usingBadge}>
             <BsCircleFill /> 사용중
           </div>
         )}
@@ -37,7 +41,7 @@ export function InvetoryItem({ item }: inventoryItemProps) {
       <div className={styles.imgContainer}>
         <Image className={styles.img} src={imageUrl} alt={name} fill />
       </div>
-      <div>{name}</div>
+      <div className={styles.itemName}>{name}</div>
     </div>
   );
 }

--- a/components/store/InventoryItem.tsx
+++ b/components/store/InventoryItem.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import { Tooltip } from '@mui/material';
 import { useRecoilValue } from 'recoil';
 import { BsGiftFill, BsCircleFill } from 'react-icons/bs';
 import { InventoryItem } from 'types/storeTypes';
@@ -14,6 +15,18 @@ export function InvetoryItem({ item }: inventoryItemProps) {
   const { itemId, name, imageUrl, purchaserIntra, itemStatus } = item;
   return (
     <div key={itemId} className={styles.inventoryItem}>
+      <div className={styles.topBadgeContainer}>
+        {user.intraId !== purchaserIntra && (
+          <Tooltip title={`from ${purchaserIntra}`}>
+            <BsGiftFill />
+          </Tooltip>
+        )}
+        {itemStatus === 'USING' && (
+          <div>
+            <BsCircleFill /> 사용중
+          </div>
+        )}
+      </div>
       <div className={styles.overlay}>
         {itemStatus === 'USING' ? (
           <button>편집하기</button>
@@ -21,13 +34,9 @@ export function InvetoryItem({ item }: inventoryItemProps) {
           <button>사용하기</button>
         )}
       </div>
-      {user.intraId !== purchaserIntra && <BsGiftFill />}
-      {itemStatus === 'USING' && (
-        <div>
-          <BsCircleFill /> 사용중
-        </div>
-      )}
-      <Image src={imageUrl} alt={name} width={100} height={100} />
+      <div className={styles.imgContainer}>
+        <Image className={styles.img} src={imageUrl} alt={name} fill />
+      </div>
       <div>{name}</div>
     </div>
   );

--- a/components/store/InventoryList.tsx
+++ b/components/store/InventoryList.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { InfinityScroll } from 'utils/infinityScroll';
 import { mockInstance } from 'utils/mockAxios';
 
@@ -18,5 +19,17 @@ export function InventoryList() {
   if (error) return <div>{error.message}</div>;
   if (!data) return <div>No data</div>;
 
-  return <div>InventoryList</div>;
+  return (
+    <div>
+      {data.pages.map((page, pageIndex) => (
+        <React.Fragment key={pageIndex}>
+          {page.storageItemList.map((item) => (
+            <div key={item.itemId}>
+              <div>{item.name}</div>
+            </div>
+          ))}
+        </React.Fragment>
+      ))}
+    </div>
+  );
 }

--- a/components/store/InventoryList.tsx
+++ b/components/store/InventoryList.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import { RiPingPongFill } from 'react-icons/ri';
 import { InvetoryItem } from './InventoryItem';
 import { InfinityScroll } from 'utils/infinityScroll';
 import { mockInstance } from 'utils/mockAxios';
@@ -17,6 +18,19 @@ export function InventoryList() {
     'JY03'
   );
 
+  const interactionObserverRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!interactionObserverRef.current || !hasNextPage) return;
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting) {
+        fetchNextPage();
+      }
+    });
+    observer.observe(interactionObserverRef.current);
+    return () => observer.disconnect();
+  }, [fetchNextPage, hasNextPage]);
+
   if (isLoading) return <div>Loading...</div>;
   if (error) return <div>{error.message}</div>;
   if (!data) return <div>No data</div>;
@@ -30,6 +44,11 @@ export function InventoryList() {
           ))}
         </React.Fragment>
       ))}
+      {hasNextPage && (
+        <div className={styles.loadIcon} ref={interactionObserverRef}>
+          <RiPingPongFill />
+        </div>
+      )}
     </div>
   );
 }

--- a/components/store/InventoryList.tsx
+++ b/components/store/InventoryList.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import { InvetoryItem } from './InventoryItem';
 import { InfinityScroll } from 'utils/infinityScroll';
 import { mockInstance } from 'utils/mockAxios';
+import styles from 'styles/store/Inventory.module.scss';
 
 function fetchInventoryData(page: number) {
   return mockInstance.get(`items?page=${page}&size=${8}`).then((res) => {
@@ -20,13 +22,11 @@ export function InventoryList() {
   if (!data) return <div>No data</div>;
 
   return (
-    <div>
+    <div className={styles.inventoryList}>
       {data.pages.map((page, pageIndex) => (
         <React.Fragment key={pageIndex}>
           {page.storageItemList.map((item) => (
-            <div key={item.itemId}>
-              <div>{item.name}</div>
-            </div>
+            <InvetoryItem key={item.itemId} item={item} />
           ))}
         </React.Fragment>
       ))}

--- a/components/store/InventoryList.tsx
+++ b/components/store/InventoryList.tsx
@@ -27,9 +27,16 @@ export function InventoryList() {
     <div className={styles.inventoryList}>
       {data.pages.map((page, pageIndex) => (
         <React.Fragment key={pageIndex}>
-          {page.storageItemList.map((item) => (
-            <InvetoryItem key={item.itemId} item={item} />
-          ))}
+          {page.storageItemList.length === 0 ? (
+            <div className={styles.emptyMessage}>
+              보유한 아이템이 없습니다.
+              <br /> 상점 탭에서 아이템을 구입해 보세요!
+            </div>
+          ) : (
+            page.storageItemList.map((item) => (
+              <InvetoryItem key={item.itemId} item={item} />
+            ))
+          )}
         </React.Fragment>
       ))}
       <InfiniteScrollComponent

--- a/components/store/InventoryList.tsx
+++ b/components/store/InventoryList.tsx
@@ -1,0 +1,22 @@
+import { InfinityScroll } from 'utils/infinityScroll';
+import { mockInstance } from 'utils/mockAxios';
+
+function fetchInventoryData(page: number) {
+  return mockInstance.get(`items?page=${page}&size=${8}`).then((res) => {
+    return res.data;
+  });
+}
+
+export function InventoryList() {
+  const { data, error, isLoading, hasNextPage, fetchNextPage } = InfinityScroll(
+    'inventory',
+    fetchInventoryData,
+    'JY03'
+  );
+
+  if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>{error.message}</div>;
+  if (!data) return <div>No data</div>;
+
+  return <div>InventoryList</div>;
+}

--- a/components/store/InventoryList.tsx
+++ b/components/store/InventoryList.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useRef } from 'react';
-import { RiPingPongFill } from 'react-icons/ri';
+import React from 'react';
 import { InvetoryItem } from './InventoryItem';
+import { InfiniteScrollComponent } from './InfiniteScrollComponent';
 import { InfinityScroll } from 'utils/infinityScroll';
 import { mockInstance } from 'utils/mockAxios';
 import styles from 'styles/store/Inventory.module.scss';
@@ -18,19 +18,7 @@ export function InventoryList() {
     'JY03'
   );
 
-  const interactionObserverRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!interactionObserverRef.current || !hasNextPage) return;
-    const observer = new IntersectionObserver((entries) => {
-      if (entries[0].isIntersecting) {
-        fetchNextPage();
-      }
-    });
-    observer.observe(interactionObserverRef.current);
-    return () => observer.disconnect();
-  }, [fetchNextPage, hasNextPage]);
-
+  // TODO : 에러 컴포넌트 구체화 필요함.
   if (isLoading) return <div>Loading...</div>;
   if (error) return <div>{error.message}</div>;
   if (!data) return <div>No data</div>;
@@ -44,11 +32,10 @@ export function InventoryList() {
           ))}
         </React.Fragment>
       ))}
-      {hasNextPage && (
-        <div className={styles.loadIcon} ref={interactionObserverRef}>
-          <RiPingPongFill />
-        </div>
-      )}
+      <InfiniteScrollComponent
+        fetchNextPage={fetchNextPage}
+        hasNextPage={hasNextPage}
+      />
     </div>
   );
 }

--- a/pages/api/pingpong/items/index.ts
+++ b/pages/api/pingpong/items/index.ts
@@ -138,12 +138,15 @@ export default function handler(
 
   const { page, size } = req.query;
 
-  const ret = InventoryData;
+  const ret: InventoryData = {
+    storageItemList: [],
+    totalPage: InventoryData.totalPage,
+  };
   if (page && size) {
     const storageItemList = pagination(
       Number(page as string),
       Number(size as string),
-      InventoryDataDouble.storageItemList
+      InventoryData.storageItemList
     );
     ret.storageItemList = storageItemList;
   }

--- a/pages/api/pingpong/items/index.ts
+++ b/pages/api/pingpong/items/index.ts
@@ -1,129 +1,149 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import {
-  InventoryData,
-  InventoryItem,
-  InventoryItemStatus,
-} from 'types/storeTypes';
+import { InventoryData, InventoryItem } from 'types/storeTypes';
+
+const item1: InventoryItem = {
+  itemId: 1,
+  name: '테스트1',
+  imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
+  purchaserIntra: 'hyobicho',
+  itemStatus: 'BEFORE',
+};
+
+const item2: InventoryItem = {
+  itemId: 2,
+  name: '테스트2',
+  imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
+  purchaserIntra: 'hyungjpa',
+  itemStatus: 'BEFORE',
+};
+
+const item3: InventoryItem = {
+  itemId: 3,
+  name: '테스트3',
+  imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
+  purchaserIntra: 'jeyoon',
+  itemStatus: 'USING',
+};
+
+const item4: InventoryItem = {
+  itemId: 4,
+  name: '테스트4',
+  imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
+  purchaserIntra: 'sangmipa',
+  itemStatus: 'USED',
+};
+
+const item5: InventoryItem = {
+  itemId: 5,
+  name: '테스트5',
+  imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
+  purchaserIntra: 'hyobicho',
+  itemStatus: 'BEFORE',
+};
+
+const item6: InventoryItem = {
+  itemId: 6,
+  name: '테스트6',
+  imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
+  purchaserIntra: 'hyungjpa',
+  itemStatus: 'BEFORE',
+};
+
+const item7: InventoryItem = {
+  itemId: 7,
+  name: '테스트7',
+  imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
+  purchaserIntra: 'jeyoon',
+  itemStatus: 'USING',
+};
+
+const item8: InventoryItem = {
+  itemId: 8,
+  name: '테스트8',
+  imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
+  purchaserIntra: 'sangmipa',
+  itemStatus: 'USED',
+};
+
+const item9: InventoryItem = {
+  itemId: 9,
+  name: '테스트9',
+  imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
+  purchaserIntra: 'hyobicho',
+  itemStatus: 'BEFORE',
+};
+
+const item10: InventoryItem = {
+  itemId: 10,
+  name: '테스트10',
+  imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
+  purchaserIntra: 'hyungjpa',
+  itemStatus: 'BEFORE',
+};
+
+const storageItemList: InventoryItem[] = [
+  item1,
+  item2,
+  item3,
+  item4,
+  item5,
+  item6,
+  item7,
+  item8,
+  item9,
+  item10,
+];
+
+// 빈 인벤토리
+const InventoryDataEmpty: InventoryData = {
+  storageItemList: [],
+  totalPage: 0,
+};
+
+// 페이지 1개
+const InventoryDataSingle: InventoryData = {
+  storageItemList: storageItemList.slice(0, 4),
+  totalPage: 1,
+};
+
+// 페이지 2개
+const InventoryDataDouble: InventoryData = {
+  storageItemList: storageItemList,
+  totalPage: 2,
+};
+
+function pagination(
+  page: number,
+  size: number,
+  storageItemList: InventoryItem[]
+): InventoryItem[] {
+  const ret = [];
+  for (let index = 0; index < storageItemList.length; index += size) {
+    ret.push(storageItemList.slice(index, index + size));
+  }
+  return ret[page - 1];
+}
 
 export default function handler(
   req: NextApiRequest,
   res: NextApiResponse<InventoryData>
 ) {
-  const item1: InventoryItem = {
-    itemId: 1,
-    name: '테스트1',
-    imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
-    purchaserIntra: 'hyobicho',
-    itemStatus: 'BEFORE',
-  };
-
-  const item2: InventoryItem = {
-    itemId: 2,
-    name: '테스트2',
-    imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
-    purchaserIntra: 'hyungjpa',
-    itemStatus: 'BEFORE',
-  };
-
-  const item3: InventoryItem = {
-    itemId: 3,
-    name: '테스트3',
-    imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
-    purchaserIntra: 'jeyoon',
-    itemStatus: 'USING',
-  };
-
-  const item4: InventoryItem = {
-    itemId: 4,
-    name: '테스트4',
-    imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
-    purchaserIntra: 'sangmipa',
-    itemStatus: 'USED',
-  };
-
-  const item5: InventoryItem = {
-    itemId: 5,
-    name: '테스트5',
-    imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
-    purchaserIntra: 'hyobicho',
-    itemStatus: 'BEFORE',
-  };
-
-  const item6: InventoryItem = {
-    itemId: 6,
-    name: '테스트6',
-    imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
-    purchaserIntra: 'hyungjpa',
-    itemStatus: 'BEFORE',
-  };
-
-  const item7: InventoryItem = {
-    itemId: 7,
-    name: '테스트7',
-    imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
-    purchaserIntra: 'jeyoon',
-    itemStatus: 'USING',
-  };
-
-  const item8: InventoryItem = {
-    itemId: 8,
-    name: '테스트8',
-    imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
-    purchaserIntra: 'sangmipa',
-    itemStatus: 'USED',
-  };
-
-  const item9: InventoryItem = {
-    itemId: 9,
-    name: '테스트9',
-    imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
-    purchaserIntra: 'hyobicho',
-    itemStatus: 'BEFORE',
-  };
-
-  const item10: InventoryItem = {
-    itemId: 10,
-    name: '테스트10',
-    imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
-    purchaserIntra: 'hyungjpa',
-    itemStatus: 'BEFORE',
-  };
-
-  const storageItemList: InventoryItem[] = [
-    item1,
-    item2,
-    item3,
-    item4,
-    item5,
-    item6,
-    item7,
-    item8,
-    item9,
-    item10,
-  ];
-
-  // 빈 인벤토리
-  const InventoryDataEmpty: InventoryData = {
-    storageItemList: [],
-    totalPage: 0,
-  };
-
-  // 페이지 1개
-  const InventoryDataSingle: InventoryData = {
-    storageItemList: storageItemList.slice(0, 4),
-    totalPage: 1,
-  };
-
-  // 페이지 2개
-  const InventoryDataDouble: InventoryData = {
-    storageItemList: storageItemList,
-    totalPage: 2,
-  };
-
   // NOTE: 테스트 케이스에 맞춰서 다른 데이터를 보내주면 됩니다.
   // const InventoryData: InventoryData = InventoryDataEmpty;
   // const InventoryData: InventoryData = InventoryDataSingle;
   const InventoryData: InventoryData = InventoryDataDouble;
 
-  res.status(200).json(InventoryData);
+  const { page, size } = req.query;
+
+  const ret = InventoryData;
+  if (page && size) {
+    const storageItemList = pagination(
+      Number(page as string),
+      Number(size as string),
+      InventoryDataDouble.storageItemList
+    );
+    ret.storageItemList = storageItemList;
+  }
+
+  res.status(200).json(ret);
 }

--- a/pages/api/pingpong/items/index.ts
+++ b/pages/api/pingpong/items/index.ts
@@ -1,0 +1,129 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import {
+  InventoryData,
+  InventoryItem,
+  InventoryItemStatus,
+} from 'types/storeTypes';
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<InventoryData>
+) {
+  const item1: InventoryItem = {
+    itemId: 1,
+    name: '테스트1',
+    imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
+    purchaserIntra: 'hyobicho',
+    itemStatus: 'BEFORE',
+  };
+
+  const item2: InventoryItem = {
+    itemId: 2,
+    name: '테스트2',
+    imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
+    purchaserIntra: 'hyungjpa',
+    itemStatus: 'BEFORE',
+  };
+
+  const item3: InventoryItem = {
+    itemId: 3,
+    name: '테스트3',
+    imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
+    purchaserIntra: 'jeyoon',
+    itemStatus: 'USING',
+  };
+
+  const item4: InventoryItem = {
+    itemId: 4,
+    name: '테스트4',
+    imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
+    purchaserIntra: 'sangmipa',
+    itemStatus: 'USED',
+  };
+
+  const item5: InventoryItem = {
+    itemId: 5,
+    name: '테스트5',
+    imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
+    purchaserIntra: 'hyobicho',
+    itemStatus: 'BEFORE',
+  };
+
+  const item6: InventoryItem = {
+    itemId: 6,
+    name: '테스트6',
+    imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
+    purchaserIntra: 'hyungjpa',
+    itemStatus: 'BEFORE',
+  };
+
+  const item7: InventoryItem = {
+    itemId: 7,
+    name: '테스트7',
+    imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
+    purchaserIntra: 'jeyoon',
+    itemStatus: 'USING',
+  };
+
+  const item8: InventoryItem = {
+    itemId: 8,
+    name: '테스트8',
+    imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
+    purchaserIntra: 'sangmipa',
+    itemStatus: 'USED',
+  };
+
+  const item9: InventoryItem = {
+    itemId: 9,
+    name: '테스트9',
+    imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
+    purchaserIntra: 'hyobicho',
+    itemStatus: 'BEFORE',
+  };
+
+  const item10: InventoryItem = {
+    itemId: 10,
+    name: '테스트10',
+    imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
+    purchaserIntra: 'hyungjpa',
+    itemStatus: 'BEFORE',
+  };
+
+  const storageItemList: InventoryItem[] = [
+    item1,
+    item2,
+    item3,
+    item4,
+    item5,
+    item6,
+    item7,
+    item8,
+    item9,
+    item10,
+  ];
+
+  // 빈 인벤토리
+  const InventoryDataEmpty: InventoryData = {
+    storageItemList: [],
+    totalPage: 0,
+  };
+
+  // 페이지 1개
+  const InventoryDataSingle: InventoryData = {
+    storageItemList: storageItemList.slice(0, 4),
+    totalPage: 1,
+  };
+
+  // 페이지 2개
+  const InventoryDataDouble: InventoryData = {
+    storageItemList: storageItemList,
+    totalPage: 2,
+  };
+
+  // NOTE: 테스트 케이스에 맞춰서 다른 데이터를 보내주면 됩니다.
+  // const InventoryData: InventoryData = InventoryDataEmpty;
+  // const InventoryData: InventoryData = InventoryDataSingle;
+  const InventoryData: InventoryData = InventoryDataDouble;
+
+  res.status(200).json(InventoryData);
+}

--- a/pages/api/pingpong/items/index.ts
+++ b/pages/api/pingpong/items/index.ts
@@ -6,7 +6,7 @@ const item1: InventoryItem = {
   name: '테스트1',
   imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
   purchaserIntra: 'hyobicho',
-  itemStatus: 'BEFORE',
+  itemStatus: 'USING',
 };
 
 const item2: InventoryItem = {

--- a/pages/api/pingpong/items/index.ts
+++ b/pages/api/pingpong/items/index.ts
@@ -148,7 +148,9 @@ export default function handler(
       Number(size as string),
       InventoryData.storageItemList
     );
-    ret.storageItemList = storageItemList;
+    if (InventoryData.totalPage !== 0) {
+      ret.storageItemList = storageItemList;
+    }
   }
 
   res.status(200).json(ret);

--- a/pages/api/pingpong/items/index.ts
+++ b/pages/api/pingpong/items/index.ts
@@ -20,7 +20,8 @@ const item2: InventoryItem = {
 const item3: InventoryItem = {
   itemId: 3,
   name: '테스트3',
-  imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
+  imageUrl:
+    'https://dodo.ac/np/images/thumb/1/17/NH_Balloon.jpg/600px-NH_Balloon.jpg',
   purchaserIntra: 'jeyoon',
   itemStatus: 'USING',
 };
@@ -44,7 +45,8 @@ const item5: InventoryItem = {
 const item6: InventoryItem = {
   itemId: 6,
   name: '테스트6',
-  imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
+  imageUrl:
+    'https://dodo.ac/np/images/thumb/1/17/NH_Balloon.jpg/600px-NH_Balloon.jpg',
   purchaserIntra: 'hyungjpa',
   itemStatus: 'BEFORE',
 };
@@ -68,7 +70,8 @@ const item8: InventoryItem = {
 const item9: InventoryItem = {
   itemId: 9,
   name: '테스트9',
-  imageUrl: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
+  imageUrl:
+    'https://dodo.ac/np/images/thumb/1/17/NH_Balloon.jpg/600px-NH_Balloon.jpg',
   purchaserIntra: 'hyobicho',
   itemStatus: 'BEFORE',
 };

--- a/pages/store.tsx
+++ b/pages/store.tsx
@@ -1,17 +1,30 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { ICoin } from 'types/userTypes';
 import { StoreMode } from 'types/storeTypes';
+import { useMockAxiosGet } from 'hooks/useAxiosGet';
 import { StoreModeWrap } from 'components/mode/modeWraps/StoreModeWrap';
+import ItemsList from 'components/shop/ItemsList';
 import { Inventory } from 'components/store/Inventory';
 import styles from 'styles/store/StoreContainer.module.scss';
-import ItemsList from 'components/shop/ItemsList';
 
 export default function Store() {
   const [mode, setMode] = useState<StoreMode>('BUY');
+  const [coin, setCoin] = useState<ICoin>({ coin: 0 });
+  useEffect(() => {
+    getCoin();
+    // TODO : 코인이 바뀔 때 마다 다시 불러와야 한다.
+  }, []);
+  const getCoin = useMockAxiosGet({
+    url: '/users/coin',
+    setState: setCoin,
+    err: 'JY01',
+    type: 'setError',
+  });
 
   return (
     <div className={styles.pageWrap}>
       <h1 className={styles.title}>GG Store</h1>
-      <StoreModeWrap currentMode={mode} setStoreMode={setMode} />
+      <StoreModeWrap currentMode={mode} setStoreMode={setMode} coin={coin} />
       <div className={styles.storeContainer}>
         {mode === 'BUY' ? <ItemsList /> : <Inventory />}
       </div>

--- a/pages/store.tsx
+++ b/pages/store.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useRouter } from 'next/router';
 import { StoreMode } from 'types/storeTypes';
 import { StoreModeWrap } from 'components/mode/modeWraps/StoreModeWrap';
 import { Inventory } from 'components/store/Inventory';
@@ -8,19 +7,10 @@ import ItemsList from 'components/shop/ItemsList';
 
 export default function Store() {
   const [mode, setMode] = useState<StoreMode>('BUY');
-  const router = useRouter();
-
-  const clickTitleHandler = () => {
-    router.push(`/store`, undefined, {
-      shallow: true,
-    });
-  };
 
   return (
     <div className={styles.pageWrap}>
-      <h1 className={styles.title} onClick={clickTitleHandler}>
-        GG Store
-      </h1>
+      <h1 className={styles.title}>GG Store</h1>
       <StoreModeWrap currentMode={mode} setStoreMode={setMode} />
       <div className={styles.storeContainer}>
         {mode === 'BUY' ? (

--- a/pages/store.tsx
+++ b/pages/store.tsx
@@ -13,13 +13,7 @@ export default function Store() {
       <h1 className={styles.title}>GG Store</h1>
       <StoreModeWrap currentMode={mode} setStoreMode={setMode} />
       <div className={styles.storeContainer}>
-        {mode === 'BUY' ? (
-          <div>
-            <ItemsList />
-          </div>
-        ) : (
-          <Inventory />
-        )}
+        {mode === 'BUY' ? <ItemsList /> : <Inventory />}
       </div>
     </div>
   );

--- a/pages/store.tsx
+++ b/pages/store.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/router';
 import { StoreMode } from 'types/storeTypes';
 import { StoreModeWrap } from 'components/mode/modeWraps/StoreModeWrap';
+import { Inventory } from 'components/store/Inventory';
 import styles from 'styles/store/StoreContainer.module.scss';
 
 export default function Store() {
@@ -21,7 +22,7 @@ export default function Store() {
       </h1>
       <StoreModeWrap currentMode={mode} setStoreMode={setMode} />
       <div className={styles.storeContainer}>
-        {mode === 'BUY' ? <div>BUY</div> : <div>INVENTORY</div>}
+        {mode === 'BUY' ? <div>BUY</div> : <Inventory />}
       </div>
     </div>
   );

--- a/styles/store/Inventory.module.scss
+++ b/styles/store/Inventory.module.scss
@@ -15,6 +15,13 @@
   border-radius: 0.5rem;
   padding: 1rem;
   color: #7a6e7b;
+  button {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 1rem;
+    color: #7a6e7b;
+  }
 }
 
 .overlay {
@@ -40,7 +47,6 @@
     opacity: 1;
   }
   button {
-    background: none;
     border: 2px solid #fff;
     color: #fff;
     font-size: 1rem;
@@ -58,6 +64,12 @@
   z-index: 2;
 }
 
+.usingBadge {
+  svg {
+    fill: #08f458;
+  }
+}
+
 .imgContainer {
   position: relative;
   width: 100%;
@@ -66,5 +78,12 @@
 }
 
 .img {
-  object-fit: contain;
+  object-fit: cover;
+  // object-fit: contain;
+}
+
+.itemName {
+  font-size: 1.3rem;
+  font-weight: bold;
+  margin-top: 0.5rem;
 }

--- a/styles/store/Inventory.module.scss
+++ b/styles/store/Inventory.module.scss
@@ -101,8 +101,7 @@
 }
 
 .img {
-  object-fit: cover;
-  // object-fit: contain;
+  object-fit: contain;
 }
 
 .itemName {

--- a/styles/store/Inventory.module.scss
+++ b/styles/store/Inventory.module.scss
@@ -16,6 +16,16 @@
   color: #d4b8f2;
 }
 
+.emptyMessage {
+  width: 100%;
+  grid-column: 1 / 3;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 1.3rem;
+  color: #d4b8f2;
+}
+
 .inventoryItem {
   position: relative;
   display: flex;

--- a/styles/store/Inventory.module.scss
+++ b/styles/store/Inventory.module.scss
@@ -65,8 +65,11 @@
 }
 
 .usingBadge {
+  display: flex;
+  align-items: center;
   svg {
     fill: #08f458;
+    margin-right: 0.3rem;
   }
 }
 

--- a/styles/store/Inventory.module.scss
+++ b/styles/store/Inventory.module.scss
@@ -1,0 +1,50 @@
+@import 'styles/common.scss';
+
+.inventoryList {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: 1rem;
+}
+
+.inventoryItem {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: #d4b8f2;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  color: #7a6e7b;
+}
+
+.overlay {
+  background: linear-gradient(
+    180deg,
+    rgba(#fe9cca, 0.7) 0%,
+    rgba(#fe6bb1, 0.7) 100%
+  );
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 0.5rem;
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  opacity: 0;
+  &:hover {
+    opacity: 1;
+  }
+  button {
+    background: none;
+    border: 2px solid #fff;
+    color: #fff;
+    font-size: 1rem;
+    padding: 1rem 1.5rem;
+    border-radius: 1.5rem;
+    cursor: pointer;
+  }
+}

--- a/styles/store/Inventory.module.scss
+++ b/styles/store/Inventory.module.scss
@@ -6,6 +6,16 @@
   grid-gap: 1rem;
 }
 
+.loadIcon {
+  width: 100%;
+  grid-column: 1 / 3;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 1.5rem;
+  color: #d4b8f2;
+}
+
 .inventoryItem {
   position: relative;
   display: flex;

--- a/styles/store/Inventory.module.scss
+++ b/styles/store/Inventory.module.scss
@@ -35,6 +35,7 @@
   bottom: 0;
   right: 0;
   opacity: 0;
+  z-index: 1;
   &:hover {
     opacity: 1;
   }
@@ -47,4 +48,23 @@
     border-radius: 1.5rem;
     cursor: pointer;
   }
+}
+
+.topBadgeContainer {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  margin-bottom: 0.5rem;
+  z-index: 2;
+}
+
+.imgContainer {
+  position: relative;
+  width: 100%;
+  height: 100px;
+  overflow: hidden;
+}
+
+.img {
+  object-fit: contain;
 }

--- a/types/storeTypes.ts
+++ b/types/storeTypes.ts
@@ -1,1 +1,16 @@
 export type StoreMode = 'BUY' | 'INVENTORY';
+
+export type InventoryItemStatus = 'BEFORE' | 'USING' | 'USED';
+
+export type InventoryItem = {
+  itemId: number;
+  name: string;
+  imageUrl: string;
+  purchaserIntra: string;
+  itemStatus: InventoryItemStatus;
+};
+
+export type InventoryData = {
+  storageItemList: InventoryItem[];
+  totalPage: number;
+};

--- a/utils/infinityScroll.ts
+++ b/utils/infinityScroll.ts
@@ -1,9 +1,12 @@
 import { useSetRecoilState } from 'recoil';
 import { useInfiniteQuery } from 'react-query';
+import axios from 'axios';
 import { errorState } from 'utils/recoil/error';
 import { instance } from './axios';
 import { GameListData } from 'types/gameTypes';
+import { InventoryData } from 'types/storeTypes';
 
+// GameListDat를 받아오는 InfiniteQuery
 export default function InfScroll(path: string) {
   const setError = useSetRecoilState(errorState);
 
@@ -23,4 +26,30 @@ export default function InfScroll(path: string) {
     retry: 0,
     keepPreviousData: true,
   });
+}
+
+// InventoryData를 받아오는 InfiniteQuery
+export function InfinityScroll(
+  queryKey: string,
+  fetchFunction: (page: number) => Promise<InventoryData>,
+  errorCode: string
+) {
+  const setError = useSetRecoilState(errorState);
+  return useInfiniteQuery<InventoryData, Error>(
+    [queryKey],
+    ({ pageParam = 1 }) => fetchFunction(pageParam),
+    {
+      getNextPageParam: (lastPage, allPages) => {
+        const nextPage = allPages.length + 1;
+        return nextPage > lastPage.totalPage ? null : nextPage;
+      },
+      onError: (e: unknown) => {
+        if (axios.isAxiosError(e)) {
+          setError(errorCode);
+        } else setError('JY02'); // axios에서 발생한 에러가 아닌 경우
+      },
+      retry: 0,
+      keepPreviousData: true,
+    }
+  );
 }

--- a/utils/infinityScroll.ts
+++ b/utils/infinityScroll.ts
@@ -36,7 +36,7 @@ export function InfinityScroll(
 ) {
   const setError = useSetRecoilState(errorState);
   return useInfiniteQuery<InventoryData, Error>(
-    [queryKey],
+    queryKey,
     ({ pageParam = 1 }) => fetchFunction(pageParam),
     {
       getNextPageParam: (lastPage, allPages) => {


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 상점 보관함 아이템 페이지의 기본적인 기능과 디자인을 추가했습니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->

- 상점 보관함 데이터 api를 이용해서 유저가 가지고 있는 아이템 목록을 보여주게 했습니다.
  아래 주석 수정해서 빈 경우, 페이지가 1개인 경우, 페이지가 2개인 경우 테스트 해 볼수 있어요,
  ```typescript
  // NOTE: 테스트 케이스에 맞춰서 다른 데이터를 보내주면 됩니다.
  // const InventoryData: InventoryData = InventoryDataEmpty;
  // const InventoryData: InventoryData = InventoryDataSingle;
  const InventoryData: InventoryData = InventoryDataDouble;
  ```
- 무한 스크롤 기능을 추가해서 가장 아래로 스크롤이 내려가면 새로 api를 불러오게 했습니다.
- **❗️ 상점 아이템 디자인 피드백 부탁드립니다!!! ❗️** (피그마에 정의해놨던 디자인으로는 아이템 설명이 없을 때 허전해져서 구조를 바꾸었어요)
  - 선물받은 아이템은 상단에 선물상자 아이콘이 뜨고, hover하면 선물한 사람의 intra id가 뜹니다.
  - 사용중인 아이템은 상단에 사용중 표시가 뜹니다.
  - 아이템 컴포넌트에 hover했을 때 사용전인 아이템에는 사용하기, 사용중인 아이템에는 편집하기 버튼이 뜹니다. (버튼 기능은 아직 구현 전)
  - **❗️ 아이템 이미지 css 속성을 `object-fit: cover;` 로 할지 `object-fit: contain;` 로 할지 고민중인데 의견 부탁드립니다❗️**

 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
