### PR TITLE
[GGFE-261] 리로드로인해 공지모달뜨는 버그 수정

### DIFF
--- a/components/modal/ModalProvider.tsx
+++ b/components/modal/ModalProvider.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useQueryClient } from 'react-query';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { reloadMatchState } from 'utils/recoil/match';
 import { modalState, modalTypeState } from 'utils/recoil/modal';
@@ -11,6 +12,7 @@ export default function ModalProvider() {
   const [{ modalName, isAttended }, setModal] = useRecoilState(modalState);
   const setReloadMatch = useSetRecoilState(reloadMatchState);
   const modalType = useRecoilValue(modalTypeState);
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     setModalOutsideScroll();
@@ -25,6 +27,9 @@ export default function ModalProvider() {
       if (modalName === 'MATCH-CANCEL') setReloadMatch(true);
       else if (modalName === 'EVENT-ANNOUNCEMENT' && isAttended === false) {
         setModal({ modalName: 'EVENT-WELCOME' });
+      } else if (modalName === 'COIN-ANIMATION') {
+        queryClient.invalidateQueries('user');
+        setModal({ modalName: null });
       } else {
         setModal({ modalName: null });
       }

--- a/components/modal/event/WelcomeModal.tsx
+++ b/components/modal/event/WelcomeModal.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useQueryClient } from 'react-query';
 import { useSetRecoilState } from 'recoil';
 import { Modal } from 'types/modalTypes';
 import { instance } from 'utils/axios';
@@ -16,7 +15,6 @@ export default function WelcomeModal() {
   const setModal = useSetRecoilState<Modal>(modalState);
   const setError = useSetRecoilState(errorState);
   const [buttonState, setButtonState] = useState(false);
-  const queryClient = useQueryClient();
   const [isLoading, setIsLoading] = useState(false);
   const content = {
     title: 'Welcome!',
@@ -28,7 +26,6 @@ export default function WelcomeModal() {
     try {
       setIsLoading(true);
       const res = await instance.post(`/pingpong/users/attendance`);
-      queryClient.invalidateQueries('user');
       return res.data;
     } catch (e: any) {
       if (e.response.status === 409) {
@@ -92,7 +89,7 @@ export default function WelcomeModal() {
             value='출석하기'
             isLoading={isLoading}
           />
-          {buttonState && <CoinPopcon amount={8} coin={1} />}
+          {buttonState && <CoinPopcon amount={5} coin={0} />}
         </ModalButtonContainer>
       </div>
     </div>

--- a/components/modal/statChange/StatChangeModal.tsx
+++ b/components/modal/statChange/StatChangeModal.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { useQueryClient } from 'react-query';
 import { useSetRecoilState } from 'recoil';
 import { CoinResult } from 'types/coinTypes';
 import { GameResult } from 'types/gameTypes';
@@ -9,7 +8,7 @@ import { reloadMatchState } from 'utils/recoil/match';
 import { modalState } from 'utils/recoil/modal';
 import ExpStat from 'components/modal/statChange/ExpStat';
 import PppStat from 'components/modal/statChange/PppStat';
-import useAxiosGet, { useMockAxiosGet } from 'hooks/useAxiosGet';
+import useAxiosGet from 'hooks/useAxiosGet';
 import styles from 'styles/modal/afterGame/StatChangeModal.module.scss';
 
 export default function StatChangeModal({ gameId, mode }: Exp) {
@@ -17,7 +16,6 @@ export default function StatChangeModal({ gameId, mode }: Exp) {
   const setReloadMatch = useSetRecoilState(reloadMatchState);
   const setError = useSetRecoilState(errorState);
   const [stat, setStat] = useState<GameResult | undefined>();
-  const queryClient = useQueryClient();
 
   const getExpHandler = useAxiosGet({
     url: `/pingpong/games/${gameId}/result/${mode?.toLowerCase()}`,
@@ -28,9 +26,6 @@ export default function StatChangeModal({ gameId, mode }: Exp) {
 
   useEffect(() => {
     getExpHandler();
-    return () => {
-      queryClient.invalidateQueries('user');
-    };
   }, []);
 
   const closeModal = () => {


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 리로드로인해 공지모달뜨는 버그 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 게임잡힌후, 출석이후에 queryClient.invalidateQueries('user')로 인해 리로드가 발생해 이 두 상황이후에 코인체인지모달이 뜨는 공통점이 있어 코인모달이 닫힐때 queryClient.invalidateQueries('user')를 실행하게 수정했습니다.
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
