### PR TITLE
[GGFE-254] 상점 모달 에러 메시지 정리 및 기타 수정

### DIFF
--- a/components/error/Error.tsx
+++ b/components/error/Error.tsx
@@ -1,9 +1,17 @@
+import { useEffect } from 'react';
+import { useResetRecoilState } from 'recoil';
 import useErrorPage from 'hooks/error/useErrorPage';
 import styles from 'styles/Error.module.scss';
 import ErrorEmoji from '/public/image/error_face.svg';
+import { modalState } from 'utils/recoil/modal';
 
 export default function ErrorPage() {
   const { error, goHome } = useErrorPage();
+  const resetModal = useResetRecoilState(modalState);
+
+  useEffect(() => {
+    resetModal();
+  }, []);
 
   return (
     <div className={styles.container}>

--- a/components/modal/store/purchase/BuyModal.tsx
+++ b/components/modal/store/purchase/BuyModal.tsx
@@ -5,6 +5,7 @@ import { instance, isAxiosError } from 'utils/axios';
 import { errorState } from 'utils/recoil/error';
 import { modalState } from 'utils/recoil/modal';
 import { updateCoinState } from 'utils/recoil/updateCoin';
+import { PURCHASE_ALERT_MESSAGE } from 'constants/store/purchaseAlertMessage';
 import {
   ModalButtonContainer,
   ModalButton,
@@ -28,19 +29,20 @@ export default function BuyModal({ itemId, product, price }: PriceTag) {
     code: errorCodeType;
   };
 
+  const { COMMON, BUY } = PURCHASE_ALERT_MESSAGE;
   const errorMessages: Record<errorCodeType, string> = {
-    IT100: '해당 아이템이 없습니다 (• ᴖ •｡)',
-    IT201: '지금은 구매할 수 없는 아이템입니다 (• ᴖ •｡)',
-    IT202: 'GG코인이 부족합니다 (• ᴖ •｡)',
-    IT203: '카카오 유저는 상점을 이용할 수 없습니다 (• ᴖ •｡)',
-    UR100: 'USER NOT FOUND',
+    IT100: COMMON.ITEM_ERROR,
+    IT201: COMMON.OUTDATED_ERROR,
+    IT202: COMMON.COIN_ERROR,
+    IT203: COMMON.KAKAO_USER_ERROR,
+    UR100: BUY.USER_ERROR,
   };
 
   const onPurchase = async () => {
     setIsLoading(true);
     try {
       await instance.post(`/pingpong/items/purchases/${itemId}`, null);
-      alert(`구매 성공 ¡¡¡( •̀ ᴗ •́ )و!!!`);
+      alert(BUY.SUCCESS);
       updateCoin(true);
       setIsLoading(false);
     } catch (error: unknown) {

--- a/components/modal/store/purchase/GiftModal.tsx
+++ b/components/modal/store/purchase/GiftModal.tsx
@@ -108,7 +108,7 @@ export default function GiftModal({ itemId, product, price }: PriceTag) {
           </div>
         )}
         <div className={styles.warning}>
-          <p>⚠ 선물한 아이템은 환불 및 취소가 불가합니다 ⚠</p>
+          <p>⚠ 선물은 환불 및 취소가 불가합니다 ⚠</p>
         </div>
       </div>
       <ModalButtonContainer>

--- a/components/modal/store/purchase/GiftModal.tsx
+++ b/components/modal/store/purchase/GiftModal.tsx
@@ -6,6 +6,7 @@ import { instance, isAxiosError } from 'utils/axios';
 import { errorState } from 'utils/recoil/error';
 import { modalState } from 'utils/recoil/modal';
 import { updateCoinState } from 'utils/recoil/updateCoin';
+import { PURCHASE_ALERT_MESSAGE } from 'constants/store/purchaseAlertMessage';
 import {
   ModalButtonContainer,
   ModalButton,
@@ -40,24 +41,26 @@ export default function GiftModal({ itemId, product, price }: PriceTag) {
     code: errorCodeType;
   };
 
+  const { COMMON, GIFT } = PURCHASE_ALERT_MESSAGE;
+
   const errorMessages: Record<errorCodeType, string> = {
-    IT100: '해당 아이템이 없습니다 (• ᴖ •｡)',
-    IT201: '지금은 구매할 수 없는 아이템입니다 (• ᴖ •｡)',
-    IT202: 'GG코인이 부족합니다 (• ᴖ •｡)',
-    IT203: '카카오 유저는 상점을 이용할 수 없습니다 (• ᴖ •｡)',
-    IT204: '카카오 유저에게는 선물할 수 없습니다 (• ᴖ •｡)',
-    UR100: '선물하려는 유저가 없습니다 (• ᴖ •｡)',
+    IT100: COMMON.ITEM_ERROR,
+    IT201: COMMON.OUTDATED_ERROR,
+    IT202: COMMON.COIN_ERROR,
+    IT203: COMMON.KAKAO_USER_ERROR,
+    IT204: GIFT.KAKAO_RECIPIENT_ERROR,
+    UR100: GIFT.RECIPIENT_ERROR,
   };
 
   const onPurchase = async () => {
     if (giftReqData.ownerId === '') {
-      alert('선물할 유저를 선택해주세요.');
+      alert(GIFT.EMPTY_RECIPIENT);
       return;
     }
     setIsLoading(true);
     try {
       await instance.post(`/pingpong/items/gift/${itemId}`, giftReqData);
-      alert(`${giftReqData.ownerId}님께 선물이 전달되었습니다 (◞ꈍ∇ꈍ)っ■`);
+      alert(`(◞ꈍ∇ꈍ)っ■ ${giftReqData.ownerId}님께 선물이 전달되었습니다`);
       updateCoin(true);
       setIsLoading(false);
     } catch (error: unknown) {

--- a/components/store/InventoryList.tsx
+++ b/components/store/InventoryList.tsx
@@ -7,7 +7,7 @@ import { InvetoryItem } from 'components/store/InventoryItem';
 import styles from 'styles/store/Inventory.module.scss';
 
 function fetchInventoryData(page: number) {
-  if (page === null) page = 0;
+  if (page === null) page = 1;
   return instance.get(`/pingpong/items?page=${page}&size=${8}`).then((res) => {
     return res.data;
   });

--- a/constants/store/purchaseAlertMessage.ts
+++ b/constants/store/purchaseAlertMessage.ts
@@ -1,0 +1,20 @@
+const SAD_EMOJI = '(｡•́︿•̀｡)' + ' ';
+const HAPPY_EMOJI = '¡¡¡( •̀ ᴗ •́ )و!!!' + ' ';
+
+export const PURCHASE_ALERT_MESSAGE = {
+  COMMON: {
+    ITEM_ERROR: SAD_EMOJI + '해당 아이템이 없습니다.',
+    OUTDATED_ERROR: SAD_EMOJI + '지금은 구매할 수 없는 아이템입니다.',
+    COIN_ERROR: SAD_EMOJI + 'GG코인이 부족합니다.',
+    KAKAO_USER_ERROR: SAD_EMOJI + '카카오 유저는 상점을 이용할 수 없습니다.',
+  },
+  BUY: {
+    SUCCESS: HAPPY_EMOJI + '구매 완료',
+    USER_ERROR: 'USER NOT FOUND',
+  },
+  GIFT: {
+    EMPTY_RECIPIENT: SAD_EMOJI + '선물할 유저를 선택해주세요.',
+    RECIPIENT_ERROR: SAD_EMOJI + '선물하려는 유저가 없습니다',
+    KAKAO_RECIPIENT_ERROR: SAD_EMOJI + '카카오 유저에게는 선물할 수 없습니다.',
+  },
+};

--- a/styles/common.scss
+++ b/styles/common.scss
@@ -271,7 +271,6 @@ $text-shadow-blue: 2px 2px 0px $pp-blue;
   position: relative;
   width: $size;
   height: $size;
-  background: linear-gradient(to right bottom, $g1-top, $g1-bottom);
   border-radius: 50%;
   img {
     border-radius: 50%;

--- a/styles/modal/store/CoinHistoryDetails.module.scss
+++ b/styles/modal/store/CoinHistoryDetails.module.scss
@@ -24,6 +24,7 @@
     .content {
       .history {
         color: black;
+        word-break: keep-all;
       }
       .date {
         font-size: 0.8rem;


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 상점 모달 에러 메시지 정리 및 기타 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
### 구매, 선물 모달 수정 사항
  - 상점 에러메시지를 purchaseAlertMessage에 정리했습니다
  - 선물 모달 주의사항 문구가 길어서 수정했습니다
  
### 그 외 수정 사항
  - 에러 페이지에서 resetModal을 호출해 모달을 끄도록 했습니다.
  - 보관함 무한 스크롤에서 page가 null일 때 에러를 page=1로 수정해서 해결했습니다
  - 코인 내역 히스토리에 단어기준 줄바꿈 적용했습니다

 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
