### PR TITLE
[GGFE-147] 관리자 거래내역 - 확성기 삭제 기능 추가

### DIFF
--- a/components/admin/receipt/MegaphoneList.tsx
+++ b/components/admin/receipt/MegaphoneList.tsx
@@ -21,7 +21,7 @@ import {
 } from '@mui/material';
 import styles from 'styles/admin/receipt/MegaphoneList.module.scss';
 import { mockInstance } from 'utils/mockAxios';
-import { errorState } from 'utils/recoil/error';
+import { toastState } from 'utils/recoil/toast';
 
 const megaPhoneTableTitle: { [key: string]: string } = {
   megaphoneId: 'ID',
@@ -49,7 +49,7 @@ function MegaphoneList() {
   });
   const [currentPage, setCurrentPage] = useState<number>(1);
   const setModal = useSetRecoilState(modalState);
-  const setError = useSetRecoilState(errorState);
+  const setSnackBar = useSetRecoilState(toastState);
 
   // todo: 특정 유저 확성기 사용내역만 가져오는 api 추가되면 handler 추가 + 유저 검색 컴포넌트 추가
 
@@ -73,7 +73,12 @@ function MegaphoneList() {
         currentPage: currentPage,
       });
     } catch (e: unknown) {
-      setError('HJ03');
+      setSnackBar({
+        toastName: 'get megaphone',
+        severity: 'error',
+        message: `API 요청에 문제가 발생했습니다.`,
+        clicked: true,
+      });
     }
   }, [currentPage]);
 

