### PR TITLE
[GGFE-259] 보관함 모달 제목 수정 및 엣지 미리보기 이름 추가

### DIFF
--- a/components/modal/store/UserCoinHistoryModal.tsx
+++ b/components/modal/store/UserCoinHistoryModal.tsx
@@ -48,8 +48,9 @@ export default function UserCoinHistoryModal({ coin }: ICoin) {
     } catch (e) {
       setError('HB06');
       closeModal();
+    } finally {
+      setIsLoading(false);
     }
-    setIsLoading(false);
   };
 
   return (

--- a/components/modal/store/inventory/BackgroundPreview.tsx
+++ b/components/modal/store/inventory/BackgroundPreview.tsx
@@ -4,7 +4,7 @@ import styles from 'styles/modal/store/BackgroundPreview.module.scss';
 export default function BackgroundPreview({
   background,
 }: {
-  background: string;
+  background: RandomColors;
 }) {
   const colorList = new Map<RandomColors, BackgroundColors>([
     ['BASIC', 'BASIC'],
@@ -32,9 +32,7 @@ export default function BackgroundPreview({
         className={`${styles['player']}
       ${styles[background.toLowerCase()]}`}
       ></div>
-      <div className={styles.colorName}>
-        {colorList.get(background as RandomColors)}
-      </div>
+      <div className={styles.colorName}>{colorList.get(background)}</div>
     </div>
   );
 }

--- a/components/modal/store/inventory/ChangeIdColorModal.tsx
+++ b/components/modal/store/inventory/ChangeIdColorModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useResetRecoilState, useSetRecoilState } from 'recoil';
-import { UseItemRequest, UseIdColorRequest } from 'types/inventoryTypes';
+import { UseIdColorRequest, UseItemData } from 'types/inventoryTypes';
 import { instance, isAxiosError } from 'utils/axios';
 import { errorState } from 'utils/recoil/error';
 import { modalState } from 'utils/recoil/modal';
@@ -15,7 +15,7 @@ import { ItemCautionContainer } from 'components/modal/store/inventory/ItemCauti
 import { useUser } from 'hooks/Layout/useUser';
 import styles from 'styles/modal/store/InventoryModal.module.scss';
 
-type ChangeIdColorModalProps = UseItemRequest;
+type ChangeIdColorModalProps = UseItemData;
 
 // TODO : 주의사항 구체화 필요
 const caution = [
@@ -54,6 +54,7 @@ const errorMessages: Record<errorCodeType, string> = {
 
 export default function ChangeIdColorModal({
   receiptId,
+  itemName,
 }: ChangeIdColorModalProps) {
   const setError = useSetRecoilState(errorState);
   const resetModal = useResetRecoilState(modalState);
@@ -93,7 +94,7 @@ export default function ChangeIdColorModal({
 
   return (
     <div className={styles.container}>
-      <div className={styles.title}>아이디 색상 변경</div>
+      <div className={styles.title}>{itemName}</div>
       <div className={styles.phrase}>
         <div className={styles.section}>
           <div className={styles.sectionTitle}>미리보기</div>

--- a/components/modal/store/inventory/ChangeIdColorModal.tsx
+++ b/components/modal/store/inventory/ChangeIdColorModal.tsx
@@ -15,8 +15,6 @@ import { ItemCautionContainer } from 'components/modal/store/inventory/ItemCauti
 import { useUser } from 'hooks/Layout/useUser';
 import styles from 'styles/modal/store/InventoryModal.module.scss';
 
-type ChangeIdColorModalProps = UseItemData;
-
 // TODO : 주의사항 구체화 필요
 const caution = [
   '아이템을 사용한 후에는 취소가 불가능합니다.',
@@ -55,7 +53,7 @@ const errorMessages: Record<errorCodeType, string> = {
 export default function ChangeIdColorModal({
   receiptId,
   itemName,
-}: ChangeIdColorModalProps) {
+}: UseItemData) {
   const setError = useSetRecoilState(errorState);
   const resetModal = useResetRecoilState(modalState);
   // const user = useRecoilValue(userState);

--- a/components/modal/store/inventory/ChangeProfileBackgroundModal.tsx
+++ b/components/modal/store/inventory/ChangeProfileBackgroundModal.tsx
@@ -15,8 +15,6 @@ import GachaBall from 'components/modal/store/inventory/GachaBall';
 import { ItemCautionContainer } from 'components/modal/store/inventory/ItemCautionContainer';
 import styles from 'styles/modal/store/InventoryModal.module.scss';
 
-type ChangeProfileBackgroundModalProps = UseItemData;
-
 const caution = [
   '색상은 랜덤으로 결정됩니다.',
   '아이템을 사용한 후에는 취소가 불가능합니다.',
@@ -45,7 +43,7 @@ const errorMessages: Record<errorCodeType, string> = {
 export default function ChangeProfileBackgroundModal({
   receiptId,
   itemName,
-}: ChangeProfileBackgroundModalProps) {
+}: UseItemData) {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const resetModal = useResetRecoilState(modalState);
   const setModal = useSetRecoilState<Modal>(modalState);

--- a/components/modal/store/inventory/ChangeProfileBackgroundModal.tsx
+++ b/components/modal/store/inventory/ChangeProfileBackgroundModal.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useQueryClient } from 'react-query';
 import { useResetRecoilState, useSetRecoilState } from 'recoil';
-import { UseItemRequest } from 'types/inventoryTypes';
+import { UseItemData, UseItemRequest } from 'types/inventoryTypes';
 import { Modal } from 'types/modalTypes';
 import { instance, isAxiosError } from 'utils/axios';
 import { errorState } from 'utils/recoil/error';
@@ -15,7 +15,7 @@ import GachaBall from 'components/modal/store/inventory/GachaBall';
 import { ItemCautionContainer } from 'components/modal/store/inventory/ItemCautionContainer';
 import styles from 'styles/modal/store/InventoryModal.module.scss';
 
-type ChangeProfileBackgroundModalProps = UseItemRequest;
+type ChangeProfileBackgroundModalProps = UseItemData;
 
 const caution = [
   '색상은 랜덤으로 결정됩니다.',
@@ -44,6 +44,7 @@ const errorMessages: Record<errorCodeType, string> = {
 
 export default function ChangeProfileBackgroundModal({
   receiptId,
+  itemName,
 }: ChangeProfileBackgroundModalProps) {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const resetModal = useResetRecoilState(modalState);
@@ -89,7 +90,7 @@ export default function ChangeProfileBackgroundModal({
 
   return (
     <div className={styles.container}>
-      <div className={styles.title}>프로필 배경색 변경</div>
+      <div className={styles.title}>{itemName}</div>
       <div className={styles.phrase}>
         <div className={styles.section}>
           <div className={styles.sectionTitle}></div>

--- a/components/modal/store/inventory/ChangeProfileEdgeModal.tsx
+++ b/components/modal/store/inventory/ChangeProfileEdgeModal.tsx
@@ -15,8 +15,6 @@ import GachaBall from 'components/modal/store/inventory/GachaBall';
 import { ItemCautionContainer } from 'components/modal/store/inventory/ItemCautionContainer';
 import styles from 'styles/modal/store/InventoryModal.module.scss';
 
-type ChangeProfileEdgeModalProps = UseItemData;
-
 const caution = [
   '색상은 랜덤으로 결정됩니다.',
   '아이템을 사용한 후에는 취소가 불가능합니다.',
@@ -45,7 +43,7 @@ const errorMessages: Record<errorCodeType, string> = {
 export default function ChangeProfileEdgeModal({
   receiptId,
   itemName,
-}: ChangeProfileEdgeModalProps) {
+}: UseItemData) {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const resetModal = useResetRecoilState(modalState);
   const setModal = useSetRecoilState<Modal>(modalState);

--- a/components/modal/store/inventory/ChangeProfileEdgeModal.tsx
+++ b/components/modal/store/inventory/ChangeProfileEdgeModal.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useQueryClient } from 'react-query';
 import { useResetRecoilState, useSetRecoilState } from 'recoil';
-import { UseItemRequest } from 'types/inventoryTypes';
+import { UseItemData, UseItemRequest } from 'types/inventoryTypes';
 import { Modal } from 'types/modalTypes';
 import { instance, isAxiosError } from 'utils/axios';
 import { errorState } from 'utils/recoil/error';
@@ -15,7 +15,7 @@ import GachaBall from 'components/modal/store/inventory/GachaBall';
 import { ItemCautionContainer } from 'components/modal/store/inventory/ItemCautionContainer';
 import styles from 'styles/modal/store/InventoryModal.module.scss';
 
-type ChangeProfileEdgeModalProps = UseItemRequest;
+type ChangeProfileEdgeModalProps = UseItemData;
 
 const caution = [
   '색상은 랜덤으로 결정됩니다.',
@@ -44,6 +44,7 @@ const errorMessages: Record<errorCodeType, string> = {
 
 export default function ChangeProfileEdgeModal({
   receiptId,
+  itemName,
 }: ChangeProfileEdgeModalProps) {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const resetModal = useResetRecoilState(modalState);
@@ -90,7 +91,7 @@ export default function ChangeProfileEdgeModal({
 
   return (
     <div className={styles.container}>
-      <div className={styles.title}>프로필 이미지띠 변경</div>
+      <div className={styles.title}>{itemName}</div>
       <div className={styles.phrase}>
         <div className={styles.section}>
           <div className={styles.sectionTitle}></div>

--- a/components/modal/store/inventory/EdgePreview.tsx
+++ b/components/modal/store/inventory/EdgePreview.tsx
@@ -23,21 +23,17 @@ const edgeColorList = new Map<RandomColors, EdgeColors>([
   ['COLOR16', 'GAGARIN VIEW'],
 ]);
 
-export default function EdgePreview({ edge }: { edge: string }) {
+export default function EdgePreview({ edge }: { edge: RandomColors }) {
   const user = useUser();
 
   if (!user) return null;
 
   const { userImageUri } = user;
 
-  // TEST용 -> 추후 삭제
-  // edge = 'COLOR1';
   return (
     <div className={styles.container}>
       <div className={styles.preview}>
-        <div className={styles.title}>
-          {edgeColorList.get(edge as RandomColors)}
-        </div>
+        <div className={styles.title}>{edgeColorList.get(edge)}</div>
         <PlayerImage
           src={userImageUri}
           styleName={`mainProfile ${edge.toLowerCase()}`}

--- a/components/modal/store/inventory/EdgePreview.tsx
+++ b/components/modal/store/inventory/EdgePreview.tsx
@@ -1,6 +1,27 @@
+import { EdgeColors, RandomColors } from 'types/colorModeTypes';
 import PlayerImage from 'components/PlayerImage';
 import { useUser } from 'hooks/Layout/useUser';
 import styles from 'styles/modal/store/EdgePreview.module.scss';
+
+const edgeColorList = new Map<RandomColors, EdgeColors>([
+  ['BASIC', 'BASIC'],
+  ['COLOR1', 'RICH METAL'],
+  ['COLOR2', 'FRUIT BLEND'],
+  ['COLOR3', 'SEASHORE'],
+  ['COLOR4', 'GROWN EARLY'],
+  ['COLOR5', 'FLYING LEMON'],
+  ['COLOR6', 'NIGHT SKY'],
+  ['COLOR7', 'HIGHFLIGHT'],
+  ['COLOR8', 'FABLED SUNSET'],
+  ['COLOR9', 'MORNING VIBE'],
+  ['COLOR10', 'NEON GREEN'],
+  ['COLOR11', 'MAGIC PINK'],
+  ['COLOR12', 'SOFT CHERISH'],
+  ['COLOR13', 'PALO ALTO'],
+  ['COLOR14', 'TWILIGHT'],
+  ['COLOR15', 'NORTH MIRACLE'],
+  ['COLOR16', 'GAGARIN VIEW'],
+]);
 
 export default function EdgePreview({ edge }: { edge: string }) {
   const user = useUser();
@@ -9,9 +30,14 @@ export default function EdgePreview({ edge }: { edge: string }) {
 
   const { userImageUri } = user;
 
+  // TEST용 -> 추후 삭제
+  // edge = 'COLOR1';
   return (
     <div className={styles.container}>
       <div className={styles.preview}>
+        <div className={styles.title}>
+          {edgeColorList.get(edge as RandomColors)}
+        </div>
         <PlayerImage
           src={userImageUri}
           styleName={`mainProfile ${edge.toLowerCase()}`}

--- a/components/modal/store/inventory/EditMegaphoneModal.tsx
+++ b/components/modal/store/inventory/EditMegaphoneModal.tsx
@@ -15,8 +15,6 @@ import { useUser } from 'hooks/Layout/useUser';
 import useAxiosGet from 'hooks/useAxiosGet';
 import styles from 'styles/modal/store/InventoryModal.module.scss';
 
-type EditMegaphoneProps = UseItemRequest;
-
 type MegaphoneData = {
   megaphoneId: number;
   content: string;
@@ -47,7 +45,7 @@ const errorMessages: Record<errorCodeType, string> = {
   RC200: EDIT_MEGAPHONE.ITEM_ERROR,
 };
 
-export default function EditMegaphoneModal({ receiptId }: EditMegaphoneProps) {
+export default function EditMegaphoneModal({ receiptId }: UseItemRequest) {
   const resetModal = useResetRecoilState(modalState);
   const user = useUser();
   const [megaphoneData, setMegaphoneData] = useState<MegaphoneData>({

--- a/components/modal/store/inventory/EditMegaphoneModal.tsx
+++ b/components/modal/store/inventory/EditMegaphoneModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useResetRecoilState, useSetRecoilState } from 'recoil';
-import { UseItemRequest } from 'types/inventoryTypes';
+import { UseItemData } from 'types/inventoryTypes';
 import { instance, isAxiosError } from 'utils/axios';
 import { errorState } from 'utils/recoil/error';
 import { modalState } from 'utils/recoil/modal';
@@ -45,7 +45,7 @@ const errorMessages: Record<errorCodeType, string> = {
   RC200: EDIT_MEGAPHONE.ITEM_ERROR,
 };
 
-export default function EditMegaphoneModal({ receiptId }: UseItemRequest) {
+export default function EditMegaphoneModal({ receiptId }: UseItemData) {
   const resetModal = useResetRecoilState(modalState);
   const user = useUser();
   const [megaphoneData, setMegaphoneData] = useState<MegaphoneData>({

--- a/components/modal/store/inventory/GachaModal.tsx
+++ b/components/modal/store/inventory/GachaModal.tsx
@@ -1,4 +1,5 @@
 import { useResetRecoilState } from 'recoil';
+import { IRandomItem } from 'types/modalTypes';
 import { modalState } from 'utils/recoil/modal';
 import {
   ModalButtonContainer,
@@ -9,12 +10,7 @@ import EdgePreview from 'components/modal/store/inventory/EdgePreview';
 import GachaConfetti from 'components/modal/store/inventory/GachaConfetti';
 import styles from 'styles/modal/store/GachaModal.module.scss';
 
-type GachaModalProps = {
-  item: string;
-  color: string;
-};
-
-export default function GachaModal({ item, color }: GachaModalProps) {
+export default function GachaModal({ item, color }: IRandomItem) {
   const resetModal = useResetRecoilState(modalState);
   const randomBall = 'ball' + Math.floor(Math.random() * 11).toString();
 

--- a/components/modal/store/inventory/NewMegaphoneModal.tsx
+++ b/components/modal/store/inventory/NewMegaphoneModal.tsx
@@ -14,8 +14,6 @@ import { ItemCautionContainer } from 'components/modal/store/inventory/ItemCauti
 import { useUser } from 'hooks/Layout/useUser';
 import styles from 'styles/modal/store/InventoryModal.module.scss';
 
-type NewMegaphoneProps = UseItemRequest;
-
 const MAX_LENGTH = 30;
 
 // TODO : 주의사항 구체화 필요
@@ -54,7 +52,7 @@ const errorMessages: Record<errorCodeType, string> = {
   CM007: MEGAPHONE.FORMAT_ERROR,
 };
 
-export default function NewMegaphoneModal({ receiptId }: NewMegaphoneProps) {
+export default function NewMegaphoneModal({ receiptId }: UseItemRequest) {
   const user = useUser();
   const [content, setContent] = useState('');
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/components/modal/store/inventory/NewMegaphoneModal.tsx
+++ b/components/modal/store/inventory/NewMegaphoneModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useResetRecoilState, useSetRecoilState } from 'recoil';
-import { UseItemRequest, UseMegaphoneRequest } from 'types/inventoryTypes';
+import { UseItemData, UseMegaphoneRequest } from 'types/inventoryTypes';
 import { instance, isAxiosError } from 'utils/axios';
 import { errorState } from 'utils/recoil/error';
 import { modalState } from 'utils/recoil/modal';
@@ -52,7 +52,7 @@ const errorMessages: Record<errorCodeType, string> = {
   CM007: MEGAPHONE.FORMAT_ERROR,
 };
 
-export default function NewMegaphoneModal({ receiptId }: UseItemRequest) {
+export default function NewMegaphoneModal({ receiptId }: UseItemData) {
   const user = useUser();
   const [content, setContent] = useState('');
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/components/modal/store/inventory/ProfileImageModal.tsx
+++ b/components/modal/store/inventory/ProfileImageModal.tsx
@@ -18,8 +18,6 @@ import useUploadImg from 'hooks/useUploadImg';
 import styles from 'styles/modal/store/InventoryModal.module.scss';
 import { ItemCautionContainer } from './ItemCautionContainer';
 
-type ProfileImageProps = UseItemData;
-
 // TODO : 주의사항 문구 확정 필요
 const cautions = [
   '변경한 프로필 이미지는 취소할 수 없습니다.',
@@ -63,7 +61,7 @@ const errorMessage: Record<errorCodeType, string> = {
 export default function ProfileImageModal({
   receiptId,
   itemName,
-}: ProfileImageProps) {
+}: UseItemData) {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const setError = useSetRecoilState(errorState);
   const user = useUser();

--- a/components/modal/store/inventory/ProfileImageModal.tsx
+++ b/components/modal/store/inventory/ProfileImageModal.tsx
@@ -4,7 +4,7 @@ import { useQueryClient } from 'react-query';
 import { useResetRecoilState, useSetRecoilState } from 'recoil';
 import { FaArrowRight } from 'react-icons/fa';
 import { TbQuestionMark } from 'react-icons/tb';
-import { UseItemRequest } from 'types/inventoryTypes';
+import { UseItemData } from 'types/inventoryTypes';
 import { instance, isAxiosError } from 'utils/axios';
 import { errorState } from 'utils/recoil/error';
 import { modalState } from 'utils/recoil/modal';
@@ -18,7 +18,7 @@ import useUploadImg from 'hooks/useUploadImg';
 import styles from 'styles/modal/store/InventoryModal.module.scss';
 import { ItemCautionContainer } from './ItemCautionContainer';
 
-type ProfileImageProps = UseItemRequest;
+type ProfileImageProps = UseItemData;
 
 // TODO : 주의사항 문구 확정 필요
 const cautions = [
@@ -60,7 +60,10 @@ const errorMessage: Record<errorCodeType, string> = {
   UR402: PROFILE.FORMAT_ERROR,
 };
 
-export default function ProfileImageModal({ receiptId }: ProfileImageProps) {
+export default function ProfileImageModal({
+  receiptId,
+  itemName,
+}: ProfileImageProps) {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const setError = useSetRecoilState(errorState);
   const user = useUser();
@@ -109,7 +112,7 @@ export default function ProfileImageModal({ receiptId }: ProfileImageProps) {
 
   return (
     <div className={styles.container}>
-      <div className={styles.title}>프로필 이미지 변경</div>
+      <div className={styles.title}>{itemName}</div>
       <div className={styles.phrase}>
         <div className={styles.section}>
           <form

--- a/components/store/InventoryItem.tsx
+++ b/components/store/InventoryItem.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import { SyntheticEvent } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { BsGiftFill, BsCircleFill } from 'react-icons/bs';
 import { Tooltip } from '@mui/material';
@@ -58,6 +59,10 @@ export function InvetoryItem({ item }: inventoryItemProps) {
     itemStatus === 'USING' ? handleEditItem() : handleUseItem();
   }
 
+  const handleImageError = (e: SyntheticEvent<HTMLImageElement>) => {
+    e.currentTarget.src = '/image/not_found.svg';
+  };
+
   if (!user) return null;
 
   return (
@@ -91,8 +96,9 @@ export function InvetoryItem({ item }: inventoryItemProps) {
         <div className={styles.imgContainer}>
           <Image
             className={styles.img}
-            src={imageUri === null ? '/image/not_found.svg' : imageUri}
+            src={imageUri ? imageUri : '/image/not_found.svg'}
             alt={itemName}
+            onError={handleImageError}
             fill
           />
         </div>

--- a/components/store/InventoryItem.tsx
+++ b/components/store/InventoryItem.tsx
@@ -90,7 +90,7 @@ export function InvetoryItem({ item }: inventoryItemProps) {
         <div className={styles.imgContainer}>
           <Image
             className={styles.img}
-            src={imageUri === null ? '/image/fallBackSrc.jpeg' : imageUri}
+            src={imageUri === null ? '/image/not_found.svg' : imageUri}
             alt={itemName}
             fill
           />

--- a/components/store/InventoryItem.tsx
+++ b/components/store/InventoryItem.tsx
@@ -35,6 +35,7 @@ export function InvetoryItem({ item }: inventoryItemProps) {
       modalName: `USE-ITEM-${item.itemType}`,
       useItemInfo: {
         receiptId: item.receiptId,
+        itemName: item.itemName,
       },
     });
   }

--- a/components/store/InventoryList.tsx
+++ b/components/store/InventoryList.tsx
@@ -7,7 +7,6 @@ import { InvetoryItem } from 'components/store/InventoryItem';
 import styles from 'styles/store/Inventory.module.scss';
 
 function fetchInventoryData(page: number) {
-  if (page === null) page = 1;
   return instance.get(`/pingpong/items?page=${page}&size=${8}`).then((res) => {
     return res.data;
   });

--- a/components/store/purchase/ItemCard.tsx
+++ b/components/store/purchase/ItemCard.tsx
@@ -44,7 +44,7 @@ export default function ItemCard({ item }: { item: Item }) {
       <div className={styles.preview}>
         <div className={styles.img}>
           <Image
-            src={item.imageUri}
+            src={item.imageUri ? item.imageUri : '/image/not_found.svg'}
             alt={item.itemName}
             onError={handleImageError}
             fill

--- a/styles/ProfileColor.scss
+++ b/styles/ProfileColor.scss
@@ -4,11 +4,7 @@ $edge-neon-green: linear-gradient(to right bottom, #a8ff78 30%, #78ffd6 70%);
 $edge-orange-red: linear-gradient(to right bottom, #f05053 30%, #e1eec3 70%);
 $edge-red: linear-gradient(to right bottom, #b20a2c 30%, #fffbd5 70%);
 $edge-blue: linear-gradient(to right bottom, #005aa7 30%, #fffde4 70%);
-$edge-pastel-green-blue: linear-gradient(
-  to right bottom,
-  #74ebd5 30%,
-  #acb6e5 70%
-);
+$edge-morning-vibe: linear-gradient(to right bottom, #74ebd5 30%, #acb6e5 70%);
 $edge-navy: linear-gradient(to right bottom, #000c40 30%, #f0f2f0 70%);
 $edge-orange-green: linear-gradient(
   to right bottom,
@@ -28,7 +24,7 @@ $edge-blue-green: linear-gradient(
   #90a5ff 50%,
   #8fffa4 100%
 );
-$edge-pink-blue-purple: linear-gradient(
+$edge-magic-pink: linear-gradient(
   to right bottom,
   #ff10af 0%,
   #8afbff 50%,
@@ -41,7 +37,7 @@ $edge-tropical-green: linear-gradient(
   #ff7700 100%
 );
 
-$edge-navy-green: linear-gradient(
+$edge-night-sky: linear-gradient(
   to right bottom,
   #6ea5ff 0%,
   #000000 50%,
@@ -54,7 +50,7 @@ $edge-green-yellow: linear-gradient(
   #799f0c 50%,
   #ffe000 100%
 );
-$edge-pastel-orange: linear-gradient(
+$edge-twilight: linear-gradient(
   to right bottom,
   #f7797d 0%,
   #fbd786 50%,
@@ -108,18 +104,18 @@ $edge-colors: (
   color4: $edge-grown-early,
   // 4티어
   color5: $edge-flying-lemon,
-  color6: $edge-navy-green,
+  color6: $edge-night-sky,
   color7: $edge-highflight,
   // 3티어
   color8: $edge-fabled-sunset,
-  color9: $edge-pastel-green-blue,
+  color9: $edge-morning-vibe,
   color10: $edge-neon-green,
   // 2티어
-  color11: $edge-pink-blue-purple,
+  color11: $edge-magic-pink,
   color12: $edge-soft-cherish,
   color13: $edge-palo-alto,
   // 1티어
-  color14: $edge-pastel-orange,
+  color14: $edge-twilight,
   color15: $edge-north-miracle,
   color16: $edge-gagarin-view,
 );

--- a/styles/modal/store/EdgePreview.module.scss
+++ b/styles/modal/store/EdgePreview.module.scss
@@ -1,11 +1,19 @@
 .container {
   display: flex;
   justify-content: center;
-  height: 5rem;
   color: white;
   opacity: 0;
   animation: appear 0.5s 3s ease-in-out forwards;
   .preview {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    .title {
+      margin-bottom: 1rem;
+      font-size: 1.5rem;
+      color: #f8f8ff;
+      text-shadow: 0px 0px 12px #ffffff;
+    }
     color: white;
     animation-name: img-poof;
     animation-duration: 0.75s;

--- a/styles/modal/store/GachaModal.module.scss
+++ b/styles/modal/store/GachaModal.module.scss
@@ -39,7 +39,7 @@
 
 .container {
   display: flex;
-  height: 30rem;
+  height: 25rem;
   max-height: 80vh;
   flex-direction: column;
   justify-content: space-evenly;

--- a/types/colorModeTypes.ts
+++ b/types/colorModeTypes.ts
@@ -40,8 +40,30 @@ const backgroundColors = [
   'MEGATRON',
 ] as const;
 
+const edgeColors = [
+  'BASIC',
+  'RICH METAL',
+  'FRUIT BLEND',
+  'SEASHORE',
+  'GROWN EARLY',
+  'FLYING LEMON',
+  'NIGHT SKY',
+  'HIGHFLIGHT',
+  'FABLED SUNSET',
+  'MORNING VIBE',
+  'NEON GREEN',
+  'MAGIC PINK',
+  'SOFT CHERISH',
+  'PALO ALTO',
+  'TWILIGHT',
+  'NORTH MIRACLE',
+  'GAGARIN VIEW',
+] as const;
+
 export type RandomColors = (typeof randomColors)[number];
 
 export type BackgroundColors = (typeof backgroundColors)[number];
+
+export type EdgeColors = (typeof edgeColors)[number];
 
 export type ColorMode = MatchMode | RandomColors;

--- a/types/inventoryTypes.ts
+++ b/types/inventoryTypes.ts
@@ -35,3 +35,7 @@ export type UseMegaphoneRequest = UseItemRequest & {
 export type UseIdColorRequest = UseItemRequest & {
   textColor: string;
 };
+
+export type UseItemData = UseItemRequest & {
+  itemName?: string;
+};

--- a/types/modalTypes.ts
+++ b/types/modalTypes.ts
@@ -4,6 +4,7 @@ import { IFeedback } from 'types/admin/adminFeedbackTypes';
 import { Imegaphone, Iprofile } from 'types/admin/adminReceiptType';
 import { ModifyScoreType } from 'types/admin/gameLogTypes';
 import { CoinResult } from 'types/coinTypes';
+import { RandomColors } from 'types/colorModeTypes';
 import { RandomItem, ItemType, UseItemData } from 'types/inventoryTypes';
 import { Item } from 'types/itemTypes';
 import { MatchMode } from 'types/mainType';
@@ -98,7 +99,7 @@ export interface StoreManual {
 
 export interface IRandomItem {
   item: RandomItem;
-  color: string;
+  color: RandomColors;
 }
 
 export interface Modal {

--- a/types/modalTypes.ts
+++ b/types/modalTypes.ts
@@ -1,11 +1,10 @@
-import { Dispatch, SetStateAction } from 'react';
 import { Value } from 'react-quill';
 import { IcoinPolicy } from 'types/admin/adminCoinTypes';
 import { IFeedback } from 'types/admin/adminFeedbackTypes';
 import { Imegaphone, Iprofile } from 'types/admin/adminReceiptType';
 import { ModifyScoreType } from 'types/admin/gameLogTypes';
 import { CoinResult } from 'types/coinTypes';
-import { RandomItem, ItemType, UseItemRequest } from 'types/inventoryTypes';
+import { RandomItem, ItemType, UseItemData } from 'types/inventoryTypes';
 import { Item } from 'types/itemTypes';
 import { MatchMode } from 'types/mainType';
 import { ISeason } from 'types/seasonTypes';
@@ -123,7 +122,7 @@ export interface Modal {
   profile?: Iprofile;
   item?: Item;
   coinPolicy?: IcoinPolicy;
-  useItemInfo?: UseItemRequest;
+  useItemInfo?: UseItemData;
   storeManual?: StoreManual;
   isAttended?: boolean;
   totalCoin?: ICoin;


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 보관함 모달 제목 수정 및 엣지 미리보기 이름 추가
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 보관함 모달에서 itemName을 받아 제목에 반영했습니다.
  - 확성기 모달은 itemName을 수정할 경우가 없을 것 같아서 건드리지 않았습니다.
  - 엣지 뽑기 미리보기에도 색상 이름을 추가했습니다. EdgePreview 컴포넌트에서 edge를 바꿔가면서 테스트해보실 수 있습니다
  - 보관함 모달에서 이미지가 널일 때 스톰트루퍼 대신 not_found이미지가 뜨도록 수정했습니다
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
