### PR TITLE
[GGFE-262] ID 색깔 변경 모달 - 색상 프리뷰 클릭 시 색상 선택기 open close 방식으로 변경

### DIFF
--- a/components/modal/store/inventory/ChangeIdColorModal.tsx
+++ b/components/modal/store/inventory/ChangeIdColorModal.tsx
@@ -100,7 +100,9 @@ export default function ChangeIdColorModal({
         </div>
         <div className={styles.section}>
           <div className={styles.sectionTitle}>색상 선택</div>
-          <ColorPicker color={color} setColor={setColor} />
+          <div className={styles.colorPickerWrapper}>
+            <ColorPicker color={color} setColor={setColor} />
+          </div>
         </div>
         <ItemCautionContainer caution={caution} />
         <ModalButtonContainer>

--- a/components/modal/store/inventory/ChangeIdColorModal.tsx
+++ b/components/modal/store/inventory/ChangeIdColorModal.tsx
@@ -99,7 +99,7 @@ export default function ChangeIdColorModal({
           <IdPreviewComponent intraId={user.intraId} color={color} />
         </div>
         <div className={styles.section}>
-          <div className={styles.sectionTitle}>색상 선택</div>
+          <div className={styles.sectionTitle}>색상 선택 (HEX 코드)</div>
           <div className={styles.colorPickerWrapper}>
             <ColorPicker color={color} setColor={setColor} />
           </div>

--- a/components/modal/store/inventory/ColorPicker.tsx
+++ b/components/modal/store/inventory/ColorPicker.tsx
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction, useCallback, useState } from 'react';
 import { HexColorInput, HexColorPicker } from 'react-colorful';
-import { MdOutlineColorLens } from 'react-icons/md';
+import { MdOutlineColorLens , MdColorLens } from 'react-icons/md';
 import styles from 'styles/modal/store/ColorPicker.module.scss';
 
 type ColorPickerProps = {
@@ -23,7 +23,11 @@ export default function ColorPicker({ color, setColor }: ColorPickerProps) {
           className={styles.colorPreview}
           onClick={pickerHandler}
         >
-          <MdOutlineColorLens className={styles.icon} />
+          {openPicker ? (
+            <MdColorLens className={styles.icon} />
+          ) : (
+            <MdOutlineColorLens className={styles.icon} />
+          )}
         </div>
         <HexColorInput
           color={color}

--- a/components/modal/store/inventory/ColorPicker.tsx
+++ b/components/modal/store/inventory/ColorPicker.tsx
@@ -1,5 +1,6 @@
-import { Dispatch, SetStateAction, useState } from 'react';
+import { Dispatch, SetStateAction, useCallback, useState } from 'react';
 import { HexColorInput, HexColorPicker } from 'react-colorful';
+import { MdOutlineColorLens } from 'react-icons/md';
 import styles from 'styles/modal/store/ColorPicker.module.scss';
 
 type ColorPickerProps = {
@@ -10,20 +11,27 @@ type ColorPickerProps = {
 export default function ColorPicker({ color, setColor }: ColorPickerProps) {
   const [openPicker, setOpenPicker] = useState<boolean>(false);
 
+  const pickerHandler = useCallback(() => {
+    setOpenPicker((prev) => !prev);
+  }, []);
+
   return (
     <>
       <div className={styles.container}>
         <div
           style={{ backgroundColor: color }}
           className={styles.colorPreview}
-          onClick={() => setOpenPicker(!openPicker)}
-        />
+          onClick={pickerHandler}
+        >
+          <MdOutlineColorLens />
+        </div>
         <HexColorInput
           color={color}
           onChange={setColor}
           prefixed
           alpha
           className={styles.colorInput}
+          onClick={pickerHandler}
         />
         {openPicker ? (
           <HexColorPicker

--- a/components/modal/store/inventory/ColorPicker.tsx
+++ b/components/modal/store/inventory/ColorPicker.tsx
@@ -8,12 +8,15 @@ type ColorPickerProps = {
 };
 
 export default function ColorPicker({ color, setColor }: ColorPickerProps) {
+  const [openPicker, setOpenPicker] = useState<boolean>(false);
+
   return (
     <>
       <div className={styles.container}>
         <div
           style={{ backgroundColor: color }}
           className={styles.colorPreview}
+          onClick={() => setOpenPicker(!openPicker)}
         />
         <HexColorInput
           color={color}
@@ -22,12 +25,16 @@ export default function ColorPicker({ color, setColor }: ColorPickerProps) {
           alpha
           className={styles.colorInput}
         />
-        <HexColorPicker
-          color={color}
-          onChange={setColor}
-          className={styles.colorPicker}
-          style={{ width: 'auto' }}
-        />
+        {openPicker ? (
+          <HexColorPicker
+            color={color}
+            onChange={setColor}
+            className={styles.colorPicker}
+            style={{ width: 'auto' }}
+          />
+        ) : (
+          ''
+        )}
       </div>
     </>
   );

--- a/components/modal/store/inventory/ColorPicker.tsx
+++ b/components/modal/store/inventory/ColorPicker.tsx
@@ -23,7 +23,7 @@ export default function ColorPicker({ color, setColor }: ColorPickerProps) {
           className={styles.colorPreview}
           onClick={pickerHandler}
         >
-          <MdOutlineColorLens />
+          <MdOutlineColorLens className={styles.icon} />
         </div>
         <HexColorInput
           color={color}
@@ -40,9 +40,7 @@ export default function ColorPicker({ color, setColor }: ColorPickerProps) {
             className={styles.colorPicker}
             style={{ width: 'auto' }}
           />
-        ) : (
-          ''
-        )}
+        ) : null}
       </div>
     </>
   );

--- a/components/rank/NormalListItem.tsx
+++ b/components/rank/NormalListItem.tsx
@@ -47,12 +47,19 @@ export function NormalListItem({
         }}
         className={styles.intraId}
       >
-        <Link href={`/users/detail?intraId=${intraId}`}>
-          <span>
+        {textColorPreview ? (
+          <div>
             {intraId}
             {level && <span className={styles.level}> ({level})</span>}
-          </span>
-        </Link>
+          </div>
+        ) : (
+          <Link href={`/users/detail?intraId=${intraId}`}>
+            <span>
+              {intraId}
+              {level && <span className={styles.level}> ({level})</span>}
+            </span>
+          </Link>
+        )}
       </div>
       {textColorPreview ? null : (
         <div className={styles.statusMessage}>{statusMessage}</div>

--- a/components/rank/RankListItem.tsx
+++ b/components/rank/RankListItem.tsx
@@ -38,9 +38,13 @@ export function RankListItem({ user, textColorPreview }: RankListItemProps) {
       {rank}
       <PlayerImage src={tierImageUri} styleName={'ranktier'} size={1} />
       <div style={{ color: textColor }} className={styles.intraId}>
-        <Link href={`/users/detail?intraId=${intraId}`}>
-          <span>{intraId}</span>
-        </Link>
+        {textColorPreview ? (
+          <div>{intraId}</div>
+        ) : (
+          <Link href={`/users/detail?intraId=${intraId}`}>
+            <span>{intraId}</span>
+          </Link>
+        )}
       </div>
       {textColorPreview ? null : (
         <div className={styles.statusMessage}>{statusMessage}</div>

--- a/styles/modal/store/ColorPicker.module.scss
+++ b/styles/modal/store/ColorPicker.module.scss
@@ -6,12 +6,21 @@
 }
 
 .colorPreview {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   width: 2rem;
+  height: 2rem;
   padding: 0.5rem;
   cursor: pointer;
   border: 3px solid #fff;
   border-radius: 0.5rem;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+  .icon {
+    width: 1rem;
+    height: 1rem;
+    color: white;
+  }
   &::after {
     display: block;
     padding-bottom: 100%;

--- a/styles/modal/store/ColorPicker.module.scss
+++ b/styles/modal/store/ColorPicker.module.scss
@@ -1,10 +1,12 @@
 .container {
+  position: absolute;
   display: grid;
   grid-template-columns: 1fr 9fr;
   grid-gap: 0.5rem;
 }
 
 .colorPreview {
+  width: 2rem;
   padding: 0.5rem;
   cursor: pointer;
   border: 3px solid #fff;
@@ -18,11 +20,14 @@
 }
 
 .colorInput {
+  font-size: 1rem;
+  text-align: center;
   border: 3px solid #fff;
   border-radius: 0.5rem;
 }
 
 .colorPicker {
+  position: absolute;
   grid-column: 1 / 3;
-  max-height: 8rem;
+  max-height: 10rem;
 }

--- a/styles/modal/store/ColorPicker.module.scss
+++ b/styles/modal/store/ColorPicker.module.scss
@@ -11,7 +11,6 @@
   align-items: center;
   width: 2rem;
   height: 2rem;
-  padding: 0.5rem;
   cursor: pointer;
   border: 3px solid #fff;
   border-radius: 0.5rem;

--- a/styles/modal/store/InventoryModal.module.scss
+++ b/styles/modal/store/InventoryModal.module.scss
@@ -2,6 +2,7 @@
 
 .container {
   @include modalContainer('PINKWHITE');
+  padding-bottom: 0;
 }
 
 .title {
@@ -23,6 +24,11 @@
   margin: 0 0 0.3rem 0.5rem;
   font-size: $medium-font;
   color: $dark-gray;
+}
+
+.colorPickerWrapper {
+  position: relative;
+  height: 2rem;
 }
 
 .textArea {


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 색상 프리뷰 클릭 시 색상 선택기 open close 방식으로 변경
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - pc에서 모달 위아래 잘림 문제로 색상 선택기를 클릭 시 open close 방식으로 변경했습니다.
  - 처음 사용하는 사람에게는 색상선택기를 열 수 있다는 걸 알려줘야하는데 어떻게 알려줘야할 지 모르겠습니다.
  - ex) 주의사항 추가, 색상프리뷰 상단 색상선택 문구 옆에 클릭하라는 문구 추가 등 피드백 부탁드립니다
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