--- a/components/admin/receipt/MegaphoneList.tsx
+++ b/components/admin/receipt/MegaphoneList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useSetRecoilState } from 'recoil';
 import {
   Imegaphone,
@@ -20,6 +20,8 @@ import {
   TableRow,
 } from '@mui/material';
 import styles from 'styles/admin/receipt/MegaphoneList.module.scss';
+import { mockInstance } from 'utils/mockAxios';
+import { errorState } from 'utils/recoil/error';
 
 const megaPhoneTableTitle: { [key: string]: string } = {
   megaphoneId: 'ID',
@@ -46,15 +48,19 @@ function MegaphoneList() {
     currentPage: 0,
   });
   const [currentPage, setCurrentPage] = useState<number>(1);
+  const setModal = useSetRecoilState(modalState);
+  const setError = useSetRecoilState(errorState);
 
-  // 특정 유저 확성기 사용내역만 가져오는 api 추가되면 handler 추가 + 유저 검색 컴포넌트 추가
+  // todo: 특정 유저 확성기 사용내역만 가져오는 api 추가되면 handler 추가 + 유저 검색 컴포넌트 추가
 
-  // api 연결 시 useCallback, instanceInManage, try catch로 변경
-  const getMegaphoneHandler = useMockAxiosGet<any>({
-    url: `/admin/megaphones/history?page=${currentPage}&size=10`,
-    setState: (data) => {
+  // todo: api 연결 시 instanceInManage로 변경
+  const getMegaphoneHandler = useCallback(async () => {
+    try {
+      const res = await mockInstance.get(
+        `/admin/megaphones/history?page=${currentPage}&size=10`
+      );
       setMegaphoneData({
-        megaphoneList: data.megaphoneList.map((megaphone: Imegaphone) => {
+        megaphoneList: res.data.megaphoneList.map((megaphone: Imegaphone) => {
           const { year, month, date, hour, min } = getFormattedDateToString(
             new Date(megaphone.usedAt)
           );
@@ -63,15 +69,34 @@ function MegaphoneList() {
             usedAt: `${year}-${month}-${date} ${hour}:${min}`,
           };
         }),
-        totalPage: data.totalPage,
+        totalPage: res.data.totalPage,
         currentPage: currentPage,
       });
-    },
-    err: 'HJ03',
-    type: 'setError',
-  });
+    } catch (e: unknown) {
+      setError('HJ03');
+    }
+  }, [currentPage]);
 
-  const setModal = useSetRecoilState(modalState);
+  // useMockAxiosGet<any>({
+  //   url: `/admin/megaphones/history?page=${currentPage}&size=10`,
+  //   setState: (data) => {
+  //     setMegaphoneData({
+  //       megaphoneList: data.megaphoneList.map((megaphone: Imegaphone) => {
+  //         const { year, month, date, hour, min } = getFormattedDateToString(
+  //           new Date(megaphone.usedAt)
+  //         );
+  //         return {
+  //           ...megaphone,
+  //           usedAt: `${year}-${month}-${date} ${hour}:${min}`,
+  //         };
+  //       }),
+  //       totalPage: data.totalPage,
+  //       currentPage: currentPage,
+  //     });
+  //   },
+  //   err: 'HJ03',
+  //   type: 'setError',
+  // });
 
   const deleteMegaphone = (megaphoneInfo: ImegaphoneInfo) => {
     setModal({
@@ -86,30 +111,36 @@ function MegaphoneList() {
 
   return (
     <>
-      <TableContainer component={Paper}>
-        <Table aria-label='customized table'>
-          <TableHead>
+      <TableContainer className={styles.tableContainer} component={Paper}>
+        <Table className={styles.table} aria-label='customized table'>
+          <TableHead className={styles.tableHeader}>
             <TableRow>
               {tableColumnName.map((column, idx) => (
-                <TableCell key={idx}>{megaPhoneTableTitle[column]}</TableCell>
+                <TableCell className={styles.tableHeaderItem} key={idx}>
+                  {megaPhoneTableTitle[column]}
+                </TableCell>
               ))}
             </TableRow>
           </TableHead>
-          <TableBody>
+          <TableBody className={styles.tableBody}>
             {megaphoneData.megaphoneList.length > 0 ? (
               megaphoneData.megaphoneList.map((megaphone: Imegaphone) => (
-                <TableRow key={megaphone.megaphoneId}>
+                <TableRow
+                  className={styles.tableRow}
+                  key={megaphone.megaphoneId}
+                >
                   {tableFormat['megaphoneList'].columns.map(
                     (columnName: string, index: number) => {
                       return (
-                        <TableCell key={index}>
+                        <TableCell className={styles.tableBodyItem} key={index}>
                           {megaphone[columnName as keyof Imegaphone].toString()}
                         </TableCell>
                       );
                     }
                   )}
-                  <TableCell>
+                  <TableCell className={styles.tableBodyItem}>
                     <button
+                      className={styles.deleteBtn}
                       onClick={() =>
                         deleteMegaphone({
                           megaphoneId: megaphone.megaphoneId,
@@ -124,14 +155,16 @@ function MegaphoneList() {
                 </TableRow>
               ))
             ) : (
-              <TableRow>
-                <TableCell>비어있습니다</TableCell>
+              <TableRow className={styles.tableBodyItem}>
+                <TableCell className={styles.tableBodyItem}>
+                  비어있습니다
+                </TableCell>
               </TableRow>
             )}
           </TableBody>
         </Table>
       </TableContainer>
-      <div>
+      <div className={styles.pageNationContainer}>
         <PageNation
           curPage={megaphoneData.currentPage}
           totalPages={megaphoneData.totalPage}

--- a/components/admin/receipt/MegaphoneList.tsx
+++ b/components/admin/receipt/MegaphoneList.tsx
@@ -77,27 +77,6 @@ function MegaphoneList() {
     }
   }, [currentPage]);
 
-  // useMockAxiosGet<any>({
-  //   url: `/admin/megaphones/history?page=${currentPage}&size=10`,
-  //   setState: (data) => {
-  //     setMegaphoneData({
-  //       megaphoneList: data.megaphoneList.map((megaphone: Imegaphone) => {
-  //         const { year, month, date, hour, min } = getFormattedDateToString(
-  //           new Date(megaphone.usedAt)
-  //         );
-  //         return {
-  //           ...megaphone,
-  //           usedAt: `${year}-${month}-${date} ${hour}:${min}`,
-  //         };
-  //       }),
-  //       totalPage: data.totalPage,
-  //       currentPage: currentPage,
-  //     });
-  //   },
-  //   err: 'HJ03',
-  //   type: 'setError',
-  // });
-
   const deleteMegaphone = (megaphoneInfo: ImegaphoneInfo) => {
     setModal({
       modalName: 'ADMIN-MEGAPHONE_DELETE',

--- a/components/admin/receipt/MenuTab.tsx
+++ b/components/admin/receipt/MenuTab.tsx
@@ -30,9 +30,7 @@ function MenuTab() {
 
   return (
     <div className={styles.mainContainer}>
-      <div className={styles.title}>
-        <h2>거래내역 관리</h2>
-      </div>
+      <div className={styles.title}>거래내역 관리</div>
       <ul className={styles.tabMenu}>
         {tabContents.map((content) => (
           <li

--- a/components/admin/receipt/ProfileList.tsx
+++ b/components/admin/receipt/ProfileList.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useSetRecoilState } from 'recoil';
 import {
   Iprofile,
@@ -21,6 +21,8 @@ import {
   TableRow,
 } from '@mui/material';
 import styles from 'styles/admin/receipt/ProfileList.module.scss';
+import { errorState } from 'utils/recoil/error';
+import { mockInstance } from 'utils/mockAxios';
 
 const profileTableTitle: { [key: string]: string } = {
   profileId: 'ID',
@@ -30,7 +32,7 @@ const profileTableTitle: { [key: string]: string } = {
   delete: '삭제',
 };
 
-const tableColumnName = ['profileId', 'data', 'intraId', 'imageUrl', 'delete'];
+const tableColumnName = ['profileId', 'date', 'intraId', 'imageUrl', 'delete'];
 
 function ProfileList() {
   const [profileData, setProfileData] = useState<IprofileTable>({
@@ -39,15 +41,19 @@ function ProfileList() {
     currentPage: 0,
   });
   const [currentPage, setCurrentPage] = useState<number>(1);
+  const setModal = useSetRecoilState(modalState);
+  const setError = useSetRecoilState(errorState);
 
-  // 특정 유저 확성기 사용내역만 가져오는 api 추가되면 handler + 유저 검색 컴포넌트 추가
+  // todo: 특정 유저 확성기 사용내역만 가져오는 api 추가되면 handler + 유저 검색 컴포넌트 추가
 
-  // api 연결 시 useCallback, instanceInManage, try catch로 변경
-  const getProfileHandler = useMockAxiosGet<any>({
-    url: `/admin/images?page=${currentPage}&size=5`,
-    setState: (data) => {
+  // todo: api 연결 시 instanceInManage로 변경
+  const getProfileHandler = useCallback(async () => {
+    try {
+      const res = await mockInstance.get(
+        `/admin/images?page=${currentPage}&size=5`
+      );
       setProfileData({
-        profileList: data.profileList.map((profile: Iprofile) => {
+        profileList: res.data.profileList.map((profile: Iprofile) => {
           const { year, month, date, hour, min } = getFormattedDateToString(
             new Date(profile.date)
           );
@@ -56,15 +62,34 @@ function ProfileList() {
             date: `${year}-${month}-${date} ${hour}:${min}`,
           };
         }),
-        totalPage: data.totalPage,
+        totalPage: res.data.totalPage,
         currentPage: currentPage,
       });
-    },
-    err: 'HJ04',
-    type: 'setError',
-  });
+    } catch (e: unknown) {
+      setError('HJ04');
+    }
+  }, [currentPage]);
 
-  const setModal = useSetRecoilState(modalState);
+  // useMockAxiosGet<any>({
+  //   url: `/admin/images?page=${currentPage}&size=5`,
+  //   setState: (data) => {
+  //     setProfileData({
+  //       profileList: data.profileList.map((profile: Iprofile) => {
+  //         const { year, month, date, hour, min } = getFormattedDateToString(
+  //           new Date(profile.date)
+  //         );
+  //         return {
+  //           ...profile,
+  //           date: `${year}-${month}-${date} ${hour}:${min}`,
+  //         };
+  //       }),
+  //       totalPage: data.totalPage,
+  //       currentPage: currentPage,
+  //     });
+  //   },
+  //   err: 'HJ04',
+  //   type: 'setError',
+  // });
 
   const deleteProfile = (profileInfo: IprofileInfo) => {
     setModal({
@@ -79,23 +104,25 @@ function ProfileList() {
 
   return (
     <>
-      <TableContainer component={Paper}>
-        <Table aria-label='customized table'>
-          <TableHead>
+      <TableContainer className={styles.tableContainer} component={Paper}>
+        <Table className={styles.table} aria-label='customized table'>
+          <TableHead className={styles.tableHeader}>
             <TableRow>
               {tableColumnName.map((columnName, idx) => (
-                <TableCell key={idx}>{profileTableTitle[columnName]}</TableCell>
+                <TableCell className={styles.tableHeaderItem} key={idx}>
+                  {profileTableTitle[columnName]}
+                </TableCell>
               ))}
             </TableRow>
           </TableHead>
-          <TableBody>
+          <TableBody className={styles.tableBody}>
             {profileData.profileList.length > 0 ? (
               profileData.profileList.map((profile: Iprofile) => (
-                <TableRow key={profile.profileId}>
+                <TableRow className={styles.tableRow} key={profile.profileId}>
                   {tableFormat['profileList'].columns.map(
                     (columnName: string, index: number) => {
                       return (
-                        <TableCell key={index}>
+                        <TableCell className={styles.tableBodyItem} key={index}>
                           {columnName === 'imageUrl' ? (
                             <Image
                               src={profile[columnName]}
@@ -110,8 +137,9 @@ function ProfileList() {
                       );
                     }
                   )}
-                  <TableCell>
+                  <TableCell className={styles.tableBodyItem}>
                     <button
+                      className={styles.deleteBtn}
                       onClick={() => {
                         deleteProfile({
                           profileId: profile.profileId,
@@ -126,14 +154,16 @@ function ProfileList() {
                 </TableRow>
               ))
             ) : (
-              <TableRow>
-                <TableCell>비어있습니다</TableCell>
+              <TableRow className={styles.tableBodyItem}>
+                <TableCell className={styles.tableBodyItem}>
+                  비어있습니다
+                </TableCell>
               </TableRow>
             )}
           </TableBody>
         </Table>
       </TableContainer>
-      <div>
+      <div className={styles.pageNationContainer}>
         <PageNation
           curPage={profileData.currentPage}
           totalPages={profileData.totalPage}

--- a/components/admin/receipt/ProfileList.tsx
+++ b/components/admin/receipt/ProfileList.tsx
@@ -70,27 +70,6 @@ function ProfileList() {
     }
   }, [currentPage]);
 
-  // useMockAxiosGet<any>({
-  //   url: `/admin/images?page=${currentPage}&size=5`,
-  //   setState: (data) => {
-  //     setProfileData({
-  //       profileList: data.profileList.map((profile: Iprofile) => {
-  //         const { year, month, date, hour, min } = getFormattedDateToString(
-  //           new Date(profile.date)
-  //         );
-  //         return {
-  //           ...profile,
-  //           date: `${year}-${month}-${date} ${hour}:${min}`,
-  //         };
-  //       }),
-  //       totalPage: data.totalPage,
-  //       currentPage: currentPage,
-  //     });
-  //   },
-  //   err: 'HJ04',
-  //   type: 'setError',
-  // });
-
   const deleteProfile = (profileInfo: IprofileInfo) => {
     setModal({
       modalName: 'ADMIN-PROFILE_DELETE',

--- a/components/admin/receipt/ProfileList.tsx
+++ b/components/admin/receipt/ProfileList.tsx
@@ -21,8 +21,8 @@ import {
   TableRow,
 } from '@mui/material';
 import styles from 'styles/admin/receipt/ProfileList.module.scss';
-import { errorState } from 'utils/recoil/error';
 import { mockInstance } from 'utils/mockAxios';
+import { toastState } from 'utils/recoil/toast';
 
 const profileTableTitle: { [key: string]: string } = {
   profileId: 'ID',
@@ -42,7 +42,7 @@ function ProfileList() {
   });
   const [currentPage, setCurrentPage] = useState<number>(1);
   const setModal = useSetRecoilState(modalState);
-  const setError = useSetRecoilState(errorState);
+  const setSnackBar = useSetRecoilState(toastState);
 
   // todo: 특정 유저 확성기 사용내역만 가져오는 api 추가되면 handler + 유저 검색 컴포넌트 추가
 
@@ -66,7 +66,12 @@ function ProfileList() {
         currentPage: currentPage,
       });
     } catch (e: unknown) {
-      setError('HJ04');
+      setSnackBar({
+        toastName: 'get profile',
+        severity: 'error',
+        message: `API 요청에 문제가 발생했습니다.`,
+        clicked: true,
+      });
     }
   }, [currentPage]);
 

--- a/components/admin/receipt/ReceiptList.tsx
+++ b/components/admin/receipt/ReceiptList.tsx
@@ -15,8 +15,8 @@ import {
 } from '@mui/material';
 import styles from 'styles/admin/receipt/ReceiptList.module.scss';
 import { useSetRecoilState } from 'recoil';
-import { errorState } from 'utils/recoil/error';
 import { mockInstance } from 'utils/mockAxios';
+import { toastState } from 'utils/recoil/toast';
 
 const receiptListTableTitle: { [key: string]: string } = {
   receiptId: 'ID',
@@ -44,9 +44,8 @@ function ReceiptList() {
     totalPage: 0,
     currentPage: 0,
   });
-
   const [currentPage, setCurrentPage] = useState<number>(1);
-  const setError = useSetRecoilState(errorState);
+  const setSnackBar = useSetRecoilState(toastState);
 
   // todo: 특정 유저 거래 내역만 가져오는 api 추가되면 handler 추가 + 유저 검색 컴포넌트 추가
 
@@ -70,7 +69,12 @@ function ReceiptList() {
         currentPage: currentPage,
       });
     } catch (e: unknown) {
-      setError('HJ02');
+      setSnackBar({
+        toastName: 'get receipt',
+        severity: 'error',
+        message: `API 요청에 문제가 발생했습니다.`,
+        clicked: true,
+      });
     }
   }, [currentPage]);
 

--- a/components/admin/receipt/ReceiptList.tsx
+++ b/components/admin/receipt/ReceiptList.tsx
@@ -74,27 +74,6 @@ function ReceiptList() {
     }
   }, [currentPage]);
 
-  // useMockAxiosGet<any>({
-  //   url: `/admin/receipt/?page=${currentPage}&size=10`,
-  //   setState: (data) => {
-  //     setReceiptData({
-  //       receiptList: data.receiptList.map((receipt: Ireceipt) => {
-  //         const { year, month, date, hour, min } = getFormattedDateToString(
-  //           new Date(receipt.createdAt)
-  //         );
-  //         return {
-  //           ...receipt,
-  //           createdAt: `${year}-${month}-${date} ${hour}:${min}`,
-  //         };
-  //       }),
-  //       totalPage: data.totalPage,
-  //       currentPage: currentPage,
-  //     });
-  //   },
-  //   err: 'HJ02',
-  //   type: 'setError',
-  // });
-
   useEffect(() => {
     getReceiptHandler();
   }, [currentPage]);

--- a/components/modal/ModalProvider.tsx
+++ b/components/modal/ModalProvider.tsx
@@ -33,6 +33,7 @@ import AdminEditCoinPolicyModal from './admin/AdminEditCoinPolicy';
 import BuyModal from './store/purchase/BuyModal';
 import GiftModal from './store/purchase/GiftModal';
 import NoCoinModal from './store/purchase/NoCoinModal';
+import AdminCheckSendNotiModal from './admin/AdminCheckSendNoti';
 
 export default function ModalProvider() {
   const [
@@ -110,6 +111,9 @@ export default function ModalProvider() {
     ) : null,
     'ADMIN-COINPOLICY_EDIT': coinPolicy ? (
       <AdminEditCoinPolicyModal {...coinPolicy} />
+    ) : null,
+    'ADMIN-CHECK_SEND_NOTI': intraId ? (
+      <AdminCheckSendNotiModal intraId={intraId} />
     ) : null,
   };
 

--- a/components/modal/admin/AdminCheckSendNoti.tsx
+++ b/components/modal/admin/AdminCheckSendNoti.tsx
@@ -1,0 +1,74 @@
+import { useSetRecoilState } from 'recoil';
+import { modalState } from 'utils/recoil/modal';
+import styles from 'styles/admin/modal/AdminCheckSendNoti.module.scss';
+import { toastState } from 'utils/recoil/toast';
+import { instanceInManage } from 'utils/axios';
+
+interface IsendNoti {
+  intraId: string;
+}
+
+export default function AdminCheckSendNotiModal(props: IsendNoti) {
+  const { intraId } = props;
+  const setModal = useSetRecoilState(modalState);
+  const setSnackBar = useSetRecoilState(toastState);
+
+  const sendNotificationHandler = async () => {
+    const notiContent =
+      '확성기 내용이 부적절하여 관리자에 의해 삭제되었습니다.';
+
+    try {
+      await instanceInManage.post(`/notifications`, {
+        intraId: intraId,
+        message: notiContent,
+      });
+      setSnackBar({
+        toastName: 'noti user',
+        severity: 'success',
+        message: `확성기 삭제 알림이 성공적으로 전송되었습니다!`,
+        clicked: true,
+      });
+      setModal({ modalName: null });
+    } catch (e) {
+      setSnackBar({
+        toastName: 'noti user',
+        severity: 'error',
+        message: `API 요청에 문제가 발생했습니다.`,
+        clicked: true,
+      });
+    }
+    setModal({ modalName: null });
+  };
+
+  return (
+    <div className={styles.whole}>
+      <div className={styles.title}>
+        <div className={styles.titleText}>알림 전송</div>
+        <hr className={styles.hr} />
+      </div>
+      <div className={styles.body}>
+        <div className={styles.bodyWrap}>
+          <div className={styles.intraText}>
+            <span className={styles.intraId}>{intraId}</span>
+            님에게
+          </div>
+          <div className={styles.text}>확성기 삭제 알림을 보내시겠습니까?</div>
+        </div>
+        <div className={styles.buttonWrap}>
+          <button
+            className={styles.deleteBtn}
+            onClick={() => sendNotificationHandler()}
+          >
+            보내기
+          </button>
+          <button
+            className={styles.cancelBtn}
+            onClick={() => setModal({ modalName: null })}
+          >
+            취소
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/modal/admin/AdminDeleteMegaphoneModal.tsx
+++ b/components/modal/admin/AdminDeleteMegaphoneModal.tsx
@@ -1,32 +1,46 @@
 import { useSetRecoilState } from 'recoil';
-import { errorState } from 'utils/recoil/error';
 import { modalState } from 'utils/recoil/modal';
 import { ImegaphoneInfo } from 'types/admin/adminReceiptType';
-import styles from 'styles/admin/modal/AdminDeleteMegaphoneModal.module.scss';
-
 import { mockInstance } from 'utils/mockAxios';
+import { toastState } from 'utils/recoil/toast';
+import styles from 'styles/admin/modal/AdminDeleteMegaphoneModal.module.scss';
 
 export default function AdminDeleteMegaphoneModal(props: ImegaphoneInfo) {
   const { megaphoneId, content, intraId } = props;
   const setModal = useSetRecoilState(modalState);
-  const setError = useSetRecoilState(errorState);
+  const setSnackBar = useSetRecoilState(toastState);
 
-  // 수정 필요 작동안함
   // instanceInManage, try catch로 변경
   const deleteMegaphoneHandler = async (megaphoneId: number) => {
     try {
       await mockInstance.delete(`/admin/megaphones/${megaphoneId}`);
     } catch (e: any) {
       if (e.response.status === 403) {
-        alert(`${megaphoneId}번 확성기는 삭제할 수 없습니다`);
+        setSnackBar({
+          toastName: 'delete megaphone',
+          severity: 'error',
+          message: `${megaphoneId}번 확성기는 삭제할 수 없는 확성기입니다.`,
+          clicked: true,
+        });
         setModal({ modalName: null });
         return;
       } else {
-        setError('HJ04');
+        setSnackBar({
+          toastName: 'delete megaphone',
+          severity: 'error',
+          message: `API 요청에 문제가 발생했습니다.`,
+          clicked: true,
+        });
+        setModal({ modalName: null });
       }
     }
-    alert(`${megaphoneId}번 확성기가 삭제되었습니다`);
-    setModal({ modalName: null });
+    setSnackBar({
+      toastName: 'delete megaphone',
+      severity: 'success',
+      message: `${megaphoneId}번 확성기가 삭제되었습니다!`,
+      clicked: true,
+    });
+    setModal({ modalName: 'ADMIN-CHECK_SEND_NOTI', intraId: intraId });
   };
 
   return (

--- a/components/modal/admin/AdminDeleteMegaphoneModal.tsx
+++ b/components/modal/admin/AdminDeleteMegaphoneModal.tsx
@@ -4,6 +4,8 @@ import { modalState } from 'utils/recoil/modal';
 import { ImegaphoneInfo } from 'types/admin/adminReceiptType';
 import styles from 'styles/admin/modal/AdminDeleteMegaphoneModal.module.scss';
 
+import { mockInstance } from 'utils/mockAxios';
+
 export default function AdminDeleteMegaphoneModal(props: ImegaphoneInfo) {
   const { megaphoneId, content, intraId } = props;
   const resetModal = useResetRecoilState(modalState);
@@ -11,21 +13,20 @@ export default function AdminDeleteMegaphoneModal(props: ImegaphoneInfo) {
 
   // 수정 필요 작동안함
   // instanceInManage, try catch로 변경
-  // const deleteMegaphoneHandler = async (id: number) => {
-  //   try {
-  //     await fetch(`http://localhost:3000/api/pingpong/admin/megaphones/${id}`, {
-  //       method: 'DELETE',
-  //     });
-  //     alert(`${id}번 확성기가 삭제되었습니다`);
-  //   } catch (e: any) {
-  //     if (e.response.status === 400) {
-  //       alert(`${id}번 확성기는 삭제할 수 없습니다`);
-  //     } else {
-  //       setError('HJ04');
-  //     }
-  //   }
-  //   resetModal();
-  // };
+  const deleteMegaphoneHandler = async (id: number) => {
+    console.log(id);
+    try {
+      await mockInstance.delete(`/admin/megaphones/${id}`);
+    } catch (e: any) {
+      if (e.response.status === 403) {
+        alert(`${id}번 확성기는 삭제할 수 없습니다`);
+      } else {
+        setError('HJ04');
+      }
+    }
+    alert(`${id}번 확성기가 삭제되었습니다`);
+    resetModal();
+  };
 
   return (
     <div className={styles.whole}>
@@ -56,7 +57,12 @@ export default function AdminDeleteMegaphoneModal(props: ImegaphoneInfo) {
           <button className={styles.cancelBtn} onClick={() => resetModal()}>
             취소
           </button>
-          <button className={styles.deleteBtn}>삭제</button>
+          <button
+            className={styles.deleteBtn}
+            onClick={() => deleteMegaphoneHandler(megaphoneId)}
+          >
+            삭제
+          </button>
         </div>
       </div>
     </div>

--- a/components/modal/admin/AdminDeleteMegaphoneModal.tsx
+++ b/components/modal/admin/AdminDeleteMegaphoneModal.tsx
@@ -1,4 +1,4 @@
-import { useResetRecoilState, useSetRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import { errorState } from 'utils/recoil/error';
 import { modalState } from 'utils/recoil/modal';
 import { ImegaphoneInfo } from 'types/admin/adminReceiptType';
@@ -8,24 +8,25 @@ import { mockInstance } from 'utils/mockAxios';
 
 export default function AdminDeleteMegaphoneModal(props: ImegaphoneInfo) {
   const { megaphoneId, content, intraId } = props;
-  const resetModal = useResetRecoilState(modalState);
+  const setModal = useSetRecoilState(modalState);
   const setError = useSetRecoilState(errorState);
 
   // 수정 필요 작동안함
   // instanceInManage, try catch로 변경
-  const deleteMegaphoneHandler = async (id: number) => {
-    console.log(id);
+  const deleteMegaphoneHandler = async (megaphoneId: number) => {
     try {
-      await mockInstance.delete(`/admin/megaphones/${id}`);
+      await mockInstance.delete(`/admin/megaphones/${megaphoneId}`);
     } catch (e: any) {
       if (e.response.status === 403) {
-        alert(`${id}번 확성기는 삭제할 수 없습니다`);
+        alert(`${megaphoneId}번 확성기는 삭제할 수 없습니다`);
+        setModal({ modalName: null });
+        return;
       } else {
         setError('HJ04');
       }
     }
-    alert(`${id}번 확성기가 삭제되었습니다`);
-    resetModal();
+    alert(`${megaphoneId}번 확성기가 삭제되었습니다`);
+    setModal({ modalName: null });
   };
 
   return (
@@ -54,14 +55,17 @@ export default function AdminDeleteMegaphoneModal(props: ImegaphoneInfo) {
           </div>
         </div>
         <div className={styles.buttonWrap}>
-          <button className={styles.cancelBtn} onClick={() => resetModal()}>
-            취소
-          </button>
           <button
             className={styles.deleteBtn}
             onClick={() => deleteMegaphoneHandler(megaphoneId)}
           >
             삭제
+          </button>
+          <button
+            className={styles.cancelBtn}
+            onClick={() => setModal({ modalName: null })}
+          >
+            취소
           </button>
         </div>
       </div>

--- a/pages/api/pingpong/admin/megaphones/[megaphoneId].ts
+++ b/pages/api/pingpong/admin/megaphones/[megaphoneId].ts
@@ -5,7 +5,12 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const { megaphoneId } = query as { megaphoneId: string };
 
   if (method === 'DELETE') {
-    if (parseInt(megaphoneId) > 5) res.status(204);
-    else res.status(400);
+    if (megaphoneId === undefined) {
+      res.status(400).end('Bad Request');
+      return;
+    } else {
+      if (parseInt(megaphoneId) < 5) res.status(204);
+      else res.status(405).end(`Megaphone ${megaphoneId} Not Found`);
+    }
   }
 }

--- a/pages/api/pingpong/admin/megaphones/[megaphoneId].ts
+++ b/pages/api/pingpong/admin/megaphones/[megaphoneId].ts
@@ -5,7 +5,12 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const { megaphoneId } = query as { megaphoneId: string };
 
   if (method === 'DELETE') {
-    if (megaphoneId === '1' || megaphoneId === '2' || megaphoneId === '3')
+    if (
+      megaphoneId === '1' ||
+      megaphoneId === '2' ||
+      megaphoneId === '3' ||
+      megaphoneId === '4'
+    )
       res.status(204).end();
     else res.status(403).end();
   }

--- a/pages/api/pingpong/admin/megaphones/[megaphoneId].ts
+++ b/pages/api/pingpong/admin/megaphones/[megaphoneId].ts
@@ -5,12 +5,8 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const { megaphoneId } = query as { megaphoneId: string };
 
   if (method === 'DELETE') {
-    if (megaphoneId === undefined) {
-      res.status(400).end('Bad Request');
-      return;
-    } else {
-      if (parseInt(megaphoneId) < 5) res.status(204);
-      else res.status(405).end(`Megaphone ${megaphoneId} Not Found`);
-    }
+    if (megaphoneId === '1' || megaphoneId === '2' || megaphoneId === '3')
+      res.status(204).end();
+    else res.status(403).end();
   }
 }

--- a/pages/api/pingpong/admin/megaphones/history/index.ts
+++ b/pages/api/pingpong/admin/megaphones/history/index.ts
@@ -19,7 +19,7 @@ const megaphone2: Imegaphone = {
   content: '확성기입니다',
   usedAt: new Date('2023-07-05 10:10:10'),
   status: '사용 중',
-  intraId: 'hyungjpa',
+  intraId: 'hyobicho',
 };
 
 const megaphone3: Imegaphone = {
@@ -27,7 +27,7 @@ const megaphone3: Imegaphone = {
   content: '확성기입니다',
   usedAt: new Date('2023-07-05 06:10:10'),
   status: '사용 중',
-  intraId: 'hyungjpa',
+  intraId: 'sangmipa',
 };
 
 const megaphone4: Imegaphone = {
@@ -35,7 +35,7 @@ const megaphone4: Imegaphone = {
   content: '확성기입니다',
   usedAt: new Date('2023-07-03 10:10:10'),
   status: '사용 중',
-  intraId: 'hyungjpa',
+  intraId: 'jeyoon',
 };
 
 const megaphone5: Imegaphone = {
@@ -43,7 +43,7 @@ const megaphone5: Imegaphone = {
   content: '확성기입니다',
   usedAt: new Date('2023-07-02 10:20:10'),
   status: '사용 대기',
-  intraId: 'hyungjpa',
+  intraId: 'Hyungjpa',
 };
 
 const megaphone6: Imegaphone = {

--- a/pages/api/pingpong/admin/megaphones/history/index.ts
+++ b/pages/api/pingpong/admin/megaphones/history/index.ts
@@ -1,114 +1,139 @@
 import { NextApiRequest, NextApiResponse } from 'next';
+import { Imegaphone } from 'types/admin/adminReceiptType';
 
-const testData1 = {
-  megaphoneList: [
-    {
-      megaphoneId: 12,
-      content: '확성기입니다',
-      usedAt: '2023-08-05 10:10:10',
-      status: '사용 중',
-      intraId: 'hyungjpa',
-    },
-    {
-      megaphoneId: 11,
-      content: '확성기입니다',
-      usedAt: '2023-07-05 10:10:10',
-      status: '사용 중',
-      intraId: 'hyungjpa',
-    },
-    {
-      megaphoneId: 10,
-      content: '확성기입니다',
-      usedAt: '2023-07-05 06:10:10',
-      status: '사용 중',
-      intraId: 'hyungjpa',
-    },
-    {
-      megaphoneId: 9,
-      content: '확성기입니다',
-      usedAt: '2023-07-03 10:10:10',
-      status: '사용 중',
-      intraId: 'hyungjpa',
-    },
-    {
-      megaphoneId: 8,
-      content: '확성기입니다',
-      usedAt: '2023-07-02 10:20:10',
-      status: '사용 대기',
-      intraId: 'hyungjpa',
-    },
-    {
-      megaphoneId: 7,
-      content: '확성기입니다',
-      usedAt: '2023-06-05 10:10:10',
-      status: '사용 대기',
-      intraId: 'hyungjpa',
-    },
-    {
-      megaphoneId: 6,
-      content: '확성기입니다',
-      usedAt: '2023-06-05 10:00:10',
-      status: '사용 대기',
-      intraId: 'hyungjpa',
-    },
-    {
-      megaphoneId: 5,
-      content: '확성기입니다',
-      usedAt: '2023-05-05 10:10:10',
-      status: '사용 완료',
-      intraId: 'hyungjpa',
-    },
-    {
-      megaphoneId: 4,
-      content: '확성기입니다',
-      usedAt: '2023-05-04 10:10:10',
-      status: '사용 완료',
-      intraId: 'hyungjpa',
-    },
-    {
-      megaphoneId: 3,
-      content: '확성기입니다',
-      usedAt: '2023-05-03 10:10:10',
-      status: '사용 완료',
-      intraId: 'hyungjpa',
-    },
-  ],
-  totalPage: 2,
+interface ImegaphoneRes {
+  megaphoneList: Array<Imegaphone>;
+  totalPage: number;
+}
+
+const megaphone1: Imegaphone = {
+  megaphoneId: 1,
+  content: '확성기입니다',
+  usedAt: new Date('2023-08-05 10:10:10'),
+  status: '사용 중',
+  intraId: 'hyungjpa',
 };
 
-const testData2 = {
-  megaphoneList: [
-    {
-      megaphoneId: 2,
-      content: '확성기입니다',
-      usedAt: '2023-05-02 10:10:10',
-      status: '사용 완료',
-      intraId: 'hyungjpa',
-    },
-    {
-      megaphoneId: 1,
-      content: '확성기입니다',
-      usedAt: '2023-05-01 10:10:10',
-      status: '사용 완료',
-      intraId: 'hyungjpa',
-    },
-    {
-      megaphoneId: 0,
-      content: '확성기입니다',
-      usedAt: '2023-05-01 00:10:10',
-      status: '사용 완료',
-      intraId: 'hyungjpa',
-    },
-  ],
-  totalPage: 2,
+const megaphone2: Imegaphone = {
+  megaphoneId: 2,
+  content: '확성기입니다',
+  usedAt: new Date('2023-07-05 10:10:10'),
+  status: '사용 중',
+  intraId: 'hyungjpa',
+};
+
+const megaphone3: Imegaphone = {
+  megaphoneId: 3,
+  content: '확성기입니다',
+  usedAt: new Date('2023-07-05 06:10:10'),
+  status: '사용 중',
+  intraId: 'hyungjpa',
+};
+
+const megaphone4: Imegaphone = {
+  megaphoneId: 4,
+  content: '확성기입니다',
+  usedAt: new Date('2023-07-03 10:10:10'),
+  status: '사용 중',
+  intraId: 'hyungjpa',
+};
+
+const megaphone5: Imegaphone = {
+  megaphoneId: 5,
+  content: '확성기입니다',
+  usedAt: new Date('2023-07-02 10:20:10'),
+  status: '사용 대기',
+  intraId: 'hyungjpa',
+};
+
+const megaphone6: Imegaphone = {
+  megaphoneId: 6,
+  content: '확성기입니다',
+  usedAt: new Date('2023-06-05 10:10:10'),
+  status: '사용 대기',
+  intraId: 'hyungjpa',
+};
+
+const megaphone7: Imegaphone = {
+  megaphoneId: 7,
+  content: '확성기입니다',
+  usedAt: new Date('2023-06-05 10:00:10'),
+  status: '사용 대기',
+  intraId: 'hyungjpa',
+};
+
+const megaphone8: Imegaphone = {
+  megaphoneId: 8,
+  content: '확성기입니다',
+  usedAt: new Date('2023-05-05 10:10:10'),
+  status: '사용 완료',
+  intraId: 'hyungjpa',
+};
+
+const megaphone9: Imegaphone = {
+  megaphoneId: 9,
+  content: '확성기입니다',
+  usedAt: new Date('2023-05-04 10:10:10'),
+  status: '사용 완료',
+  intraId: 'hyungjpa',
+};
+
+const megaphone10: Imegaphone = {
+  megaphoneId: 10,
+  content: '확성기입니다',
+  usedAt: new Date('2023-05-03 10:10:10'),
+  status: '사용 완료',
+  intraId: 'hyungjpa',
+};
+
+const megaphoneList: Array<Imegaphone> = [
+  megaphone1,
+  megaphone2,
+  megaphone3,
+  megaphone4,
+  megaphone5,
+  megaphone6,
+  megaphone7,
+  megaphone8,
+  megaphone9,
+  megaphone10,
+];
+
+const ResEmpty: ImegaphoneRes = {
+  megaphoneList: [],
+  totalPage: 0,
+};
+
+const ResOne: ImegaphoneRes = {
+  megaphoneList: megaphoneList.slice(0, 8),
+  totalPage: 1,
+};
+
+const ResTwo: ImegaphoneRes = {
+  megaphoneList: megaphoneList,
+  totalPage: 3,
 };
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  const { method, query } = req;
+  const { query } = req;
   const { page } = query as { page: string };
 
-  if (method === 'GET') {
-    if (page === '1') res.status(200).json(testData1);
-    else res.status(200).json(testData2);
+  // const temp: ImegaphoneTable = ResEmpty;
+  // const temp: ImegaphoneTable = ResOne;
+  const temp: ImegaphoneRes = ResTwo;
+
+  const resData: ImegaphoneRes = {
+    megaphoneList: [],
+    totalPage: temp.totalPage,
+  };
+
+  if (page) {
+    if (parseInt(page) === resData.totalPage) {
+      resData.megaphoneList = temp.megaphoneList.slice(0, 5);
+    } else {
+      resData.megaphoneList = temp.megaphoneList;
+    }
   }
+
+  res.status(200).json(resData);
 }

--- a/styles/admin/modal/AdminCheckSendNoti.module.scss
+++ b/styles/admin/modal/AdminCheckSendNoti.module.scss
@@ -1,0 +1,87 @@
+.whole {
+  display: flex;
+  flex-direction: column;
+  width: 510px;
+  height: 250px;
+  background: #ffffff;
+  border-radius: 9px;
+}
+
+.title {
+  display: flex;
+  flex-wrap: wrap;
+  align-content: space-evenly;
+  width: 510px;
+  height: 130px;
+  padding: 0 1rem;
+}
+
+.titleText {
+  margin-top: 15px;
+  margin-left: 1rem;
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 500;
+  font-size: 28px;
+  line-height: 150%;
+  color: #000000;
+}
+
+.hr {
+  width: 455px;
+  height: 0.5px;
+  background: #e5e5e5;
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  height: 100%;
+}
+
+.bodyWrap {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  height: 30%;
+  width: 80%;
+  margin-bottom: 30px;
+}
+
+.intraText {
+  padding-bottom: 5px;
+}
+
+.intraId {
+  font-weight: 600;
+}
+
+.buttonWrap {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+  width: 90%;
+  height: 50%;
+}
+
+.deleteBtn,
+.cancelBtn {
+  width: 246.45px;
+  height: 37.73px;
+  color: #ffffff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.deleteBtn {
+  background: #2678f3;
+}
+
+.cancelBtn {
+  background: #6c757d;
+}

--- a/styles/admin/modal/AdminDeleteMegaphoneModal.module.scss
+++ b/styles/admin/modal/AdminDeleteMegaphoneModal.module.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   width: 510px;
-  height: 569px;
+  height: 490px;
   background: #ffffff;
   border-radius: 9px;
 }
@@ -36,10 +36,9 @@
 .body {
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
   height: 100%;
-  background-color: yellow;
 }
 
 .bodyWrap {
@@ -47,10 +46,9 @@
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
-  height: 80%;
+  height: 60%;
   width: 80%;
-
-  background-color: blue;
+  margin-bottom: 30px;
 }
 
 .bodyText {
@@ -59,33 +57,68 @@
   font-family: 'Inter';
   font-style: normal;
   font-weight: 500;
-  font-size: 1rem;
+  font-size: 0.8rem;
   line-height: 150%;
   color: #6b7280;
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: red;
 }
 
-.intraWrap {
+.intraWrap,
+.contentWrap {
   display: flex;
   align-items: center;
   margin-bottom: 10px;
   padding: 0 1rem;
-  :focus {
-    outline: none;
-  }
 }
 
-.intraBlank {
+.intraBlank,
+.contentBlank {
   display: flex;
   margin-left: 1rem;
   width: 275px;
-  height: 33px;
+  height: 60px;
   resize: none;
   box-sizing: border-box;
   background: #f9fafb;
   border: 0.5px solid #ced4da;
   border-radius: 1px;
+  font-size: 0.8rem;
+  text-align: center;
+}
+
+.contentBlank {
+  height: 100px;
+}
+
+.contentWrap {
+  margin-bottom: 30px;
+}
+
+.buttonWrap {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+  width: 90%;
+  height: 25%;
+}
+
+.deleteBtn,
+.cancelBtn {
+  width: 246.45px;
+  height: 37.73px;
+  color: #ffffff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.deleteBtn {
+  background: #2678f3;
+}
+
+.cancelBtn {
+  background: #6c757d;
 }

--- a/styles/admin/receipt/MegaphoneList.module.scss
+++ b/styles/admin/receipt/MegaphoneList.module.scss
@@ -1,0 +1,51 @@
+@import 'styles/admin/common/Pagination.module.scss';
+@import 'styles/common.scss';
+
+.tableContainer {
+  width: 100%;
+  min-width: 700px;
+  margin: auto;
+  .table {
+    .tableHeader {
+      background-color: lightgray;
+      .tableHeaderItem {
+        padding: 0.7rem;
+        text-align: center;
+        font-weight: 600;
+        font-size: $medium-font;
+        line-height: 150%;
+      }
+    }
+    .tableBody {
+      .tableRow {
+        &:nth-child(odd) {
+          background-color: #f9fafb;
+        }
+        &:nth-child(even) {
+          background-color: #fff;
+        }
+        .tableBodyItem {
+          padding: 10px;
+          text-align: center;
+          line-height: 150%;
+          font-size: $medium-font;
+        }
+      }
+    }
+  }
+}
+
+.deleteBtn {
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 10px;
+  width: 3rem;
+  height: 1.5rem;
+  background: #2678f3;
+  color: #ffffff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+@include pagination;

--- a/styles/admin/receipt/MenuTab.module.scss
+++ b/styles/admin/receipt/MenuTab.module.scss
@@ -1,4 +1,3 @@
-@import 'styles/admin/common/Pagination.module.scss';
 @import 'styles/common.scss';
 
 .mainContainer {

--- a/styles/admin/receipt/MenuTab.module.scss
+++ b/styles/admin/receipt/MenuTab.module.scss
@@ -1,27 +1,30 @@
+@import 'styles/admin/common/Pagination.module.scss';
+@import 'styles/common.scss';
+
 .mainContainer {
   position: relative;
-  width: 80%;
+  width: 90%;
   height: 100%;
-  left: 10%;
+  left: 5%;
   display: flex;
   flex-direction: column;
 }
 
 .title {
-  width: 100%;
-  h2 {
-    width: fit-content;
-  }
+  font-weight: 600;
+  font-size: $giant-font;
+  line-height: 150%;
+  width: fit-content;
 }
 
 .tabMenu {
   width: 100%;
-  height: 3rem;
   display: flex;
   flex-direction: row;
   justify-content: space-around;
   align-items: center;
   font-weight: 500;
+  padding-bottom: 0.3rem;
 }
 
 .active {
@@ -35,4 +38,5 @@
 }
 
 .subContainer {
+  width: 100%;
 }

--- a/styles/admin/receipt/ProfileList.module.scss
+++ b/styles/admin/receipt/ProfileList.module.scss
@@ -1,0 +1,51 @@
+@import 'styles/admin/common/Pagination.module.scss';
+@import 'styles/common.scss';
+
+.tableContainer {
+  width: 100%;
+  min-width: 700px;
+  margin: auto;
+  .table {
+    .tableHeader {
+      background-color: lightgray;
+      .tableHeaderItem {
+        padding: 0.7rem;
+        text-align: center;
+        font-weight: 600;
+        font-size: $medium-font;
+        line-height: 150%;
+      }
+    }
+    .tableBody {
+      .tableRow {
+        &:nth-child(odd) {
+          background-color: #f9fafb;
+        }
+        &:nth-child(even) {
+          background-color: #fff;
+        }
+        .tableBodyItem {
+          padding: 10px;
+          text-align: center;
+          line-height: 150%;
+          font-size: $medium-font;
+        }
+      }
+    }
+  }
+}
+
+.deleteBtn {
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 10px;
+  width: 3rem;
+  height: 1.5rem;
+  background: #2678f3;
+  color: #ffffff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+@include pagination;

--- a/styles/admin/receipt/ReceiptList.module.scss
+++ b/styles/admin/receipt/ReceiptList.module.scss
@@ -1,0 +1,38 @@
+@import 'styles/admin/common/Pagination.module.scss';
+@import 'styles/common.scss';
+
+.tableContainer {
+  width: 100%;
+  min-width: 700px;
+  margin: auto;
+  .table {
+    .tableHeader {
+      background-color: lightgray;
+      .tableHeaderItem {
+        padding: 0.7rem;
+        text-align: center;
+        font-weight: 600;
+        font-size: $medium-font;
+        line-height: 150%;
+      }
+    }
+    .tableBody {
+      .tableRow {
+        &:nth-child(odd) {
+          background-color: #f9fafb;
+        }
+        &:nth-child(even) {
+          background-color: #fff;
+        }
+        .tableBodyItem {
+          padding: 10px;
+          text-align: center;
+          line-height: 150%;
+          font-size: $medium-font;
+        }
+      }
+    }
+  }
+}
+
+@include pagination;

--- a/types/modalTypes.ts
+++ b/types/modalTypes.ts
@@ -33,7 +33,8 @@ type AdminModal =
   | 'PROFILE_DELETE'
   | 'ITEM_EDIT'
   | 'ITEM_DELETE'
-  | 'COINPOLICY_EDIT';
+  | 'COINPOLICY_EDIT'
+  | 'CHECK_SEND_NOTI';
 
 type ModalName =
   | null
@@ -43,7 +44,7 @@ type ModalName =
   | `USER-${UserModal}`
   | `FIXED-${FixedModal}`
   | `ADMIN-${AdminModal}`
-  | `COIN-ANIMATION`;
+  | `COIN-ANIMATION`
   | `PURCHASE-${PurchaseModal}`;
 export interface Cancel {
   startTime: string;


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 관리자 확성기 삭제 기능 추가
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
---
  - 삭제 버튼 클릭 시 삭제 모달 ->  알림 전달 모달 방식으로 작동합니다
  - -> (삭제성공과 알림성공 토스트 메세지가 겹치는 문제때문에 분리해뒀습니다)
  -  1 ~ 4번 확성기만 삭제되게 mock api 만들어놨습니다.(실제로 삭제되지는 않고 토스트 메세지만 보여줍니다)
  - 1 ~ 4번 중 본인의 intraId에 해당하는 확성기를 삭제하여 알림이 실제로 가는지 확인할 수 있습니다.
 ---
  - 거래내역의 setError를 setSnackBar로 변경시켰습니다.
  - 거래내역의 get 요청들에 useCallback을 적용시켜놨습니다.
  - Admin 기본 스타일만 적용시켜놨습니다.(추후에 수정이 필요하다면 수정)
 ---
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
