### PR TITLE
[GGFE-265] 확성기 가상 리스트 적용

### DIFF
--- a/components/Layout/MegaPhone.tsx
+++ b/components/Layout/MegaPhone.tsx
@@ -120,7 +120,7 @@ const Megaphone = () => {
         align: 'start',
         behavior: 'smooth',
       });
-  }, 5000);
+  }, 4000);
 
   return (
     <div className={styles.rollingBanner}>

--- a/components/Layout/MegaPhone.tsx
+++ b/components/Layout/MegaPhone.tsx
@@ -98,14 +98,13 @@ const Megaphone = () => {
     if (contents.length > 0) setMegaphoneData([...contents, adminContent]);
     else {
       setMegaphoneData([
-        ...itemList.reduce((acc: MegaphoneList, cur) => {
-          acc.push({
-            megaphoneId: cur.itemId,
-            content: cur.itemName + ' : ' + cur.mainContent,
+        ...itemList.map(
+          (item): IMegaphoneContent => ({
+            megaphoneId: item.itemId,
+            content: item.itemName + ' : ' + item.mainContent,
             intraId: '절찬 판매 중!',
-          });
-          return acc;
-        }, []),
+          })
+        ),
         adminContent,
       ]);
     }

--- a/components/Layout/MegaPhone.tsx
+++ b/components/Layout/MegaPhone.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import { useState, useEffect, useRef } from 'react';
 import { Item } from 'types/itemTypes';
 import useAxiosGet from 'hooks/useAxiosGet';
@@ -63,6 +64,8 @@ export const MegaphoneItem = ({ content, intraId }: IMegaphoneContent) => {
 const Megaphone = () => {
   const [contents, setContents] = useState<MegaphoneList>([]);
   const [itemList, setItemList] = useState<Item[]>([]);
+  const [megaphoneData, setMegaphoneData] = useState<MegaphoneList>([]);
+  const presentPath = useRouter().asPath;
 
   const getItemListHandler = useAxiosGet<any>({
     url: `/pingpong/items/store`,
@@ -81,13 +84,33 @@ const Megaphone = () => {
   });
 
   useEffect(() => {
-    getItemListHandler();
     getMegaphoneHandler();
-  }, []);
+  }, [presentPath]);
 
-  return contents.length > 0 ? (
-    <MegaphoneContainer count={contents.length}>
-      {contents.map((content, idx) => (
+  useEffect(() => {
+    if (contents.length === 0) getItemListHandler();
+  }, [contents]);
+
+  useEffect(() => {
+    if (contents.length > 0) setMegaphoneData(contents);
+    else {
+      setMegaphoneData([
+        adminContent,
+        ...itemList.reduce((acc: MegaphoneList, cur) => {
+          acc.push({
+            megaphoneId: cur.itemId,
+            content: cur.itemName + ' : ' + cur.mainContent,
+            intraId: '절찬 판매 중!',
+          });
+          return acc;
+        }, []),
+      ]);
+    }
+  }, [contents, itemList]);
+
+  return (
+    <MegaphoneContainer count={megaphoneData.length}>
+      {megaphoneData.map((content, idx) => (
         <MegaphoneItem
           content={content.content}
           intraId={content.intraId}
@@ -95,21 +118,33 @@ const Megaphone = () => {
         />
       ))}
     </MegaphoneContainer>
-  ) : (
-    <MegaphoneContainer count={itemList.length + 1}>
-      <MegaphoneItem
-        content={adminContent.content}
-        intraId={adminContent.intraId}
-      />
-      {itemList.map((item, idx) => (
-        <MegaphoneItem
-          content={item.itemName + ' : ' + item.mainContent}
-          intraId={'절찬 판매 중!'}
-          key={idx}
-        />
-      ))}
-    </MegaphoneContainer>
   );
+
+  // return contents.length > 0 ? (
+  //   <MegaphoneContainer count={contents.length}>
+  //     {contents.map((content, idx) => (
+  //       <MegaphoneItem
+  //         content={content.content}
+  //         intraId={content.intraId}
+  //         key={idx}
+  //       />
+  //     ))}
+  //   </MegaphoneContainer>
+  // ) : (
+  //   <MegaphoneContainer count={itemList.length + 1}>
+  //     <MegaphoneItem
+  //       content={adminContent.content}
+  //       intraId={adminContent.intraId}
+  //     />
+  //     {itemList.map((item, idx) => (
+  //       <MegaphoneItem
+  //         content={item.itemName + ' : ' + item.mainContent}
+  //         intraId={'절찬 판매 중!'}
+  //         key={idx}
+  //       />
+  //     ))}
+  //   </MegaphoneContainer>
+  // );
 };
 
 export default Megaphone;

--- a/components/Layout/MegaPhone.tsx
+++ b/components/Layout/MegaPhone.tsx
@@ -95,10 +95,9 @@ const Megaphone = () => {
   }, [contents]);
 
   useEffect(() => {
-    if (contents.length > 0) setMegaphoneData(contents);
+    if (contents.length > 0) setMegaphoneData([...contents, adminContent]);
     else {
       setMegaphoneData([
-        adminContent,
         ...itemList.reduce((acc: MegaphoneList, cur) => {
           acc.push({
             megaphoneId: cur.itemId,
@@ -107,6 +106,7 @@ const Megaphone = () => {
           });
           return acc;
         }, []),
+        adminContent,
       ]);
     }
   }, [contents, itemList]);

--- a/components/Layout/MegaPhone.tsx
+++ b/components/Layout/MegaPhone.tsx
@@ -126,6 +126,7 @@ const Megaphone = () => {
     <div className={styles.rollingBanner}>
       <div className={styles.wrapper}>
         <Virtuoso
+          className={styles.virtuoso}
           totalCount={megaphoneData.length}
           data={megaphoneData}
           ref={virtuoso}

--- a/components/Layout/MegaPhone.tsx
+++ b/components/Layout/MegaPhone.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router';
 import { useState, useEffect, useRef } from 'react';
+import { Virtuoso } from 'react-virtuoso';
 import { Item } from 'types/itemTypes';
 import useAxiosGet from 'hooks/useAxiosGet';
 import useInterval from 'hooks/useInterval';
@@ -109,16 +110,33 @@ const Megaphone = () => {
   }, [contents, itemList]);
 
   return (
-    <MegaphoneContainer count={megaphoneData.length}>
-      {megaphoneData.map((content, idx) => (
-        <MegaphoneItem
-          content={content.content}
-          intraId={content.intraId}
-          key={idx}
+    <div className={styles.rollingBanner}>
+      <div className={styles.wrapper}>
+        <Virtuoso
+          totalCount={megaphoneData.length}
+          itemContent={(index) => (
+            <MegaphoneItem
+              content={megaphoneData[index].content}
+              intraId={megaphoneData[index].intraId}
+            />
+          )}
+          style={{ height: '100%' }}
         />
-      ))}
-    </MegaphoneContainer>
+      </div>
+    </div>
   );
+
+  // return (
+  //   <MegaphoneContainer count={megaphoneData.length}>
+  //     {megaphoneData.map((content, idx) => (
+  //       <MegaphoneItem
+  //         content={content.content}
+  //         intraId={content.intraId}
+  //         key={idx}
+  //       />
+  //     ))}
+  //   </MegaphoneContainer>
+  // );
 
   // return contents.length > 0 ? (
   //   <MegaphoneContainer count={contents.length}>

--- a/components/Layout/MegaPhone.tsx
+++ b/components/Layout/MegaPhone.tsx
@@ -14,10 +14,10 @@ interface IMegaphoneContent {
 
 type MegaphoneList = Array<IMegaphoneContent>;
 
-type MegaphoneContainerProps = {
-  children: React.ReactNode;
-  count: number;
-};
+// type MegaphoneContainerProps = {
+//   children: React.ReactNode;
+//   count: number;
+// };
 
 const adminContent: IMegaphoneContent = {
   megaphoneId: 0,
@@ -25,33 +25,33 @@ const adminContent: IMegaphoneContent = {
   intraId: '관리자',
 };
 
-export const MegaphoneContainer = ({
-  children,
-  count,
-}: MegaphoneContainerProps) => {
-  const ref = useRef<HTMLDivElement>(null);
-  const [selectedIndex, setSelectedIndex] = useState<number>(0);
+// export const MegaphoneContainer = ({
+//   children,
+//   count,
+// }: MegaphoneContainerProps) => {
+//   const ref = useRef<HTMLDivElement>(null);
+//   const [selectedIndex, setSelectedIndex] = useState<number>(0);
 
-  useInterval(() => {
-    const nextIndex = (selectedIndex + 1) % count;
-    setSelectedIndex(nextIndex);
-  }, 4000);
+//   useInterval(() => {
+//     const nextIndex = (selectedIndex + 1) % count;
+//     setSelectedIndex(nextIndex);
+//   }, 4000);
 
-  return (
-    <div className={styles.rollingBanner}>
-      <div
-        className={styles.wrapper}
-        style={{
-          transition: 'all 1s ease-in-out',
-          transform: `translateY(${selectedIndex * -100}%)`,
-        }}
-        ref={ref}
-      >
-        {children}
-      </div>
-    </div>
-  );
-};
+//   return (
+//     <div className={styles.rollingBanner}>
+//       <div
+//         className={styles.wrapper}
+//         style={{
+//           transition: 'all 1s ease-in-out',
+//           transform: `translateY(${selectedIndex * -100}%)`,
+//         }}
+//         ref={ref}
+//       >
+//         {children}
+//       </div>
+//     </div>
+//   );
+// };
 
 export const MegaphoneItem = ({ content, intraId }: IMegaphoneContent) => {
   return (

--- a/components/Layout/MegaPhone.tsx
+++ b/components/Layout/MegaPhone.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
 import { useState, useEffect, useRef } from 'react';
-import { Virtuoso } from 'react-virtuoso';
+import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 import { Item } from 'types/itemTypes';
 import useAxiosGet from 'hooks/useAxiosGet';
 import useInterval from 'hooks/useInterval';
@@ -66,6 +66,8 @@ const Megaphone = () => {
   const [contents, setContents] = useState<MegaphoneList>([]);
   const [itemList, setItemList] = useState<Item[]>([]);
   const [megaphoneData, setMegaphoneData] = useState<MegaphoneList>([]);
+  const [selectedIndex, setSelectedIndex] = useState<number>(0);
+  const virtuoso = useRef<VirtuosoHandle>(null);
   const presentPath = useRouter().asPath;
 
   const getItemListHandler = useAxiosGet<any>({
@@ -109,11 +111,24 @@ const Megaphone = () => {
     }
   }, [contents, itemList]);
 
+  useInterval(() => {
+    const nextIndex = (selectedIndex + 1) % megaphoneData.length;
+    setSelectedIndex(nextIndex);
+    if (virtuoso.current !== null)
+      virtuoso.current.scrollToIndex({
+        index: nextIndex,
+        align: 'start',
+        behavior: 'smooth',
+      });
+  }, 5000);
+
   return (
     <div className={styles.rollingBanner}>
       <div className={styles.wrapper}>
         <Virtuoso
           totalCount={megaphoneData.length}
+          data={megaphoneData}
+          ref={virtuoso}
           itemContent={(index) => (
             <MegaphoneItem
               content={megaphoneData[index].content}

--- a/components/Layout/MegaPhone.tsx
+++ b/components/Layout/MegaPhone.tsx
@@ -112,6 +112,7 @@ const Megaphone = () => {
   }, [contents, itemList]);
 
   useInterval(() => {
+    if (!megaphoneData) return;
     const nextIndex = (selectedIndex + 1) % megaphoneData.length;
     setSelectedIndex(nextIndex);
     if (virtuoso.current !== null)
@@ -125,19 +126,21 @@ const Megaphone = () => {
   return (
     <div className={styles.rollingBanner}>
       <div className={styles.wrapper}>
-        <Virtuoso
-          className={styles.virtuoso}
-          totalCount={megaphoneData.length}
-          data={megaphoneData}
-          ref={virtuoso}
-          itemContent={(index) => (
-            <MegaphoneItem
-              content={megaphoneData[index].content}
-              intraId={megaphoneData[index].intraId}
-            />
-          )}
-          style={{ height: '100%' }}
-        />
+        {!!megaphoneData && megaphoneData.length > 0 && (
+          <Virtuoso
+            className={styles.virtuoso}
+            totalCount={megaphoneData.length}
+            data={megaphoneData}
+            ref={virtuoso}
+            itemContent={(index) => (
+              <MegaphoneItem
+                content={megaphoneData[index].content}
+                intraId={megaphoneData[index].intraId}
+              />
+            )}
+            style={{ height: '100%' }}
+          />
+        )}
       </div>
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "react-query": "^3.39.1",
         "react-quill": "^2.0.0",
         "react-router-dom": "^6.3.0",
+        "react-virtuoso": "^4.5.1",
         "recoil": "^0.7.3",
         "recoil-persist": "^4.2.0",
         "uuid": "^8.3.2",
@@ -12821,12 +12822,6 @@
       "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
       "dev": true
     },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-      "dev": true
-    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -17304,6 +17299,18 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/react-virtuoso": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.5.1.tgz",
+      "integrity": "sha512-Jdo9M/T5PcDAczvmXAKwvb/BW0MCMr/cb+3j2m9192zlQgQ+syMdJR42i+Sk80ln5aSNaL1fnxleJzdKsCc4lw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16 || >=17 || >= 18",
+        "react-dom": ">=16 || >=17 || >= 18"
+      }
+    },
     "node_modules/read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -19193,28 +19200,6 @@
       "version": "2.0.17",
       "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.17.tgz",
       "integrity": "sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==",
-      "dev": true
-    },
-    "node_modules/synckit": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
-      "integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
-      "dev": true,
-      "dependencies": {
-        "@pkgr/utils": "^2.3.1",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/unts"
-      }
-    },
-    "node_modules/synckit/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
       "dev": true
     },
     "node_modules/table": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-query": "^3.39.1",
     "react-quill": "^2.0.0",
     "react-router-dom": "^6.3.0",
+    "react-virtuoso": "^4.5.1",
     "recoil": "^0.7.3",
     "recoil-persist": "^4.2.0",
     "uuid": "^8.3.2",

--- a/styles/Layout/MegaPhone.module.scss
+++ b/styles/Layout/MegaPhone.module.scss
@@ -48,3 +48,9 @@
   justify-content: center;
   align-items: center;
 }
+
+.virtuoso {
+  // NOTE : 라이브러리에서 인라인 스타일로 overflow-y: auto를 주고 있어 스크롤바가 생김
+  // 이를 상쇄하기 위해서 !important를 사용함.
+  overflow-y: hidden !important;
+}


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 확성기 컴포넌트에 가상 리스트 라이브러리(https://github.com/petyosi/react-virtuoso) 를 적용했습니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 기존에 사용하려던 react-window 라이브러리는 애니메이션 적용에 시간이 많이 들 것 같아서 기능이 좀 더 많고 document가 잘 정리되어 있는 react-virtuoso로 적용했습니다.
  - 기존에 애니메이션으로 처리되어 있던 기능을 라이브러리의 "부드러운(?) 스크롤"기능으로 대체했습니다.
---
 - 기존 데이터 로드 방식으로는 확성기가 삭제되었을 때 새로고침해야만 변경된 데이터를 확인할 수 있어서 path가 바뀔 때 마다 새로 받아오도록 수정해봤습니다.
 - 모든 확성기 데이터 끝에 adminContent를 추가해보았습니다.
---
  - 모든 환경에서 잘 돌아간다는 확신이 없어서 일단은 기존 코드 주석을 유지한채로 main에 머지하겠습니다.. 🥲 배포 직전에 주석 정리하도록 하겠습니다!! ㅜㅜ 
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
