### PR TITLE
[GGFE-224] 프로필 이미지 수정 api 연결

### DIFF
--- a/components/modal/store/inventory/ProfileImageModal.tsx
+++ b/components/modal/store/inventory/ProfileImageModal.tsx
@@ -3,7 +3,7 @@ import { useRecoilValue, useResetRecoilState } from 'recoil';
 import { FaArrowRight } from 'react-icons/fa';
 import { TbQuestionMark } from 'react-icons/tb';
 import { UseItemRequest } from 'types/inventoryTypes';
-import { mockInstance } from 'utils/mockAxios';
+import { instance, isAxiosError } from 'utils/axios';
 import { userState } from 'utils/recoil/layout';
 import { modalState } from 'utils/recoil/modal';
 import {
@@ -37,19 +37,24 @@ export default function ProfileImageModal({ receiptId }: ProfileImageProps) {
       const formData = new FormData();
       // TODO : receiptId 데이터에 대한 key는 결정되지 않음.
       formData.append(
-        'receiptId',
+        'userProfileImageRequestDto',
         new Blob([JSON.stringify({ receiptId: receiptId })], {
           type: 'application/json',
         })
       );
-      formData.append('imgData', new Blob([imgData], { type: 'image/jpeg' }));
-      const ret = await mockInstance.post('/users/profile-image', formData);
-      if (ret.status === 201) {
-        alert('프로필 이미지가 변경되었습니다.');
-        resetModal();
-      } else throw new Error();
+      formData.append(
+        'profileImage',
+        new Blob([imgData], { type: 'image/jpeg' })
+      );
+      const ret = await instance.post(
+        '/pingpong/users/profile-image',
+        formData
+      );
+      alert('프로필 이미지가 변경되었습니다.');
+      resetModal();
     } catch (error) {
       alert('프로필 이미지 변경에 실패했습니다.');
+      resetModal();
     }
   }
 

--- a/components/modal/store/inventory/ProfileImageModal.tsx
+++ b/components/modal/store/inventory/ProfileImageModal.tsx
@@ -3,16 +3,16 @@ import { useRecoilValue, useResetRecoilState } from 'recoil';
 import { FaArrowRight } from 'react-icons/fa';
 import { TbQuestionMark } from 'react-icons/tb';
 import { UseItemRequest } from 'types/inventoryTypes';
-import { modalState } from 'utils/recoil/modal';
-import { userState } from 'utils/recoil/layout';
 import { mockInstance } from 'utils/mockAxios';
-import useUploadImg from 'hooks/useUploadImg';
-import { ItemCautionContainer } from './ItemCautionContainer';
+import { userState } from 'utils/recoil/layout';
+import { modalState } from 'utils/recoil/modal';
 import {
   ModalButtonContainer,
   ModalButton,
 } from 'components/modal/ModalButton';
+import useUploadImg from 'hooks/useUploadImg';
 import styles from 'styles/modal/store/InventoryModal.module.scss';
+import { ItemCautionContainer } from './ItemCautionContainer';
 
 type ProfileImageProps = UseItemRequest;
 

--- a/components/modal/store/inventory/ProfileImageModal.tsx
+++ b/components/modal/store/inventory/ProfileImageModal.tsx
@@ -92,9 +92,10 @@ export default function ProfileImageModal({ receiptId }: ProfileImageProps) {
     } catch (error: unknown) {
       if (isAxiosError<errorPayload>(error) && error.response) {
         const { code } = error.response.data;
-        if (code === 'UR100') setError;
-        if (errorCode.includes(code)) alert(errorMessage[code]);
-      }
+        if (code === 'UR100') setError('JY08');
+        else if (errorCode.includes(code)) alert(errorMessage[code]);
+        else setError('JY08');
+      } else setError('JY08');
       resetModal();
     }
   }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 프로필 이미지 수정 api 연결했습니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->

프로필 이미지 변경이 가능합니다 ^_^

이미지 확장자를 이미지 압축 과정에서 바꾸고 있긴 한데 (아마도 이러한 이유로 관리자에서 직접 유저 이미지를 바꿀 때에는 선택할 수 있는 이미지 타입에 제한을 두지 않았던 것 같네요..) 아직 이 과정이 괜찮은 방법인지, 예상대로 동작하는건지 잘 모르겠어서 일단 여기서는 선택할 수 있는 이미지 타입을 jpeg만으로 제한해두었습니다.
 
## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
