### PR TITLE
[Feat] 알림 메시지 템플릿 레이아웃

### DIFF
--- a/components/admin/recruitments/recruitmentsuser/editRecruitResultTemplates.tsx
+++ b/components/admin/recruitments/recruitmentsuser/editRecruitResultTemplates.tsx
@@ -37,7 +37,7 @@ function EditRecruitResultTemplates() {
       setTemplates(messages);
     } catch (e: any) {
       setSnackbar({
-        toastName: `get recruitment result templates`,
+        toastName: `api error`,
         severity: 'error',
         message: `API 요청에 문제가 발생했습니다.`,
         clicked: true,

--- a/components/admin/recruitments/recruitmentsuser/editRecruitResultTemplates.tsx
+++ b/components/admin/recruitments/recruitmentsuser/editRecruitResultTemplates.tsx
@@ -1,10 +1,60 @@
+import { useEffect, useState } from 'react';
 // import { instanceInManage } from 'utils/axios';
+import { useSetRecoilState } from 'recoil';
+import {
+  IRecruitmentTemplate,
+  RecruitmentMessageType,
+} from 'types/recruit/recruitments';
+import { mockInstance } from 'utils/mockAxios';
+import { toastState } from 'utils/recoil/toast';
+import TemplateEditor from 'components/admin/recruitments/recruitmentsuser/tmplateEditor';
+import styles from 'styles/admin/recruitments/RecruitmentResultTemplates.module.scss';
+
+type TemplateListType = Record<RecruitmentMessageType, string>;
 
 function EditRecruitResultTemplates() {
+  const setSnackbar = useSetRecoilState(toastState);
+  const [templates, setTemplates] = useState<TemplateListType>({
+    INTERVIEW: '',
+    PASS: '',
+    FAIL: '',
+  });
+  const getTemplates = async () => {
+    try {
+      // const res = await instanceInManage.get('/recruitments/result/message');
+      const res = await mockInstance.get('/admin/recruitments/result/message');
+      const messages = res.data.messages.reduce(
+        (acc: TemplateListType, curr: IRecruitmentTemplate) => {
+          acc[curr.messageType] = curr.message;
+          return acc;
+        },
+        {
+          INTERVIEW: '',
+          PASS: '',
+          FAIL: '',
+        }
+      );
+      setTemplates(messages);
+    } catch (e: any) {
+      setSnackbar({
+        toastName: `get recruitment result templates`,
+        severity: 'error',
+        message: `API 요청에 문제가 발생했습니다.`,
+        clicked: true,
+      });
+    }
+  };
+
+  useEffect(() => {
+    getTemplates();
+  }, []);
+
   return (
-    <>
-      <div>hellooooooo</div>
-    </>
+    <div className={styles.container}>
+      <TemplateEditor messageType='INTERVIEW' message={templates.INTERVIEW} />
+      <TemplateEditor messageType='PASS' message={templates.PASS} />
+      <TemplateEditor messageType='FAIL' message={templates.FAIL} />
+    </div>
   );
 }
 

--- a/components/admin/recruitments/recruitmentsuser/editRecruitResultTemplates.tsx
+++ b/components/admin/recruitments/recruitmentsuser/editRecruitResultTemplates.tsx
@@ -1,0 +1,11 @@
+// import { instanceInManage } from 'utils/axios';
+
+function EditRecruitResultTemplates() {
+  return (
+    <>
+      <div>hellooooooo</div>
+    </>
+  );
+}
+
+export default EditRecruitResultTemplates;

--- a/components/admin/recruitments/recruitmentsuser/menuTab.tsx
+++ b/components/admin/recruitments/recruitmentsuser/menuTab.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import RecruitmentsHistoryList from 'components/admin/recruitments/recruitmentsHistoryList';
 import DetailRecruitUserList from 'components/admin/recruitments/recruitmentsuser/detailRecruitUserList';
+import EditRecruitResultTemplates from 'components/admin/recruitments/recruitmentsuser/editRecruitResultTemplates';
 import NotificationResults from 'components/admin/recruitments/recruitmentsuser/notificationResults';
 import styles from 'styles/admin/recruitments/MenuTab.module.scss';
 
@@ -23,11 +24,16 @@ function MenuTab({ recruitId }: { recruitId: number }) {
 
   useEffect(() => {
     switch (tabIdx) {
+      case -1:
+        setChild(<EditRecruitResultTemplates />);
+        break;
       case 0:
         setChild(<DetailRecruitUserList recruitId={recruitId} />);
         break;
       case 1:
-        setChild(<NotificationResults recruitId={recruitId} />);
+        setChild(
+          <NotificationResults recruitId={recruitId} setTabIdx={setTabIdx} />
+        );
         break;
     }
   }, [tabIdx, recruitId]);

--- a/components/admin/recruitments/recruitmentsuser/notificationResults.tsx
+++ b/components/admin/recruitments/recruitmentsuser/notificationResults.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useState } from 'react';
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
 import DatePicker from 'react-datepicker';
 import { useSetRecoilState } from 'recoil';
 import {
@@ -39,7 +45,13 @@ export interface notiMessageType {
   content: string;
 }
 
-function NotificationResults({ recruitId }: { recruitId: number }) {
+function NotificationResults({
+  recruitId,
+  setTabIdx,
+}: {
+  recruitId: number;
+  setTabIdx: Dispatch<SetStateAction<number>>;
+}) {
   const [notificationData, setNotificationData] = useState<InoticationTable>({
     noticationList: [],
     totalPage: 0,
@@ -172,6 +184,9 @@ function NotificationResults({ recruitId }: { recruitId: number }) {
           }}
         />
       </div>
+      <button className={styles.button} onClick={() => setTabIdx(-1)}>
+        메시지 템플릿 작성하기
+      </button>
     </>
   );
 }

--- a/components/admin/recruitments/recruitmentsuser/tmplateEditor.tsx
+++ b/components/admin/recruitments/recruitmentsuser/tmplateEditor.tsx
@@ -1,0 +1,24 @@
+import { IRecruitmentResultMessage } from 'types/recruit/recruitments';
+import styles from 'styles/admin/recruitments/RecruitmentResultTemplates.module.scss';
+
+function TemplateEditor({ messageType, message }: IRecruitmentResultMessage) {
+  const titles = {
+    INTERVIEW: '면접',
+    PASS: '합격',
+    FAIL: '불합격',
+  };
+
+  return (
+    <div className={styles.templateContainer}>
+      <div className={styles.title}>{`${titles[messageType]} 안내`}</div>
+      <textarea
+        name='template'
+        defaultValue={message}
+        placeholder='템플릿을 입력해주세요.'
+      />
+      <button className={styles.button}>등록하기</button>
+    </div>
+  );
+}
+
+export default TemplateEditor;

--- a/components/admin/recruitments/recruitmentsuser/tmplateEditor.tsx
+++ b/components/admin/recruitments/recruitmentsuser/tmplateEditor.tsx
@@ -1,22 +1,81 @@
+import { useState } from 'react';
+import { useSetRecoilState } from 'recoil';
 import { IRecruitmentResultMessage } from 'types/recruit/recruitments';
+import { mockInstance } from 'utils/mockAxios';
+// import { instanceInManage } from 'utils/axios';
+import { toastState } from 'utils/recoil/toast';
 import styles from 'styles/admin/recruitments/RecruitmentResultTemplates.module.scss';
 
 function TemplateEditor({ messageType, message }: IRecruitmentResultMessage) {
+  const [tempalte, setTemplate] = useState<IRecruitmentResultMessage>({
+    messageType: messageType,
+    message: message,
+  });
+  const [alert, setAlert] = useState<string>('');
+  const setSnackbar = useSetRecoilState(toastState);
   const titles = {
     INTERVIEW: '면접',
     PASS: '합격',
     FAIL: '불합격',
   };
+  const DATE = '${선택날짜}'; // 치환 문구
+
+  const inputHandler = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const message = e.target.value;
+    if (messageType === 'INTERVIEW' && !message.includes(DATE)) {
+      setAlert(`${DATE}를 포함해주세요.`);
+    } else {
+      setAlert('');
+      setTemplate({ ...tempalte, message: message });
+    }
+  };
+
+  const onClick = async () => {
+    if (alert) {
+      setSnackbar({
+        toastName: `alert`,
+        severity: 'error',
+        message: `치환 문구가 필요합니다.`,
+        clicked: true,
+      });
+      return;
+    }
+    try {
+      // TODO: 해당 API가 맞는지 확인 필요
+      // await instanceInManage.post('/recruitments/result/message', tempalte);
+      await mockInstance.post('/admin/recruitments/result/message', tempalte);
+      setSnackbar({
+        toastName: `post request`,
+        severity: 'success',
+        message: `템플릿이 성공적으로 등록되었습니다.`,
+        clicked: true,
+      });
+    } catch (e: any) {
+      setSnackbar({
+        toastName: `bad request`,
+        severity: 'error',
+        message: `템플릿 등록에 문제가 발생했습니다.`,
+        clicked: true,
+      });
+    }
+  };
 
   return (
     <div className={styles.templateContainer}>
-      <div className={styles.title}>{`${titles[messageType]} 안내`}</div>
-      <textarea
-        name='template'
-        defaultValue={message}
-        placeholder='템플릿을 입력해주세요.'
-      />
-      <button className={styles.button}>등록하기</button>
+      <div>{`${titles[messageType]} 안내`}</div>
+      <div className={styles.textarea}>
+        <textarea
+          name='template'
+          defaultValue={message}
+          placeholder='템플릿을 입력해주세요.'
+          rows={10}
+          onChange={inputHandler}
+        />
+        <div className={styles.alertText}>{alert}</div>
+      </div>
+      <button className={styles.button} onClick={onClick}>
+        등록하기
+      </button>
     </div>
   );
 }

--- a/components/admin/recruitments/recruitmentsuser/tmplateEditor.tsx
+++ b/components/admin/recruitments/recruitmentsuser/tmplateEditor.tsx
@@ -41,7 +41,6 @@ function TemplateEditor({ messageType, message }: IRecruitmentResultMessage) {
       return;
     }
     try {
-      // TODO: 해당 API가 맞는지 확인 필요
       // await instanceInManage.post('/recruitments/result/message', tempalte);
       await mockInstance.post('/admin/recruitments/result/message', tempalte);
       setSnackbar({

--- a/pages/api/pingpong/admin/recruitments/result/message.ts
+++ b/pages/api/pingpong/admin/recruitments/result/message.ts
@@ -1,0 +1,40 @@
+import {
+  IRecruitmentTemplate,
+  IRecruitmentTemplateList,
+} from 'types/recruit/recruitments';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const messageList: IRecruitmentTemplate[] = [
+  {
+    messageId: 1,
+    messageType: 'INTERVIEW',
+    isUse: true,
+    message: '면접에 합격하셨습니다. 면접 일정은 ${선택날짜}입니다.',
+  },
+  {
+    messageId: 2,
+    messageType: 'PASS',
+    isUse: true,
+    message: '합격하셨습니다. 합격자 안내 메일을 확인해주세요.',
+  },
+  {
+    messageId: 3,
+    messageType: 'FAIL',
+    isUse: true,
+    message: '아쉽지만 불합격하셨습니다. 다음 기회에 도전해주세요.',
+  },
+  {
+    messageId: 4,
+    messageType: 'FAIL',
+    isUse: true,
+    message: '아쉽지만 불합격하셨습니다. 다음 기회에 도전해주세요.',
+  },
+];
+
+const templateList: IRecruitmentTemplateList = {
+  messages: messageList,
+};
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.status(200).json(templateList);
+}

--- a/pages/api/pingpong/admin/recruitments/result/message.ts
+++ b/pages/api/pingpong/admin/recruitments/result/message.ts
@@ -36,5 +36,11 @@ const templateList: IRecruitmentTemplateList = {
 };
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  res.status(200).json(templateList);
+  const { method } = req;
+
+  if (method === 'GET') {
+    res.status(200).json(templateList);
+  } else if (method === 'POST') {
+    res.status(201).end();
+  }
 }

--- a/styles/admin/common.scss
+++ b/styles/admin/common.scss
@@ -10,6 +10,7 @@
 }
 
 @mixin admin-button($color, $disabled: '') {
+  cursor: pointer;
   border: none;
   @if ($color == 'BLUE') {
     color: #ffffff;

--- a/styles/admin/recruitments/RecruitmentResultTemplates.module.scss
+++ b/styles/admin/recruitments/RecruitmentResultTemplates.module.scss
@@ -1,26 +1,32 @@
-@import 'styles/common.scss';
 @import 'styles/admin/common.scss';
 
 .container {
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
+  justify-content: space-around;
   align-items: center;
   padding: 3rem;
+}
 
-  .templateContainer {
+.templateContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+
+  .textarea {
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
-    align-items: center;
-
-    .title {
-      margin-bottom: 0.5rem;
+    justify-content: center;
+    margin: 0.5rem 0;
+    .alertText {
+      height: 1rem;
+      font-size: 0.7rem;
+      color: #fe3737;
     }
-    .button {
-      @include admin-button('BLUE');
-      padding: 0.6rem;
-      margin-top: 0.5rem;
-    }
+  }
+  .button {
+    @include admin-button('BLUE');
+    padding: 0.6rem;
   }
 }

--- a/styles/admin/recruitments/RecruitmentResultTemplates.module.scss
+++ b/styles/admin/recruitments/RecruitmentResultTemplates.module.scss
@@ -1,0 +1,26 @@
+@import 'styles/common.scss';
+@import 'styles/admin/common.scss';
+
+.container {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding: 3rem;
+
+  .templateContainer {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+
+    .title {
+      margin-bottom: 0.5rem;
+    }
+    .button {
+      @include admin-button('BLUE');
+      padding: 0.6rem;
+      margin-top: 0.5rem;
+    }
+  }
+}

--- a/styles/admin/recruitments/Recruitments.module.scss
+++ b/styles/admin/recruitments/Recruitments.module.scss
@@ -1,5 +1,6 @@
 @import 'styles/admin/common/Pagination.module.scss';
 @import 'styles/common.scss';
+@import 'styles/admin/common.scss';
 
 .tableContainer {
   width: 100%;
@@ -55,6 +56,12 @@
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+.button {
+  @include admin-button('PALE-BLUE');
+  padding: 0.5rem 1.3rem;
+  margin-top: 1rem;
 }
 
 @include pagination;

--- a/types/recruit/recruitments.d.ts
+++ b/types/recruit/recruitments.d.ts
@@ -29,3 +29,18 @@ export interface IRecruitmentDetail {
   generations: string;
   form: IQuestionForm[];
 }
+
+export type RecruitmentMessageType = 'INTERVIEW' | 'PASS' | 'FAIL';
+
+export interface IRecruitmentResultMessage {
+  messageType: RecruitmentMessageType;
+  message: string;
+}
+export interface IRecruitmentTemplate extends IRecruitmentResultMessage {
+  messageId: number;
+  isUse: boolean;
+}
+
+export interface IRecruitmentTemplateList {
+  messages: IRecruitmentTemplate[];
+}


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
 - 면접 안내 메시지 템플릿 등록 화면 구현
 - #1269
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 관리자 -> 공고관리 -> 지원자 보기 -> 결과 입력 탭 하단에 버튼 클릭
  - 면접 안내 템플릿에서 치환 문구가 없을 시 경고 메시지 표시 및 등록하기 클릭 시 에러 스낵바 띄움
  - 템플릿 수정하는 화면에서 위에 탭 보이는게 어색하진 않은지 의견 부탁드립니다.. 탭을 안보이게 하고 뒤로가기 버튼을 만드는게 나을지 고민입니다
<img width="1430" alt="스크린샷 2024-03-12 오전 11 56 43" src="https://github.com/42organization/42gg.client/assets/105159293/0af0aa39-078a-4176-889b-b660d043c87c">
<img width="1421" alt="스크린샷 2024-03-12 오전 11 58 19" src="https://github.com/42organization/42gg.client/assets/105159293/9384c78d-2e46-4492-8a13-0b90c950b8c8">
<img width="1419" alt="스크린샷 2024-03-12 오전 11 58 34" src="https://github.com/42organization/42gg.client/assets/105159293/c501541e-4977-48eb-8de4-145eb646a58e">

