### PR TITLE
[GGFE-272] 상점 매뉴얼 뽑기 확률표 링크 추가

### DIFF
--- a/components/modal/store/StoreManualModal.tsx
+++ b/components/modal/store/StoreManualModal.tsx
@@ -124,6 +124,19 @@ const modalContents: contentsType = {
         },
       ],
     },
+    {
+      title: (
+        <ContentTitle title={'뽑기 아이템의 확률을 알고싶어요!'} icon={'🔍'} />
+      ),
+      description: [
+        {
+          tag: '🔗 뽑기 확률표',
+          content: [
+            '위 링크를 누르면 뽑기 아이템의 확률표 페이지로 이동합니다',
+          ],
+        },
+      ],
+    },
   ],
 };
 
@@ -157,7 +170,22 @@ export default function StoreManualModal({ radioMode }: StoreManual) {
               {item.title}
               <ul className={styles.ruleDetail}>
                 {item.description.map((rule, idx) =>
-                  rule.tag !== '' ? (
+                  rule.tag === '' ? (
+                    rule.content.map((content, idx) => (
+                      <li key={idx}>{content}</li>
+                    ))
+                  ) : rule.tag === '🔗 뽑기 확률표' ? (
+                    <li key={idx}>
+                      <a href='https://www.notion.so/21cadc74ddb245ea9494c7b203892c83?pvs=4'>
+                        {rule.tag}
+                      </a>
+                      <ul className={styles.ruleContent}>
+                        {rule.content.map((rule, idx) => (
+                          <li key={idx}>{rule}</li>
+                        ))}
+                      </ul>
+                    </li>
+                  ) : (
                     <li key={idx}>
                       {rule.tag}
                       <ul className={styles.ruleContent}>
@@ -166,8 +194,6 @@ export default function StoreManualModal({ radioMode }: StoreManual) {
                         ))}
                       </ul>
                     </li>
-                  ) : (
-                    rule.content.map((e, idx) => <li key={idx}>{e}</li>)
                   )
                 )}
               </ul>

--- a/components/modal/store/StoreManualModal.tsx
+++ b/components/modal/store/StoreManualModal.tsx
@@ -176,7 +176,10 @@ export default function StoreManualModal({ radioMode }: StoreManual) {
                     ))
                   ) : rule.tag === '🔗 뽑기 확률표' ? (
                     <li key={idx}>
-                      <a href='https://www.notion.so/21cadc74ddb245ea9494c7b203892c83?pvs=4'>
+                      <a
+                        href='https://www.notion.so/21cadc74ddb245ea9494c7b203892c83?pvs=4'
+                        target='_blank'
+                      >
                         {rule.tag}
                       </a>
                       <ul className={styles.ruleContent}>

--- a/styles/modal/store/StoreManualModal.module.scss
+++ b/styles/modal/store/StoreManualModal.module.scss
@@ -80,6 +80,9 @@
     line-height: 170%;
     list-style-type: '- ';
   }
+  a {
+    color: #c66bf2;
+  }
 }
 
 .ruleList::-webkit-scrollbar {


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 상점 매뉴얼 뽑기 확률표 링크 추가
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 상점 매뉴얼 상점이용 탭 마지막 부분에 뽑기 확률표 링크 추가했습니다
  - tag 문자열 비교로 뽑기확률표인지 확인해서 링크를 걸도록 했습니다
  - 현재 링크는 권한 제한이 되어있는데, 배포 직전에 정리해서 링크 교체하면 될 것 같습니다!
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
