### PR TITLE
[Feat] party category api사용 hook 구현

### DIFF
--- a/hooks/party/usePartyCategory.ts
+++ b/hooks/party/usePartyCategory.ts
@@ -1,0 +1,52 @@
+import { useMutation, useQuery, useQueryClient } from 'react-query';
+import { useSetRecoilState } from 'recoil';
+import { PartyCategory } from 'types/partyTypes';
+import { instance, instanceInPartyManage } from 'utils/axios';
+import { toastState } from 'utils/recoil/toast';
+
+export default function usePartyCategory() {
+  const queryClient = useQueryClient();
+  const setSnackBar = useSetRecoilState(toastState);
+
+  const { data } = useQuery({
+    queryKey: 'partyCategory',
+    queryFn: () =>
+      instance
+        .get('/party/categories')
+        .then(({ data }: { data: PartyCategory[] }) => data),
+    onError: () => {
+      setSnackBar({
+        toastName: 'GET request',
+        message: '카테고리를 가져오는데 실패했습니다.',
+        severity: 'error',
+        clicked: true,
+      });
+    },
+  });
+
+  const createMutation = useMutation(
+    (categoryName: string) =>
+      instanceInPartyManage.post('/categories', { categoryName }),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries('partyCategory');
+      },
+    }
+  );
+  const deleteMutation = useMutation(
+    (categoryId: number) =>
+      instanceInPartyManage.delete(`/categories/${categoryId}`),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries('partyCategory');
+      },
+    }
+  );
+
+  return {
+    categories: data ?? [], // undefind 대신 []을 이용해 에러 처리
+    deleteCategory: (categoryId: number) => deleteMutation.mutate(categoryId),
+    createCategory: (categoryName: string) =>
+      createMutation.mutate(categoryName),
+  };
+}

--- a/utils/axios.ts
+++ b/utils/axios.ts
@@ -2,9 +2,12 @@ import axios, { AxiosError } from 'axios';
 
 const baseURL = `${process.env.NEXT_PUBLIC_SERVER_ENDPOINT}`;
 const manageBaseURL = process.env.NEXT_PUBLIC_MANAGE_SERVER_ENDPOINT ?? '/';
+const managePartyBaseURL =
+  process.env.NEXT_PUBLIC_PARTY_MANAGE_SERVER_ENDPOINT ?? '/';
 
 const instance = axios.create({ baseURL });
 const instanceInManage = axios.create({ baseURL: manageBaseURL });
+const instanceInPartyManage = axios.create({ baseURL: managePartyBaseURL });
 
 instance.interceptors.request.use(
   function setConfig(config) {
@@ -34,10 +37,24 @@ instanceInManage.interceptors.request.use(
   }
 );
 
+instanceInPartyManage.interceptors.request.use(
+  function setConfig(config) {
+    config.headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${localStorage.getItem('42gg-token')}`,
+    };
+    config.withCredentials = true;
+    return config;
+  },
+  function getError(error) {
+    return Promise.reject(error);
+  }
+);
+
 function isAxiosError<ErrorPayload>(
   error: unknown
 ): error is AxiosError<ErrorPayload> {
   return axios.isAxiosError(error);
 }
 
-export { instance, instanceInManage, isAxiosError };
+export { instance, instanceInManage, instanceInPartyManage, isAxiosError };


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
# 중요
- 현재 axios의 admin url에 대한 환경변수가 'pingpong/admin'으로 되어있어 새로운 'party/admin'과 관련된 api를 사용할 수 없어 새로운 환경변수가 추가되었는데 이거에 대해 이야기를 해되야될 것 같습니다.

 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - PartyCategory데이터를 서버에서 가져와서 관리하는 hook
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 한번가져오면 react-query를 이용해 캐싱됩니다.
  - hook이 가진 함수로 categoryAPI를 사용해야만 데이터가 refresh됩니다.
  - 로딩 및 에러에는 빈 리스트([]) 반환
  - API오류가 나면 간단히 토스트를 띄움
 
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
