### PR TITLE
[GGFE-181] 페이지네이션 겹침현상

### DIFF
--- a/styles/admin/common/Pagination.module.scss
+++ b/styles/admin/common/Pagination.module.scss
@@ -8,9 +8,8 @@
         display: flex;
         justify-content: center;
         align-items: center;
-        // width: 2.4rem;
         height: 1.5rem;
-        margin: 0 0.2rem;
+        margin: 0 0.3rem;
         font-size: 1.2rem; /* $big-font */
         font-weight: 600;
         cursor: pointer;

--- a/styles/admin/common/Pagination.module.scss
+++ b/styles/admin/common/Pagination.module.scss
@@ -8,8 +8,9 @@
         display: flex;
         justify-content: center;
         align-items: center;
-        width: 2.4rem;
+        // width: 2.4rem;
         height: 1.5rem;
+        margin: 0 0.2rem;
         font-size: 1.2rem; /* $big-font */
         font-weight: 600;
         cursor: pointer;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -82,7 +82,6 @@ body {
   src: url('../public/font/NanumSquare_acEB.ttf') format('opentype');
   font-weight: normal;
   font-style: normal;
-
 }
 
 @font-face {
@@ -153,8 +152,8 @@ ul.pagination li {
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 27px;
-  height: 27px;
+  width: 2.4rem;
+  height: 1.5rem;
   font-size: 1.2rem; /* $big-font */
   font-weight: 600;
   cursor: pointer;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -152,9 +152,8 @@ ul.pagination li {
   display: flex;
   justify-content: center;
   align-items: center;
-  /* width: 2.4rem; */
   height: 1.5rem;
-  margin: 0 0.2rem;
+  margin: 0 0.3rem;
   font-size: 1.2rem; /* $big-font */
   font-weight: 600;
   cursor: pointer;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -152,8 +152,9 @@ ul.pagination li {
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 2.4rem;
+  /* width: 2.4rem; */
   height: 1.5rem;
+  margin: 0 0.2rem;
   font-size: 1.2rem; /* $big-font */
   font-weight: 600;
   cursor: pointer;


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
closes #769
페이지네이션 페이지 크기가 커졌을 때 숫자가 겹치는 부분을 수정했습니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
기존 문제는 관리자 페이지에서 발생하고 있었는데 이 부분은 예전 PR에서 해결되었던 문제였습니다 😂
관리자 페이지에서 해결한 방법은 페이지 번호 태그의 너비를 넓혀주는 방법인데요.
이렇게 하면 자릿수에 상관없이 페이지네이션 자체의 너비가 고정되는 장점이 있지만 나중에 자릿수가 더 커지면 또 다시 동일한 문제가 발생할 것 같아서 너비를 고정하지 않고 margin을 주는 방식도 관리자 페이지와 일반 페이지 모두에 추가해보았습니다.
둘 다 확인해보시고 괜찮은 방법 알려주시면 그 방법으로 적용할게요.

 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
