### PR TITLE
[GGFE-260] 보관함 무한스크롤 버그 수정

### DIFF
--- a/components/store/InventoryList.tsx
+++ b/components/store/InventoryList.tsx
@@ -7,7 +7,6 @@ import { InvetoryItem } from 'components/store/InventoryItem';
 import styles from 'styles/store/Inventory.module.scss';
 
 function fetchInventoryData(page: number) {
-  if (page === null) page = 1;
   return instance.get(`/pingpong/items?page=${page}&size=${8}`).then((res) => {
     return res.data;
   });

--- a/utils/infinityScroll.ts
+++ b/utils/infinityScroll.ts
@@ -41,7 +41,7 @@ export function InfinityScroll(
     {
       getNextPageParam: (lastPage, allPages) => {
         const nextPage = allPages.length + 1;
-        return nextPage > lastPage.totalPage ? null : nextPage;
+        return nextPage > lastPage.totalPage ? undefined : nextPage;
       },
       onError: (e: unknown) => {
         if (axios.isAxiosError(e)) {


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 보관함 무한스크롤에서 발생하는 버그를 수정했습니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
마지막 페이지의 마지막 아이템을 사용하는 경우에 해당 페이지가 삭제되고 마지막 페이지가 달라지면서 `page=null`을 요청하는 문제가 있었습니다. 그래서 `page=null`인 경우에 1페이지를 요청하도록 고치기로 해서 #1012 에 같이 올려주셨는데요. 이렇게 고쳤더니 마지막 페이지에 이어서 다시 1페이지를 불러오는 문제가 발생했습니다..

알아보니 이 문제는 `useInfiniteQuery`에서 `pageParam`이 `null`이 아니라 `undefined`인 경우를 마지막 페이지로 판단했기 때문이었어서
`getNextPageParam` 함수에서 마지막 페이지일 경우에 `null`이 아닌 `undefined`를 반환하도록 고쳐서 문제 해결했습니다 
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
