### PR TITLE
[Fix] 모바일 환경에서 브라켓 뷰 하이라이트 안됨#1161

### DIFF
--- a/components/tournament/TournamentMatch.tsx
+++ b/components/tournament/TournamentMatch.tsx
@@ -34,6 +34,9 @@ function TournamentMatchParty({
       }`}
       onMouseEnter={() => onMouseEnter(party.id)}
       onClick={() => onPartyClick(party, false)}
+      onTouchStartCapture={() => {
+        onPartyClick(party, false);
+      }}
     >
       <PlayerImage
         src={party.picture ?? '/image/match_qustion.png'}

--- a/components/tournament/TournamentMatch.tsx
+++ b/components/tournament/TournamentMatch.tsx
@@ -34,7 +34,7 @@ function TournamentMatchParty({
       }`}
       onMouseEnter={() => onMouseEnter(party.id)}
       onClick={() => onPartyClick(party, false)}
-      onTouchStartCapture={() => {
+      onTouchStart={() => {
         onPartyClick(party, false);
       }}
     >

--- a/pages/tournament.tsx
+++ b/pages/tournament.tsx
@@ -23,7 +23,6 @@ export default function Tournament() {
       instance
         .get('/pingpong/tournaments?size=20&page=1&status=LIVE')
         .then((res) => {
-          console.log(res.data.tournaments[0].tournamentId);
           setOpenTournamentId(res.data.tournaments[0].tournamentId);
           return res.data;
         }),


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 모바일에서도 하이라이트가 잘 클릭될 수 있도록 만들었습니다.
  - HighLightUser를 Recoil을 통해 관리하고있는데, 해당 사항을 Context 로 변경하니 계속해서 새로고침을 해서 브라켓 뷰의 zoom 이 초기화 되는 문제가 있어서 일단은 Recoil을 그대로 사용하고있습니다.
<img width="500" alt="image" src="https://github.com/42organization/42gg.client/assets/76806109/270f90b6-18a2-455e-9d00-516dfd21be31">

 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
