### PR TITLE
[GGFE-263] 상점 로딩 처리

### DIFF
--- a/components/modal/store/UserCoinHistoryModal.tsx
+++ b/components/modal/store/UserCoinHistoryModal.tsx
@@ -19,8 +19,8 @@ export default function UserCoinHistoryModal({ coin }: ICoin) {
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [coinHistoryList, setCoinHistoryList] = useState<ICoinHistoryTable>({
     useCoinList: [],
-    totalPage: 0,
-    currentPage: 0,
+    totalPage: 1,
+    currentPage: 1,
   });
   const setError = useSetRecoilState(errorState);
 

--- a/components/store/InventoryList.tsx
+++ b/components/store/InventoryList.tsx
@@ -4,6 +4,7 @@ import { InfinityScroll } from 'utils/infinityScroll';
 import EmptyImage from 'components/EmptyImage';
 import { InfiniteScrollComponent } from 'components/store/InfiniteScrollComponent';
 import { InvetoryItem } from 'components/store/InventoryItem';
+import StoreLoading from 'components/store/StoreLoading';
 import styles from 'styles/store/Inventory.module.scss';
 
 function fetchInventoryData(page: number) {
@@ -20,7 +21,7 @@ export function InventoryList() {
   );
 
   // TODO : 에러 컴포넌트 구체화 필요함.
-  if (isLoading) return <div>Loading...</div>;
+  if (isLoading) return <StoreLoading />;
   if (error) return <div>{error.message}</div>;
   if (!data) return <div>No data</div>;
 

--- a/components/store/StoreLoading.tsx
+++ b/components/store/StoreLoading.tsx
@@ -1,0 +1,10 @@
+import { RiPingPongFill } from 'react-icons/ri';
+import styles from 'styles/store/Inventory.module.scss';
+
+export default function StoreLoading() {
+  return (
+    <div className={styles.loadIcon}>
+      <RiPingPongFill />
+    </div>
+  );
+}

--- a/components/store/purchase/ItemsList.tsx
+++ b/components/store/purchase/ItemsList.tsx
@@ -1,25 +1,31 @@
-import { useEffect, useState } from 'react';
+import { useQuery } from 'react-query';
+import { useSetRecoilState } from 'recoil';
 import { ItemList } from 'types/itemTypes';
+import { instance } from 'utils/axios';
+import { errorState } from 'utils/recoil/error';
 import ItemCard from 'components/store/purchase/ItemCard';
-import useAxiosGet from 'hooks/useAxiosGet';
+import StoreLoading from 'components/store/StoreLoading';
 
 export default function ItemsList() {
-  const [itemList, setItemList] = useState<ItemList>({ itemList: [] });
+  const setError = useSetRecoilState(errorState);
+  const { data, isError, isLoading } = useQuery<ItemList>(
+    'itemList',
+    () => instance.get('/pingpong/items/store').then((res) => res.data),
+    {
+      retry: 1,
+    }
+  );
 
-  useEffect(() => {
-    getItemList();
-  }, []);
+  if (isError) {
+    setError('HB01');
+  }
+  if (isLoading) return <StoreLoading />;
 
-  const getItemList = useAxiosGet({
-    url: 'pingpong/items/store',
-    setState: setItemList,
-    err: 'HB01',
-    type: 'setError',
-  });
+  if (!data) return null;
 
   return (
     <div>
-      {itemList.itemList.map((item) => (
+      {data.itemList.map((item) => (
         <ItemCard key={item.itemId} item={item} />
       ))}
     </div>

--- a/styles/modal/store/CoinHistoryDetails.module.scss
+++ b/styles/modal/store/CoinHistoryDetails.module.scss
@@ -35,5 +35,6 @@
   .section2 {
     display: flex;
     align-items: center;
+    margin-left: 0.3rem;
   }
 }

--- a/styles/modal/store/UserCoinHistoryModal.module.scss
+++ b/styles/modal/store/UserCoinHistoryModal.module.scss
@@ -27,7 +27,11 @@
   }
 
   .loading {
-    margin: 5rem 0;
+    display: flex;
+    width: 85%;
+    height: 30vh;
+    justify-content: center;
+    padding-top: 14vh;
     color: #ffffff;
     .span1 {
       @include waitAnimation(0.3s);


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 상점페이지 로딩 처리
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 상점, 보관함 탭에서 로딩상태일 때 탁구채 이모지 띄우도록 했습니다.
  - 상점 판매 아이템 api 요청 시 로딩처리를 간단히 하기 위해 useQuery 사용하는 것으로 수정했습니다
  - 그 외에 코인 내역 모달에서 로딩 애니메이션 컨테이너 높이를 고정해서 높이가 왔다갔다하지 않도록 수정했습니다.
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
