### PR TITLE
[GGFE-225] 확성기 개수 제한 없이 작동하게 css 변경

### DIFF
--- a/components/Layout/MegaPhone.tsx
+++ b/components/Layout/MegaPhone.tsx
@@ -30,19 +30,19 @@ const megaphoneContent: IMegaphoneContent = {
 
 const profileContent: IMegaphoneContent = {
   megaphoneId: 3,
-  content: '이미지 변경권 : 얼굴 체인지',
+  content: '이미지 변경권 : 잘 지내? 프사 바꿨네...',
   intraId: '절찬 판매 중!',
 };
 
 const edgeContent: IMegaphoneContent = {
   megaphoneId: 4,
-  content: 'Edge 뽑기 : 난 "Edge"로 말해.. -sishin 😝',
+  content: 'Edge 뽑기 : 난 "Edge"로 말해',
   intraId: '절찬 판매 중!',
 };
 
 const backgroundContent: IMegaphoneContent = {
   megaphoneId: 5,
-  content: '배경 뽑기 : 난 "Background"부터가 달라 - klew 😝',
+  content: '배경 뽑기 : 난 "Background"부터가 달라',
   intraId: '절찬 판매 중!',
 };
 
@@ -60,12 +60,6 @@ const defaultContents: MegaphoneList = [
   backgroundContent,
   idContent,
 ];
-
-// 메가폰 10개 넘어도 잘 작동하는지 테스트하는 테스트용 temp 입니다.
-const temp = defaultContents;
-for (let i = 0; i < 4; i++) {
-  temp.push(...defaultContents);
-}
 
 export const MegaphoneContainer = ({
   children,
@@ -110,10 +104,7 @@ const Megaphone = () => {
   const getMegaphoneHandler = useAxiosGet<any>({
     url: `/pingpong/megaphones`,
     setState: (data) => {
-      // megaphone 아이템이 여러개 들어와도 잘 작동하는지 테스트용 임시 temp입니다.
-      // 위에서 temp 길이를 조정할 수 있습니다.
-      // setContents(data.length > 0 ? data : defaultContents);
-      setContents(data.length > 0 ? data : temp);
+      setContents(data.length > 0 ? data : defaultContents);
     },
     err: 'HJ01',
     type: 'setError',

--- a/components/Layout/MegaPhone.tsx
+++ b/components/Layout/MegaPhone.tsx
@@ -16,18 +16,56 @@ type MegaphoneContainerProps = {
   count: number;
 };
 
+const adminContent: IMegaphoneContent = {
+  megaphoneId: 1,
+  content: '상점에서 아이템을 구매해서 확성기를 등록해보세요!(30자 제한)',
+  intraId: '관리자',
+};
+
+const megaphoneContent: IMegaphoneContent = {
+  megaphoneId: 2,
+  content: '오늘 하루 42GG는 내가 접수한다 📢😎',
+  intraId: '확성기',
+};
+
+const profileContent: IMegaphoneContent = {
+  megaphoneId: 3,
+  content: '얼굴 체인지',
+  intraId: '이미지 변경권',
+};
+
+const edgeContent: IMegaphoneContent = {
+  megaphoneId: 4,
+  content: '난 "Edge"로 말해.. -sishin 😝',
+  intraId: 'Edge 뽑기',
+};
+
+const backgroundContent: IMegaphoneContent = {
+  megaphoneId: 5,
+  content: '난 "Background"부터가 달라 - klew 😝',
+  intraId: '배경 뽑기',
+};
+
+const idContent: IMegaphoneContent = {
+  megaphoneId: 6,
+  content: '남들과는 다르게! ID 색깔을 바꿔보세요!',
+  intraId: 'ID 색깔 변경권',
+};
+
 const defaultContents: MegaphoneList = [
-  {
-    megaphoneId: 1,
-    content: '상점에서 아이템을 구매해서 확성기를 등록해보세요!(30자 제한)',
-    intraId: '관리자',
-  },
-  {
-    megaphoneId: 2,
-    content: '상점에서 아이템을 구매해서 확성기를 등록해보세요!(30자 제한)',
-    intraId: '관리자',
-  },
+  adminContent,
+  megaphoneContent,
+  profileContent,
+  edgeContent,
+  backgroundContent,
+  idContent,
 ];
+
+// 메가폰 10개 넘어도 잘 작동하는지 테스트하는 테스트용 temp 입니다.
+const temp = defaultContents;
+for (let i = 0; i < 4; i++) {
+  temp.push(...defaultContents);
+}
 
 export const MegaphoneContainer = ({
   children,
@@ -41,7 +79,7 @@ export const MegaphoneContainer = ({
     const nextIndex = (selectedIndex + 1) % count;
     setWrapperStyle('slideNext' + nextIndex.toString());
     setSelectedIndex(nextIndex);
-  }, 4500);
+  }, 1000);
 
   return (
     <div className={styles.rollingBanner}>
@@ -67,7 +105,10 @@ const Megaphone = () => {
   const getMegaphoneHandler = useAxiosGet<any>({
     url: `/pingpong/megaphones`,
     setState: (data) => {
-      setContents(data.length > 0 ? data : defaultContents);
+      // megaphone 아이템이 여러개 들어와도 잘 작동하는지 테스트용 임시 temp입니다.
+      // 위에서 temp 길이를 조정할 수 있습니다.
+      // setContents(data.length > 0 ? data : defaultContents);
+      setContents(data.length > 0 ? data : temp);
     },
     err: 'HJ01',
     type: 'setError',

--- a/components/Layout/MegaPhone.tsx
+++ b/components/Layout/MegaPhone.tsx
@@ -73,17 +73,22 @@ export const MegaphoneContainer = ({
 }: MegaphoneContainerProps) => {
   const ref = useRef<HTMLDivElement>(null);
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
-  const [wrapperStyle, setWrapperStyle] = useState<string>('slideNext0');
 
   useInterval(() => {
     const nextIndex = (selectedIndex + 1) % count;
-    setWrapperStyle('slideNext' + nextIndex.toString());
     setSelectedIndex(nextIndex);
-  }, 1000);
+  }, 4000);
 
   return (
     <div className={styles.rollingBanner}>
-      <div className={`${styles.wrapper} ${styles[wrapperStyle]}`} ref={ref}>
+      <div
+        className={styles.wrapper}
+        style={{
+          transition: 'all 1s ease-in-out',
+          transform: `translateY(${selectedIndex * -100}%)`,
+        }}
+        ref={ref}
+      >
         {children}
       </div>
     </div>

--- a/components/Layout/MegaPhone.tsx
+++ b/components/Layout/MegaPhone.tsx
@@ -24,32 +24,32 @@ const adminContent: IMegaphoneContent = {
 
 const megaphoneContent: IMegaphoneContent = {
   megaphoneId: 2,
-  content: '오늘 하루 42GG는 내가 접수한다 📢😎',
-  intraId: '확성기',
+  content: '확성기 : 오늘 하루 42GG는 내가 접수한다 📢😎',
+  intraId: '절찬 판매 중!',
 };
 
 const profileContent: IMegaphoneContent = {
   megaphoneId: 3,
-  content: '얼굴 체인지',
-  intraId: '이미지 변경권',
+  content: '이미지 변경권 : 얼굴 체인지',
+  intraId: '절찬 판매 중!',
 };
 
 const edgeContent: IMegaphoneContent = {
   megaphoneId: 4,
-  content: '난 "Edge"로 말해.. -sishin 😝',
-  intraId: 'Edge 뽑기',
+  content: 'Edge 뽑기 : 난 "Edge"로 말해.. -sishin 😝',
+  intraId: '절찬 판매 중!',
 };
 
 const backgroundContent: IMegaphoneContent = {
   megaphoneId: 5,
-  content: '난 "Background"부터가 달라 - klew 😝',
-  intraId: '배경 뽑기',
+  content: '배경 뽑기 : 난 "Background"부터가 달라 - klew 😝',
+  intraId: '절찬 판매 중!',
 };
 
 const idContent: IMegaphoneContent = {
   megaphoneId: 6,
-  content: '남들과는 다르게! ID 색깔을 바꿔보세요!',
-  intraId: 'ID 색깔 변경권',
+  content: 'ID 색깔 변경권 : 남들과는 다르게! ID 색깔을 바꿔보세요!',
+  intraId: '절찬 판매 중!',
 };
 
 const defaultContents: MegaphoneList = [

--- a/styles/Layout/MegaPhone.module.scss
+++ b/styles/Layout/MegaPhone.module.scss
@@ -1,10 +1,3 @@
-@mixin slide($num) {
-  transition: all 1s ease-in-out;
-  transform: translateY($num);
-}
-
-$slide_count: 1000;
-
 .rollingBanner {
   position: relative;
   display: flex;
@@ -22,14 +15,6 @@ $slide_count: 1000;
   width: 100%;
   height: 100%;
   text-align: center;
-
-  @for $i from 0 to $slide_count {
-    $class-name: 'slideNext#{$i}';
-    $slide-distance: $i * -100%;
-    &.#{$class-name} {
-      @include slide($slide-distance);
-    }
-  }
 }
 
 .contentWrapper {

--- a/styles/Layout/MegaPhone.module.scss
+++ b/styles/Layout/MegaPhone.module.scss
@@ -3,6 +3,8 @@
   transform: translateY($num);
 }
 
+$slide_count: 1000;
+
 .rollingBanner {
   position: relative;
   display: flex;
@@ -21,35 +23,12 @@
   height: 100%;
   text-align: center;
 
-  &.slideNext0 {
-    @include slide(0%);
-  }
-  &.slideNext1 {
-    @include slide(-100%);
-  }
-  &.slideNext2 {
-    @include slide(-200%);
-  }
-  &.slideNext3 {
-    @include slide(-300%);
-  }
-  &.slideNext4 {
-    @include slide(-400%);
-  }
-  &.slideNext5 {
-    @include slide(-500%);
-  }
-  &.slideNext6 {
-    @include slide(-600%);
-  }
-  &.slideNext7 {
-    @include slide(-700%);
-  }
-  &.slideNext8 {
-    @include slide(-800%);
-  }
-  &.slideNext9 {
-    @include slide(-900%);
+  @for $i from 0 to $slide_count {
+    $class-name: 'slideNext#{$i}';
+    $slide-distance: $i * -100%;
+    &.#{$class-name} {
+      @include slide($slide-distance);
+    }
   }
 }
 


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 확성기 개수 제한 없이 작동하는  로직으로 변경
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - ~~기존에 확성기 10개로 생각하고 작성하였던 확성기 css를 최대 1000개까지 받을 수 있게 변경했습니다.~~
  - ~~1000개는 임의로 설정한 값이라 더 큰 값이 필요하다면 바꾸기만 하면 됩니다.~~
  - 피드백 주신 내용 반영하여 div에 style 직접 주는 방식으로 변경했습니다!
  - megaphone 기본값을 관리자 멘트 -> 관리자 + 아이템 설명으로 변경해봤습니다.(피드백 환영합니다)
  - megaphone.tsx 파일에서 테스트용 temp로 확성기 내용 개수 조절해서 테스트 해보실 수 있습니다.
  - (66번 줄 for문 조작하시면 됩니다. 넘어가는 시간은 78번 줄의 useInterval 값 조정해주시면 됩니다.)
  - 주석과 temp는 리뷰 끝나면 merge하기 전에 다 지우겠습니다
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
