### PR TITLE
Feat/관리자 토너먼트 유저 전체조회, 추가 및 삭제 mock api #1119

### DIFF
--- a/pages/api/pingpong/admin/tournament/[tournamentId]/users/[userId].ts
+++ b/pages/api/pingpong/admin/tournament/[tournamentId]/users/[userId].ts
@@ -1,0 +1,17 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'DELETE') {
+    res.status(405).end('허용되지 않는 메소드입니다.');
+    return;
+  }
+  const { intraId } = req.query;
+  if (
+    intraId !== 'jincpark' &&
+    intraId !== 'junhjeon' &&
+    intraId !== 'jaehyuki'
+  ) {
+    res.status(404).end('존재하지 않는 유저입니다.');
+  }
+  res.status(204).end('명단에서 유저 삭제 성공');
+}

--- a/pages/api/pingpong/admin/tournament/[tournamentId]/users/index.ts
+++ b/pages/api/pingpong/admin/tournament/[tournamentId]/users/index.ts
@@ -1,0 +1,95 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { ITournamentUser } from 'types/admin/adminTournamentTypes';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { tournamentId } = req.query;
+  if (req.method === 'GET') {
+    const isJoined = req.query.isJoined;
+    if (isJoined === undefined) {
+      res.status(200).json({ users: tournamentUsers });
+    } else {
+      const isJoinedBool = isJoined === 'true';
+      const filteredTournamentUsers = tournamentUsers.filter(
+        (user) => user.isJoined === isJoinedBool
+      );
+      res.status(200).json({ users: filteredTournamentUsers });
+    }
+  } else if (req.method === 'POST') {
+    const { intraId } = req.body;
+
+    let joinedCount = 0;
+    for (let i = 0; i < tournamentUsers.length; i++) {
+      if (tournamentUsers[i].isJoined === true) {
+        joinedCount++;
+        if (intraId === tournamentUsers[i].intraId) {
+          res.status(409).end('이미 리그에 참여중인 유저입니다.');
+          return;
+        }
+      }
+    }
+
+    const newUser: ITournamentUser = {
+      userId: Math.floor(Math.random() * (1000000 - 11 + 1)) + 11,
+      intraId: intraId,
+      isJoined: joinedCount < 8 ? true : false,
+    };
+
+    tournamentUsers.push(newUser);
+    res.status(201).json(newUser);
+  } else {
+    res.status(405).end('허용되지 않는 메소드입니다.');
+  }
+}
+
+const tournamentUsers: ITournamentUser[] = [
+  {
+    userId: Math.floor(Math.random() * (1000000 - 11 + 1)) + 11,
+    intraId: 'jincpark',
+    isJoined: true,
+  },
+  {
+    userId: Math.floor(Math.random() * (1000000 - 11 + 1)) + 11,
+    intraId: 'junhjeon',
+    isJoined: true,
+  },
+  {
+    userId: Math.floor(Math.random() * (1000000 - 11 + 1)) + 11,
+    intraId: 'jaehyuki',
+    isJoined: true,
+  },
+  {
+    userId: Math.floor(Math.random() * (1000000 - 11 + 1)) + 11,
+    intraId: 'sechung',
+    isJoined: true,
+  },
+  {
+    userId: Math.floor(Math.random() * (1000000 - 11 + 1)) + 11,
+    intraId: 'sgo',
+    isJoined: true,
+  },
+  {
+    userId: Math.floor(Math.random() * (1000000 - 11 + 1)) + 11,
+    intraId: 'spark2',
+    isJoined: true,
+  },
+  {
+    userId: Math.floor(Math.random() * (1000000 - 11 + 1)) + 11,
+    intraId: 'hannkim',
+    isJoined: true,
+  },
+  {
+    userId: Math.floor(Math.random() * (1000000 - 11 + 1)) + 11,
+    intraId: 'jahlee',
+    isJoined: true,
+  },
+  {
+    userId: Math.floor(Math.random() * (1000000 - 11 + 1)) + 11,
+    intraId: 'jang-cho',
+    isJoined: false,
+  },
+  {
+    userId: Math.floor(Math.random() * (1000000 - 11 + 1)) + 11,
+    intraId: 'chanheki',
+    isJoined: false,
+  },
+];

--- a/types/admin/adminTournamentTypes.ts
+++ b/types/admin/adminTournamentTypes.ts
@@ -16,3 +16,9 @@ export interface ITournamentTable {
   totalPage: number;
   currentPage: number;
 }
+
+export interface ITournamentUser {
+  userId: number;
+  intraId: string;
+  isJoined: boolean;
+}


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 관리자 토너먼트 유저 전체조회, 추가 및 삭제 mock API를 구현하였습니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 관리자 토너먼트 유저 전체조회 mock API
  - 관리자 토너먼트 유저 추가 mock API
  - 관리자 토너먼트 유저 삭제 mock API
  - 관리자 토너먼트 유저 타입 `ITournamentUser` 추가
