### PR TITLE
[GGFE-246] 일반랭커 트로피에 티어 표시 제거

### DIFF
--- a/components/rank/topRank/RankListItemMain.tsx
+++ b/components/rank/topRank/RankListItemMain.tsx
@@ -49,11 +49,13 @@ export default function RankListItemMain({
                   size={50}
                 />
                 <div className={`${styles.tierImageId}`}>
-                  <PlayerImage
-                    src={tierImage}
-                    styleName={'ranktier'}
-                    size={10}
-                  />
+                  {Mode == 'RANK' && (
+                    <PlayerImage
+                      src={tierImage}
+                      styleName={'ranktier'}
+                      size={10}
+                    />
+                  )}
                   {intraId}
                 </div>
               </Link>

--- a/components/rank/topRank/RankListItemMain.tsx
+++ b/components/rank/topRank/RankListItemMain.tsx
@@ -49,7 +49,7 @@ export default function RankListItemMain({
                   size={50}
                 />
                 <div className={`${styles.tierImageId}`}>
-                  {Mode == 'RANK' && (
+                  {Mode === 'RANK' && (
                     <PlayerImage
                       src={tierImage}
                       styleName={'ranktier'}

--- a/styles/rank/RankListMain.module.scss
+++ b/styles/rank/RankListMain.module.scss
@@ -276,9 +276,13 @@
   span {
     cursor: pointer;
   }
+  a {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
   .tierImageId {
     display: flex;
-    flex-direction: row;
     align-items: center;
     justify-content: center;
   }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 일반랭커인경우 티어표시되는 문제 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 일반랭커인경우 (트로피에) 티어표시가 안되게 수정했습니다.
  - 이름이 너무 길경우 가운데 정렬이 안되는 부분 수정했습니다.
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
