### PR TITLE
[GGFE-242] 확성기 데이터 로딩 문구 수정

### DIFF
--- a/components/modal/store/inventory/EditMegaphoneModal.tsx
+++ b/components/modal/store/inventory/EditMegaphoneModal.tsx
@@ -26,7 +26,7 @@ const caution = [
   '삭제한 확성기는 다시 복구할 수 없습니다.',
 ];
 
-const failMessage = '확성기 데이터를 불러오는데 실패했습니다.';
+const loadingMessage = '확성기 불러오는 중... ᪤ࡇ᪤';
 
 const errorCode = ['ME200', 'RC500', 'RC200'] as const;
 
@@ -97,7 +97,7 @@ export default function EditMegaphoneModal({ receiptId }: EditMegaphoneProps) {
           <div className={styles.sectionTitle}>미리보기</div>
           <MegaphoneItem
             content={
-              megaphoneData.content === '' ? failMessage : megaphoneData.content
+              megaphoneData.content ? megaphoneData.content : loadingMessage
             }
             intraId={user.intraId}
           />


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 확성기 데이터 기본 문구를 ‘오류’로 해서 로딩 전에도 ‘오류’문구가 떠서 어색한 문제 해결
 
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->

기존에는 `content  === ''` 인 경우에 `failMessage`를 띄우게 했었는데요.
데이터 로딩이 실패하는 경우에는 `setError`로 에러 페이지로 리다이렉트 되도록 처리되어있어서 실제로 에러가 발생했을 때 `failMessage`를 보는 상황이 없었습니다.
그래서 `failMessage` 대신 `loadingMessage`로 변경해서 실제 데이터 로드 전에 로딩 메시지를 띄우도록 했습니다.

 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
