### PR TITLE
[GGFE-205] 유저 보유 코인 조회 api 연결

### DIFF
--- a/components/mode/modeWraps/StoreModeWrap.tsx
+++ b/components/mode/modeWraps/StoreModeWrap.tsx
@@ -44,7 +44,7 @@ export function StoreModeWrap({
           매뉴얼
         </button>
         <div className={styles.coins} onClick={viewCoinHistory}>
-          {coin.coin}
+          {coin.coin.toLocaleString()}
           <FaCoins />
         </div>
       </div>

--- a/pages/store.tsx
+++ b/pages/store.tsx
@@ -4,22 +4,27 @@ import { ICoin } from 'types/userTypes';
 import { StoreModeWrap } from 'components/mode/modeWraps/StoreModeWrap';
 import ItemsList from 'components/shop/ItemsList';
 import { Inventory } from 'components/store/Inventory';
-import { useMockAxiosGet } from 'hooks/useAxiosGet';
+import useAxiosGet from 'hooks/useAxiosGet';
 import styles from 'styles/store/StoreContainer.module.scss';
 
 export default function Store() {
   const [mode, setMode] = useState<StoreMode>('BUY');
   const [coin, setCoin] = useState<ICoin>({ coin: 0 });
-  useEffect(() => {
-    getCoin();
-    // TODO : 코인이 바뀔 때 마다 다시 불러와야 한다.
-  }, []);
-  const getCoin = useMockAxiosGet({
-    url: '/users/coin',
+  const [updateCoin, setUpdateCoin] = useState<boolean>(true);
+
+  const getCoin = useAxiosGet({
+    url: '/pingpong/users/coin',
     setState: setCoin,
     err: 'JY01',
     type: 'setError',
   });
+
+  useEffect(() => {
+    if (updateCoin) {
+      getCoin();
+      setUpdateCoin(false);
+    }
+  }, [updateCoin]);
 
   return (
     <div className={styles.pageWrap}>


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 유저 보유 코인 조회 api 연결했습니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 기존 mock api로 되어있던 코인 api를 실제 api로 변경했습니다.
  - 상점 페이지 내에서 코인을 사용하는 경우 코인이 줄어든 내역을 새로 받아올 수 있게 state를 만들었습니다. 코인을 사용한 뒤에 `setUpdateCoin`로 `updateCoin` 값을 `true`로 설정하면 코인을 새로 받아옵니다.
    (서버 측에 업데이트 된 매치 정보를 다시 받아오는 로직도 `reloadMatchState`라는 리코일로 관리하고 있어서 코인 업데이트 방식도 동일하게 프론트에서 관리하는 식으로 처리했는데 나중에 여유 되면 react-query 로 관리하는 쪽으로 바꾸는 것도 좋을 것 같습니다 ^_ㅜ)
 
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
