### PR TITLE
[GGFE-264] modeWrapBasic 내부 요소들 사이에 좌우 간격 추가

### DIFF
--- a/styles/mode/ModeWrap.module.scss
+++ b/styles/mode/ModeWrap.module.scss
@@ -1,6 +1,7 @@
 @mixin modeWrapBasic {
   display: flex;
   justify-content: space-between;
+  gap: 0 10px;
   margin: 0 0.6rem 2rem;
 }
 


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - `modeWrapBasic`의 내부 요소들 사이에 `gap` 속성을 사용해서 좌우 간격을 추가했습니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 모바일 환경에서 game page 위의 검색바와 시즌 드롭다운 사이의 간격이 없이 딱 붙는 문제가 있어 수정했습니다.
  - 크롬 개발자 도구에서는 위의 문제가 발생하지 않아서 정확한 적용 결과는 배포 후에 확인해봐야 할 것 같아요 🥲
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
