### PR TITLE
[Feat]토너먼트 페이지 메뉴얼 추가#1232

### DIFF
--- a/components/modal/modalType/TournamentModal.tsx
+++ b/components/modal/modalType/TournamentModal.tsx
@@ -1,5 +1,6 @@
 import { useRecoilValue } from 'recoil';
 import { modalState } from 'utils/recoil/modal';
+import TournamentManualModal from '../tournament/TournamentManualModal';
 import TournamentRegistryModal from '../tournament/TournamentRegistryModal';
 
 export default function TournamentModal() {
@@ -9,6 +10,7 @@ export default function TournamentModal() {
     'TOURNAMENT-REGISTRY': tournamentInfo ? (
       <TournamentRegistryModal {...tournamentInfo} />
     ) : null,
+    'TOURNAMENT-MANUAL': <TournamentManualModal />,
   };
 
   if (!modalName) return null;

--- a/components/modal/tournament/TournamentManualModal.tsx
+++ b/components/modal/tournament/TournamentManualModal.tsx
@@ -1,0 +1,109 @@
+import { useSetRecoilState } from 'recoil';
+import { modalState } from 'utils/recoil/modal';
+import {
+  ModalButtonContainer,
+  ModalButton,
+} from 'components/modal/ModalButton';
+import styles from 'styles/modal/match/MatchManualModal.module.scss';
+
+type contentType = {
+  title: React.ReactNode;
+  description: string[];
+};
+
+type contentsType = contentType[];
+
+// TODO : 토너먼트 경기에 대한 룰 설명
+const modalContents: contentsType = [
+  {
+    title: <ContentTitle title={'토너먼트 경기 규칙'} icon={'📖'} />,
+    description: [
+      '11점 3판 2선승제',
+      '경기시간은 슬롯에 표기',
+      '점수가 10:10 인 경우 듀스',
+      '듀스인 경우, 2점 차가 나면 경기 종료',
+      '탁구채를 잡지 않은 손으로 탁구대를 짚으면 실점',
+      '탁구대 및 네트가 아닌 곳에 공이 맞을 시 실점',
+    ],
+  },
+  {
+    title: <ContentTitle title={'서브 규칙'} icon={'🚨'} />,
+    description: [
+      '첫 세트만 서브 게임 진행',
+      '서브 게임 승자부터 세트별 교대로 서브',
+      '서브는 2점마다 교대하며, 듀스일 때는 1점마다 교대',
+      '서브 시작 시 상대방에게 신호 (e.g. 서브하겠습니다.)',
+      '서브 시 공이 네트에 맞고 넘어가면 다시 서브',
+    ],
+  },
+  {
+    title: <ContentTitle title={'경기 결과'} icon={'✅'} />,
+    description: [
+      '경기 종료 후 그 자리에서 세트 점수 입력',
+      '종료시간에 다음 경기가 있을 시 현재 스코어가 높은 선수가 승리',
+      '다음 경기가 없을 시 계속 진행 가능',
+    ],
+  },
+  {
+    title: <ContentTitle title={'노쇼'} icon={'🚨'} />,
+    description: [
+      `매치가 시작 되었으나 상대방이 나오지 않는다면 3분이 지날 때 마다 세트 점수 1점씩 획득`,
+      '6분이 지났을 때도 나오지 않았다면 세트 점수 2:0 승리 처리',
+    ],
+  },
+];
+
+export default function TournamentManualModal() {
+  const setModal = useSetRecoilState(modalState);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.title}>토너먼트 규칙</div>
+      <ul className={styles.ruleList}>
+        {modalContents.map(
+          (
+            item: {
+              title: React.ReactNode;
+              description: string[];
+            },
+            index
+          ) => (
+            <li key={index}>
+              {item.title}
+              <ul className={styles.ruleDetail}>
+                {item.description.map((e, idx) => (
+                  <li key={idx}>{e}</li>
+                ))}
+              </ul>
+            </li>
+          )
+        )}
+      </ul>
+      <ModalButtonContainer>
+        <ModalButton
+          onClick={() => setModal({ modalName: null })}
+          style='positive'
+          value='확인'
+        />
+      </ModalButtonContainer>
+    </div>
+  );
+}
+
+type contentTitleProps = {
+  title: string;
+  icon?: React.ReactNode | string;
+};
+
+function ContentTitle({ title, icon }: contentTitleProps) {
+  icon = typeof icon === 'string' ? <span>{icon}</span> : icon;
+  return (
+    <div
+      className={`${styles.ruleTitle} 
+      ${styles[icon ? 'withIcon' : 'withoutIcon']}`}
+    >
+      {icon ? icon : null}
+      <span>{title}</span>
+    </div>
+  );
+}

