### PR TITLE
[GGFE-154] 상점 이름 색상 변경 모달

### DIFF
--- a/components/modal/ModalProvider.tsx
+++ b/components/modal/ModalProvider.tsx
@@ -39,6 +39,7 @@ import AdminCheckSendNotiModal from './admin/AdminCheckSendNoti';
 // Inventory Modal
 import NewMegaphoneModal from './store/inventory/NewMegaphoneModal';
 import EditMegaphoneModal from './store/inventory/EditMegaphoneModal';
+import ChangeIdColorModal from './store/inventory/ChangeIdColorModal';
 
 export default function ModalProvider() {
   const [
@@ -129,6 +130,9 @@ export default function ModalProvider() {
     ) : null,
     'EDIT-ITEM-MEGAPHONE': useItemInfo ? (
       <EditMegaphoneModal {...useItemInfo} />
+    ) : null,
+    'USE-ITEM-TEXT_COLOR': useItemInfo ? (
+      <ChangeIdColorModal {...useItemInfo} />
     ) : null,
   };
 

--- a/components/modal/store/inventory/ChangeIdColorModal.tsx
+++ b/components/modal/store/inventory/ChangeIdColorModal.tsx
@@ -31,7 +31,7 @@ export default function ChangeIdColorModal({
   async function handleChangeIdColor() {
     const data: UseIdColorRequest = {
       receiptId: receiptId,
-      color: color,
+      textColor: color,
     };
     // 색상 입력값 확인.
     const ret = confirm(

--- a/components/modal/store/inventory/ChangeIdColorModal.tsx
+++ b/components/modal/store/inventory/ChangeIdColorModal.tsx
@@ -8,6 +8,7 @@ import {
   ModalButtonContainer,
   ModalButton,
 } from 'components/modal/ModalButton';
+import IdPreviewComponent from './IdPreviewComponent';
 import styles from 'styles/modal/store/InventoryModal.module.scss';
 
 type ChangeIdColorModalProps = UseItemRequest;
@@ -15,21 +16,32 @@ type ChangeIdColorModalProps = UseItemRequest;
 export default function ChangeIdColorModal({
   receiptId,
 }: ChangeIdColorModalProps) {
+  const resetModal = useResetRecoilState(modalState);
+  const user = useRecoilValue(userState);
+  const [color, setColor] = useState<string>('#000000');
   return (
     <div className={styles.container}>
       <div className={styles.title}>아이디 색상 변경</div>
       <div className={styles.phrase}>
         <div className={styles.section}>
           <div className={styles.sectionTitle}>미리보기</div>
-          {/* 랭크와 일반 버전 두개 미리 보기 */}
+          <IdPreviewComponent color={color} />
         </div>
         <div className={styles.section}>
           <div className={styles.sectionTitle}>색상 선택</div>
           <div className={styles.colorPicker}>
-            <HexColorPicker />
-            <HexColorInput />
+            <HexColorPicker color={color} onChange={setColor} />
+            <HexColorInput color={color} onChange={setColor} prefixed alpha />
           </div>
         </div>
+        <ModalButtonContainer>
+          <ModalButton
+            style='negative'
+            value='취소'
+            onClick={() => resetModal()}
+          />
+          <ModalButton style='positive' value='등록' onClick={() => void 0} />
+        </ModalButtonContainer>
       </div>
     </div>
   );

--- a/components/modal/store/inventory/ChangeIdColorModal.tsx
+++ b/components/modal/store/inventory/ChangeIdColorModal.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { useRecoilValue, useResetRecoilState } from 'recoil';
-import { HexColorPicker, HexColorInput } from 'react-colorful';
 import { userState } from 'utils/recoil/layout';
 import { modalState } from 'utils/recoil/modal';
 import { UseItemRequest } from 'types/inventoryTypes';
@@ -11,6 +10,7 @@ import {
 import { ItemCautionContainer } from './ItemCautionContainer';
 import IdPreviewComponent from './IdPreviewComponent';
 import styles from 'styles/modal/store/InventoryModal.module.scss';
+import ColorPicker from './ColorPicker';
 
 type ChangeIdColorModalProps = UseItemRequest;
 
@@ -36,10 +36,7 @@ export default function ChangeIdColorModal({
         </div>
         <div className={styles.section}>
           <div className={styles.sectionTitle}>색상 선택</div>
-          <div className={styles.colorPicker}>
-            <HexColorPicker color={color} onChange={setColor} />
-            <HexColorInput color={color} onChange={setColor} prefixed alpha />
-          </div>
+          <ColorPicker color={color} setColor={setColor} />
         </div>
         <ItemCautionContainer caution={caution} />
         <ModalButtonContainer>

--- a/components/modal/store/inventory/ChangeIdColorModal.tsx
+++ b/components/modal/store/inventory/ChangeIdColorModal.tsx
@@ -8,10 +8,17 @@ import {
   ModalButtonContainer,
   ModalButton,
 } from 'components/modal/ModalButton';
+import { ItemCautionContainer } from './ItemCautionContainer';
 import IdPreviewComponent from './IdPreviewComponent';
 import styles from 'styles/modal/store/InventoryModal.module.scss';
 
 type ChangeIdColorModalProps = UseItemRequest;
+
+// TODO : 주의사항 구체화 필요
+const caution = [
+  '아이템을 사용한 후에는 취소가 불가능합니다.',
+  '색상 변경은 아이템 당 1회만 가능합니다.',
+];
 
 export default function ChangeIdColorModal({
   receiptId,
@@ -25,7 +32,7 @@ export default function ChangeIdColorModal({
       <div className={styles.phrase}>
         <div className={styles.section}>
           <div className={styles.sectionTitle}>미리보기</div>
-          <IdPreviewComponent color={color} />
+          <IdPreviewComponent intraId={user.intraId} color={color} />
         </div>
         <div className={styles.section}>
           <div className={styles.sectionTitle}>색상 선택</div>
@@ -34,6 +41,7 @@ export default function ChangeIdColorModal({
             <HexColorInput color={color} onChange={setColor} prefixed alpha />
           </div>
         </div>
+        <ItemCautionContainer caution={caution} />
         <ModalButtonContainer>
           <ModalButton
             style='negative'

--- a/components/modal/store/inventory/ChangeIdColorModal.tsx
+++ b/components/modal/store/inventory/ChangeIdColorModal.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import { useRecoilValue, useResetRecoilState } from 'recoil';
+import { HexColorPicker, HexColorInput } from 'react-colorful';
+import { userState } from 'utils/recoil/layout';
+import { modalState } from 'utils/recoil/modal';
+import { UseItemRequest } from 'types/inventoryTypes';
+import {
+  ModalButtonContainer,
+  ModalButton,
+} from 'components/modal/ModalButton';
+import styles from 'styles/modal/store/InventoryModal.module.scss';
+
+type ChangeIdColorModalProps = UseItemRequest;
+
+export default function ChangeIdColorModal({
+  receiptId,
+}: ChangeIdColorModalProps) {
+  return (
+    <div className={styles.container}>
+      <div className={styles.title}>아이디 색상 변경</div>
+      <div className={styles.phrase}>
+        <div className={styles.section}>
+          <div className={styles.sectionTitle}>미리보기</div>
+          {/* 랭크와 일반 버전 두개 미리 보기 */}
+        </div>
+        <div className={styles.section}>
+          <div className={styles.sectionTitle}>색상 선택</div>
+          <div className={styles.colorPicker}>
+            <HexColorPicker />
+            <HexColorInput />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/modal/store/inventory/ChangeIdColorModal.tsx
+++ b/components/modal/store/inventory/ChangeIdColorModal.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useRecoilValue, useResetRecoilState } from 'recoil';
 import { userState } from 'utils/recoil/layout';
 import { modalState } from 'utils/recoil/modal';
-import { UseItemRequest } from 'types/inventoryTypes';
+import { UseItemRequest, UseIdColorRequest } from 'types/inventoryTypes';
 import {
   ModalButtonContainer,
   ModalButton,
@@ -11,6 +11,7 @@ import { ItemCautionContainer } from './ItemCautionContainer';
 import IdPreviewComponent from './IdPreviewComponent';
 import styles from 'styles/modal/store/InventoryModal.module.scss';
 import ColorPicker from './ColorPicker';
+import { mockInstance } from 'utils/mockAxios';
 
 type ChangeIdColorModalProps = UseItemRequest;
 
@@ -26,6 +27,32 @@ export default function ChangeIdColorModal({
   const resetModal = useResetRecoilState(modalState);
   const user = useRecoilValue(userState);
   const [color, setColor] = useState<string>('#000000');
+
+  async function handleChangeIdColor() {
+    const data: UseIdColorRequest = {
+      receiptId: receiptId,
+      color: color,
+    };
+    // 색상 입력값 확인.
+    const ret = confirm(
+      `아이디 색상을 ${color}로 변경하시겠습니까?\n(아이템을 사용한 후에는 취소가 불가능합니다.)`
+    );
+    if (!ret) return;
+    try {
+      // await mockInstance.post('/users/text-color', data);
+      // NOTE : 테스트를 위해 응답 body를 console에 출력 <- 아이디 색상 변경 결과 확인. 추후 삭제
+      const response = await mockInstance.patch('/users/text-color', data);
+      console.log(response.data);
+      //
+      alert('아이디 색상이 변경되었습니다.');
+    } catch (error: unknown) {
+      // TODO : error 정의 필요
+      console.log(error);
+    } finally {
+      resetModal();
+    }
+  }
+
   return (
     <div className={styles.container}>
       <div className={styles.title}>아이디 색상 변경</div>
@@ -45,7 +72,11 @@ export default function ChangeIdColorModal({
             value='취소'
             onClick={() => resetModal()}
           />
-          <ModalButton style='positive' value='등록' onClick={() => void 0} />
+          <ModalButton
+            style='positive'
+            value='등록'
+            onClick={() => handleChangeIdColor()}
+          />
         </ModalButtonContainer>
       </div>
     </div>

--- a/components/modal/store/inventory/ColorPicker.tsx
+++ b/components/modal/store/inventory/ColorPicker.tsx
@@ -8,12 +8,10 @@ type ColorPickerProps = {
 };
 
 export default function ColorPicker({ color, setColor }: ColorPickerProps) {
-  const [showPicker, setShowPicker] = useState<boolean>(false);
   return (
     <>
       <div className={styles.container}>
         <div
-          onClick={() => setShowPicker(!showPicker)}
           style={{ backgroundColor: color }}
           className={styles.colorPreview}
         />
@@ -24,14 +22,12 @@ export default function ColorPicker({ color, setColor }: ColorPickerProps) {
           alpha
           className={styles.colorInput}
         />
-        {showPicker && (
-          <HexColorPicker
-            color={color}
-            onChange={setColor}
-            className={styles.colorPicker}
-            style={{ width: 'auto' }}
-          />
-        )}
+        <HexColorPicker
+          color={color}
+          onChange={setColor}
+          className={styles.colorPicker}
+          style={{ width: 'auto' }}
+        />
       </div>
     </>
   );

--- a/components/modal/store/inventory/ColorPicker.tsx
+++ b/components/modal/store/inventory/ColorPicker.tsx
@@ -1,0 +1,38 @@
+import { Dispatch, SetStateAction, useState } from 'react';
+import { HexColorInput, HexColorPicker } from 'react-colorful';
+import styles from 'styles/modal/store/ColorPicker.module.scss';
+
+type ColorPickerProps = {
+  color: string;
+  setColor: Dispatch<SetStateAction<string>>;
+};
+
+export default function ColorPicker({ color, setColor }: ColorPickerProps) {
+  const [showPicker, setShowPicker] = useState<boolean>(false);
+  return (
+    <>
+      <div className={styles.container}>
+        <div
+          onClick={() => setShowPicker(!showPicker)}
+          style={{ backgroundColor: color }}
+          className={styles.colorPreview}
+        />
+        <HexColorInput
+          color={color}
+          onChange={setColor}
+          prefixed
+          alpha
+          className={styles.colorInput}
+        />
+        {showPicker && (
+          <HexColorPicker
+            color={color}
+            onChange={setColor}
+            className={styles.colorPicker}
+            style={{ width: 'auto' }}
+          />
+        )}
+      </div>
+    </>
+  );
+}

--- a/components/modal/store/inventory/IdPreviewComponent.tsx
+++ b/components/modal/store/inventory/IdPreviewComponent.tsx
@@ -1,10 +1,11 @@
 import styles from 'styles/rank/RankList.module.scss';
 
 type IdPreviewProps = {
+  intraId: string;
   color: string;
 };
 
-export default function IdPreviewComponent({ color }: IdPreviewProps) {
+export default function IdPreviewComponent({ intraId, color }: IdPreviewProps) {
   // TODO : RankListItem 2개로 분리 후 import해서 사용할 것.
   // NOTE : 아래는 임시 구현임.
   return (
@@ -14,7 +15,7 @@ export default function IdPreviewComponent({ color }: IdPreviewProps) {
         className={`${styles.rankItemWrap} ${styles.standard} ${styles.Ranking}`}
       >
         <div className={styles.intraId} style={{ color: color }}>
-          intraId
+          {intraId}
         </div>
       </div>
       {/* NORMAL */}
@@ -22,7 +23,7 @@ export default function IdPreviewComponent({ color }: IdPreviewProps) {
         className={`${styles.rankItemWrap} ${styles.standard} ${styles.Vip}`}
       >
         <div className={styles.intraId} style={{ color: color }}>
-          intraId
+          {intraId}
         </div>
       </div>
     </div>

--- a/components/modal/store/inventory/IdPreviewComponent.tsx
+++ b/components/modal/store/inventory/IdPreviewComponent.tsx
@@ -1,0 +1,30 @@
+import styles from 'styles/rank/RankList.module.scss';
+
+type IdPreviewProps = {
+  color: string;
+};
+
+export default function IdPreviewComponent({ color }: IdPreviewProps) {
+  // TODO : RankListItem 2개로 분리 후 import해서 사용할 것.
+  // NOTE : 아래는 임시 구현임.
+  return (
+    <div>
+      {/* RANK */}
+      <div
+        className={`${styles.rankItemWrap} ${styles.standard} ${styles.Ranking}`}
+      >
+        <div className={styles.intraId} style={{ color: color }}>
+          intraId
+        </div>
+      </div>
+      {/* NORMAL */}
+      <div
+        className={`${styles.rankItemWrap} ${styles.standard} ${styles.Vip}`}
+      >
+        <div className={styles.intraId} style={{ color: color }}>
+          intraId
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/rank/RankList.tsx
+++ b/components/rank/RankList.tsx
@@ -61,6 +61,7 @@ function makeUser(user: NormalUser | RankUser) {
   return {
     intraId: user.intraId,
     rank: user.rank,
+    idColor: '#000000', // TODO : 랭크 정보에 아이디 색상 정보도 필요함.
     statusMessage: makeStatusMessage(user.statusMessage),
     point: !isRankModeType(user) ? user.exp : makeInit(user.ppp),
     level: !isRankModeType(user) ? user.level : null,

--- a/components/rank/RankListItem.tsx
+++ b/components/rank/RankListItem.tsx
@@ -7,6 +7,7 @@ import PlayerImage from 'components/PlayerImage';
 
 interface User {
   intraId: string;
+  idColor: string;
   rank: number;
   statusMessage: string;
   point: number | string;
@@ -16,11 +17,17 @@ interface User {
 
 interface RankListItemProps {
   user: User;
+  idColorPreview?: string;
 }
 
-export default function RankListItem({ user }: RankListItemProps) {
+export default function RankListItem({
+  user,
+  idColorPreview,
+}: RankListItemProps) {
   const Mode = useRecoilValue(colorToggleSelector);
-  const { rank, intraId, statusMessage, point, level, tierImageUri } = user;
+  // TODO : 랭크 정보에 아이디 색상 정보도 필요함.
+  const { rank, intraId, statusMessage, point, level, tierImageUri, idColor } =
+    user;
   const myIntraId = useRecoilValue(userState).intraId;
   const wrapStyle = {
     topStandard: rank < 4 ? styles.top : styles.standard,
@@ -53,7 +60,14 @@ export default function RankListItem({ user }: RankListItemProps) {
       ) : (
         ''
       )}
-      <div className={styles.intraId}>{makeIntraIdLink()}</div>
+      <div
+        style={{
+          color: idColorPreview === undefined ? idColor : idColorPreview,
+        }}
+        className={styles.intraId}
+      >
+        {makeIntraIdLink()}
+      </div>
       <div className={styles.statusMessage}>{statusMessage}</div>
       <div className={styles.ppp}>{point}</div>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "42arcade.gg.client",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "42arcade.gg.client",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "dependencies": {
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
@@ -22,6 +22,7 @@
         "next-images": "^1.8.4",
         "react": "^18.2.0",
         "react-chartjs-2": "^4.2.0",
+        "react-colorful": "^5.6.1",
         "react-dom": "^18.2.0",
         "react-hooks-paginator": "^0.5.0",
         "react-icons": "^4.4.0",
@@ -16649,7 +16650,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
       "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
-      "dev": true,
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "next-images": "^1.8.4",
     "react": "^18.2.0",
     "react-chartjs-2": "^4.2.0",
+    "react-colorful": "^5.6.1",
     "react-dom": "^18.2.0",
     "react-hooks-paginator": "^0.5.0",
     "react-icons": "^4.4.0",

--- a/pages/api/pingpong/items/index.ts
+++ b/pages/api/pingpong/items/index.ts
@@ -43,14 +43,14 @@ const item3: InventoryItem = {
 
 const item4: InventoryItem = {
   receiptId: 4,
-  itemName: '테스트4',
+  itemName: '이름 색깔 변경',
   imageUri: 'https://cdn.nookazon.com/nookazon/icons/leaf.png',
   purchaserIntra: 'kim_takgu',
   itemStatus: 'USED',
   // ANCHOR - 추가된 속성. 필요 여부 논의 필요
   itemPrice: 1000,
   ownerIntra: 'aa',
-  itemType: 'MEGAPHONE',
+  itemType: 'TEXT_COLOR',
   createdAt: '2021-08-07',
 };
 

--- a/pages/api/pingpong/users/text-color.ts
+++ b/pages/api/pingpong/users/text-color.ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<string>
+) {
+  const { method } = req;
+  const { receiptId, color } = req.body;
+  if (method === 'PATCH') {
+    // res.status(204).end();
+    res.status(200).json(`receiptId : ${receiptId}, color : ${color}`);
+  }
+}

--- a/styles/modal/store/ColorPicker.module.scss
+++ b/styles/modal/store/ColorPicker.module.scss
@@ -24,4 +24,5 @@
 
 .colorPicker {
   grid-column: 1 / 3;
+  max-height: 10rem;
 }

--- a/styles/modal/store/ColorPicker.module.scss
+++ b/styles/modal/store/ColorPicker.module.scss
@@ -1,0 +1,27 @@
+.container {
+  display: grid;
+  grid-template-columns: 1fr 9fr;
+  grid-gap: 0.5rem;
+}
+
+.colorPreview {
+  padding: 0.5rem;
+  border: 3px solid #fff;
+  border-radius: 0.5rem;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  &::after {
+    content: '';
+    display: block;
+    padding-bottom: 100%;
+  }
+}
+
+.colorInput {
+  border: 3px solid #fff;
+  border-radius: 0.5rem;
+}
+
+.colorPicker {
+  grid-column: 1 / 3;
+}

--- a/types/inventoryTypes.ts
+++ b/types/inventoryTypes.ts
@@ -31,3 +31,8 @@ export type UseItemRequest = {
 export type UseMegaphoneRequest = UseItemRequest & {
   content: string;
 };
+
+// NOTE : request body 미정
+export type UseIdColorRequest = UseItemRequest & {
+  color: string;
+};

--- a/types/inventoryTypes.ts
+++ b/types/inventoryTypes.ts
@@ -32,7 +32,6 @@ export type UseMegaphoneRequest = UseItemRequest & {
   content: string;
 };
 
-// NOTE : request body 미정
 export type UseIdColorRequest = UseItemRequest & {
-  color: string;
+  textColor: string;
 };


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 랭크 페이지의 이름 색상 변경 아이템을 사용하기 위한 모달
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 미리보기
    - 기존 `RankListItem` 컴포넌트를 이용해서 미리보기 블록을 만드려고 했었는데 `RankListItem` 컴포넌트가 너무 복잡해서,, 바로 수정이 안될 것 같아 일단은 배경이랑 글씨 색만 확인할 수 있게 대강 만들어 두었습니다... (글씨 삐져나와있는 점 미리 죄송합니다...)
    - `RankListItem` 컴포넌트를 활용하게 된다면 기존의 RANK와 NORMAL 모드를 같은 컴포넌트에서 처리하던 방식에서 두 모드를 각각 처리하는 식으로 변경하려고 하고, 색깔 미리보기에서는 상태메시지를 제외한 정보만 보여줄까 합니다!
  - 색깔 선택
    - `<input type="color">` 를 사용하게 되면 버튼 스타일링이 어렵고, hex color 코드를 직접 입력받기 까다로워져서 **react-colorful** 라이브러리를 설치했습니다! **❗️실행 전에 npm install 실행해주세요❗️**
    - 색깔 버튼을 눌러서 컬러 팔레트를 열고 닫을 수 있게 했습니다. 열고 닫는게 좋을지 아니면 기본적으로 보여주고 있는게 나을지는 잘 모르겠어요 🥲
    - hex color 코드를 직접 입력할 수 있습니다! 빈 경우에는 기본값인 `#000` 이 들어가고 유효하지 않은 입력의 경우에는 _아마도_ 가장 가까운 유효한 입력으로 들어가는 것 같아요.
  - 변경하기
    - 적용 결과를 직접 확인하기는 어려워서 응답 결과를 확인하게만 했습니다..
    - 추가로 rank api 응답 결과에도 색깔 항목이 들어가야 하는데 이 부분은 api 명세가 아직 안나와서 (...) 아직 적용하지 않았습니다.
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