--- a/pages/tournament.tsx
+++ b/pages/tournament.tsx
@@ -4,6 +4,7 @@ import { useSetRecoilState } from 'recoil';
 import { instance } from 'utils/axios';
 import { convertTournamentGamesToBracketMatchs } from 'utils/handleTournamentGame';
 import { errorState } from 'utils/recoil/error';
+import { modalState } from 'utils/recoil/modal';
 import TournamentBraket from 'components/tournament/TournamentBraket';
 import TournamentCard from 'components/tournament/TournamentCard';
 import useBeforeLiveTournamentData from 'hooks/tournament/useBeforeLiveTournamentData';
@@ -12,9 +13,14 @@ import styles from 'styles/tournament/TournamentContainer.module.scss';
 
 export default function Tournament() {
   const setError = useSetRecoilState(errorState);
+  const setModal = useSetRecoilState(modalState);
   const { data, isLoading } = useBeforeLiveTournamentData();
   const [ref, size] = useComponentSize<HTMLDivElement>();
   const [liveMatch, setLiveMatch] = useState<Match[]>();
+
+  const openManual = () => {
+    setModal({ modalName: 'TOURNAMENT-MANUAL' });
+  };
 
   const fetchTournamentGames = useCallback(
     async (tournamentId: number) => {
@@ -62,6 +68,12 @@ export default function Tournament() {
           </div>
         )}
         <div className={styles.tournamentText}> 진행중인 토너먼트 </div>
+        <div className={styles.buttonWrap}>
+          <button className={styles.manual} onClick={openManual}>
+            {' '}
+            경기 규칙
+          </button>
+        </div>
         {data?.liveTournament?.length === 0 ? (
           <div className={styles.noTournamentText}>
             진행중인 토너먼트가 없습니다

--- a/styles/tournament/TournamentContainer.module.scss
+++ b/styles/tournament/TournamentContainer.module.scss
@@ -56,3 +56,20 @@
   justify-content: center;
   align-content: center;
 }
+.buttonWrap {
+  display: flex;
+  margin-right: 0.6rem;
+  margin-bottom: 1rem;
+  justify-content: flex-end;
+  align-items: center;
+
+  .manual {
+    @include match-noti-button;
+    width: 4.2rem;
+    height: 1.6rem;
+    padding: 0;
+    margin: 0 0.8rem 0 0;
+    font-size: $small-font;
+    border-radius: $small-radius;
+  }
+}

--- a/types/modalTypes.ts
+++ b/types/modalTypes.ts
@@ -33,7 +33,7 @@ type EditItemModal = 'MEGAPHONE';
 
 type StoreModal = 'MANUAL' | 'COIN_HISTORY';
 
-type TournamentModal = 'REGISTRY';
+type TournamentModal = 'REGISTRY' | 'MANUAL';
 
 type AdminModal =
   | 'PROFILE'


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 토너먼트 경기 규칙에 대해서 안내하는 모달을 만들었습니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 기존의 match화면에서 사용되는 modal 을 참고해서만들었습니다.
  - 기존의 modal을 재활용할수도있지만, match페이지에서는 토너먼트 경기방식에 대한 정보가 불필요하고 반대도 마찬가지이기 때문에 새로운 모달을 생성했습니다.
  - match페이지와 마찬가지로 현재 진행중인 토너먼트의 정보를 갱신하는 버튼을 만들어 옆에 놓아도 될 것 같습니다.
<img width="400" alt="image" src="https://github.com/42organization/42gg.client/assets/76806109/9ff7cf9e-20db-4d76-b9cc-eaa72f5eca50">
<img width="400" alt="image" src="https://github.com/42organization/42gg.client/assets/76806109/c94278ac-d3d5-404a-a55c-2073307d3b46">

 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
