### PR TITLE
Feat/make party detail #1283

### DIFF
--- a/components/modal/modalType/PartyModal.tsx
+++ b/components/modal/modalType/PartyModal.tsx
@@ -1,10 +1,15 @@
 import { useRecoilValue } from 'recoil';
 import { modalState } from 'utils/recoil/modal';
+import { PartyReportModal } from '../party/PartyReportModal';
 
 export default function PartyModal() {
-  const { modalName } = useRecoilValue(modalState);
+  const { modalName, partyReport } = useRecoilValue(modalState);
 
-  const content: { [key: string]: JSX.Element | null } = {};
+  const content: { [key: string]: JSX.Element | null } = {
+    'PARTY-REPORT': partyReport ? (
+      <PartyReportModal report={partyReport} />
+    ) : null,
+  };
 
   if (!modalName) return null;
   return content[modalName];

--- a/components/modal/party/PartyReportModal.tsx
+++ b/components/modal/party/PartyReportModal.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import { useSetRecoilState } from 'recoil';
+import { Modal, PartyReportModalData } from 'types/modalTypes';
+import { instance } from 'utils/axios';
+import { modalState } from 'utils/recoil/modal';
+import styles from 'styles/modal/menu/ReportModal.module.scss';
+import { ModalButton, ModalButtonContainer } from '../ModalButton';
+
+export function PartyReportModal({ report }: { report: PartyReportModalData }) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [content, setContent] = useState('');
+  const setModal = useSetRecoilState<Modal>(modalState);
+
+  const reportHandler = async () => {
+    const reportResponse: { [key: string]: string } = {
+      SUCCESS: '신고해주셔서 감사합니다 ❤️',
+      REJECT: '내용을 적어주세요 ❤️',
+    };
+
+    try {
+      if (!content.replace(/^\s+|\s+$/g, '')) {
+        throw new Error('칸을 입력하지 않았습니다.');
+      }
+      switch (report.name) {
+        case 'COMMENT':
+          await instance.post(`/party/reports/comments/${report.commentId}`);
+          break;
+        case 'ROOM':
+          await instance.post(`/party/reports/rooms/${report.roomId}`);
+          break;
+        case 'NOSHOW':
+          await instance.post(
+            `/party/reports/rooms/${report.roomId}/users/${report.userIntraId}`
+          );
+          break;
+      }
+      setModal({ modalName: null });
+      alert(reportResponse.SUCCESS);
+    } catch (e) {
+      console.log(e);
+      alert(reportResponse.REJECT);
+      throw new Error('REJECT');
+    }
+  };
+
+  const handleReport = () => {
+    setIsLoading(true);
+    reportHandler().catch(() => setIsLoading(false));
+  };
+
+  return (
+    <div className={styles.container}>
+      <div>
+        <div className={styles.title}>42GG</div>
+        <div className={styles.phrase}>{report.name}</div>
+      </div>
+      <form>
+        <div className={styles.contentWrapper}>
+          <div className={styles.content}>
+            <textarea
+              name='content'
+              maxLength={300}
+              onChange={(e) => setContent(content + e)}
+            />
+            <div>{`${content.length}/300`}</div>
+          </div>
+        </div>
+        <ModalButtonContainer>
+          <ModalButton
+            onClick={() => setModal({ modalName: null })}
+            style='negative'
+            value='취소'
+          />
+          <ModalButton
+            onClick={handleReport}
+            style='positive'
+            value='보내기'
+            isLoading={isLoading}
+          />
+        </ModalButtonContainer>
+      </form>
+    </div>
+  );
+}

--- a/components/party/roomDetail/PartyDetailButton.tsx
+++ b/components/party/roomDetail/PartyDetailButton.tsx
@@ -1,0 +1,100 @@
+import { useRouter } from 'next/router';
+import { useSetRecoilState } from 'recoil';
+import { instance } from 'utils/axios';
+import { modalState } from 'utils/recoil/modal';
+
+type ParytButtonProps = {
+  roomId?: number;
+  commentId?: number;
+};
+
+function ReportComment({ commentId }: ParytButtonProps) {
+  const setModal = useSetRecoilState(modalState);
+
+  return (
+    <button
+      onClick={() => {
+        setModal({
+          partyReport: {
+            name: 'COMMENT',
+            commentId: commentId,
+          },
+          modalName: 'PARTY-REPORT',
+        });
+      }}
+    >
+      신고
+    </button>
+  );
+}
+
+function ReportRoom({ roomId }: ParytButtonProps) {
+  const setModal = useSetRecoilState(modalState);
+
+  return (
+    <button
+      onClick={() => {
+        setModal({
+          partyReport: {
+            name: 'ROOM',
+            roomId: roomId,
+          },
+          modalName: 'PARTY-REPORT',
+        });
+      }}
+    >
+      신고
+    </button>
+  );
+}
+
+function ShareRoom() {
+  const roomId = useRouter().query.roomId;
+
+  return (
+    <button
+      onClick={() => {
+        navigator.clipboard.writeText(`http://42gg.kr/parties/${roomId}`);
+      }}
+    >
+      공유하기
+    </button>
+  );
+}
+
+function JoinRoom({ roomId }: ParytButtonProps) {
+  const handlerJoin = async () => {
+    await instance.post(`/party/rooms/${roomId}/join`).catch((error) => {
+      console.error(error);
+    });
+  };
+
+  <button onClick={handlerJoin}>참여하기</button>;
+}
+
+function LeaveRoom({ roomId }: ParytButtonProps) {
+  const handlerExit = async () => {
+    await instance.patch(`/party/rooms/${roomId}`).catch((error) => {
+      console.error(error);
+    });
+  };
+
+  return <button onClick={handlerExit}>방 나가기</button>;
+}
+
+function BackRoomList() {
+  const router = useRouter();
+
+  return <button onClick={() => router.push('/party')}></button>;
+}
+
+const PartyRoomDetailButton = {
+  ReportComment,
+  ReportRoom,
+  ShareRoom,
+  JoinRoom,
+  LeaveRoom,
+  BackRoomList,
+};
+
+export default PartyRoomDetailButton;

--- a/components/party/roomDetail/PartyDetailButton.tsx
+++ b/components/party/roomDetail/PartyDetailButton.tsx
@@ -43,7 +43,7 @@ function ReportRoom({ roomId }: ParytButtonProps) {
         });
       }}
     >
-      신고
+      방 신고
     </button>
   );
 }
@@ -62,21 +62,27 @@ function ShareRoom() {
   );
 }
 
-function JoinRoom({ roomId }: ParytButtonProps) {
+type ReprashProps = ParytButtonProps & {
+  fetchRoomDetail: () => void;
+};
+
+function JoinRoom({ roomId, fetchRoomDetail }: ReprashProps) {
   const handlerJoin = async () => {
     await instance.post(`/party/rooms/${roomId}/join`).catch((error) => {
       console.error(error);
     });
+    fetchRoomDetail();
   };
 
-  <button onClick={handlerJoin}>참여하기</button>;
+  return <button onClick={handlerJoin}>참여하기</button>;
 }
 
-function LeaveRoom({ roomId }: ParytButtonProps) {
+function LeaveRoom({ roomId, fetchRoomDetail }: ReprashProps) {
   const handlerExit = async () => {
     await instance.patch(`/party/rooms/${roomId}`).catch((error) => {
       console.error(error);
     });
+    fetchRoomDetail();
   };
 
   return <button onClick={handlerExit}>방 나가기</button>;

--- a/components/party/roomDetail/PartyDetailCommentBox.tsx
+++ b/components/party/roomDetail/PartyDetailCommentBox.tsx
@@ -1,0 +1,102 @@
+import { useSetRecoilState } from 'recoil';
+import {
+  PartyComment,
+  PartyRoomDetail,
+  PartyRoomStatus,
+} from 'types/partyTypes';
+import { instance } from 'utils/axios';
+import { getTimeAgo } from 'utils/handleTime';
+import { modalState } from 'utils/recoil/modal';
+
+type PartyRoomDetailProps = {
+  partyRoomDetail: PartyRoomDetail;
+  fetchRoomDetail: () => void;
+};
+
+type CommentCreateBarProps = {
+  roomId: number;
+  roomStatus: PartyRoomStatus;
+  myNickname: string | null;
+  fetchRoomDetail: () => void;
+};
+
+export default function PartyDetailCommentBox({
+  partyRoomDetail,
+  fetchRoomDetail,
+}: PartyRoomDetailProps) {
+  const totalComments = partyRoomDetail.comments.length;
+
+  return (
+    <div>
+      <div>{partyRoomDetail.content}</div>
+      <div>댓글({totalComments})</div>
+      <CommentLine comments={partyRoomDetail.comments} />
+      <CommentCreateBar
+        roomId={partyRoomDetail.roomId}
+        roomStatus={partyRoomDetail.roomStatus}
+        myNickname={partyRoomDetail.myNickname}
+        fetchRoomDetail={fetchRoomDetail}
+      />
+    </div>
+  );
+}
+
+function CommentLine({ comments }: { comments: PartyComment[] }) {
+  const setModal = useSetRecoilState(modalState);
+
+  const reportComment = (commentId: number) => {
+    setModal({
+      partyReport: {
+        name: 'COMMENT',
+        commentId,
+      },
+      modalName: 'PARTY-REPORT',
+    });
+  };
+
+  return (
+    <>
+      {comments.map((comment) =>
+        comment.isHidden ? (
+          <div key={comment.commentId}>`숨김 처리된 댓글입니다.`</div>
+        ) : (
+          <div key={comment.commentId}>
+            <span>{comment.nickname}</span>
+            <span>
+              {comment.content}
+              {`(${getTimeAgo(comment.createDate)})`}
+              <button onClick={() => reportComment(comment.commentId)}>
+                신고
+              </button>
+            </span>
+          </div>
+        )
+      )}
+    </>
+  );
+}
+
+function CommentCreateBar({
+  roomId,
+  roomStatus,
+  myNickname,
+  fetchRoomDetail,
+}: CommentCreateBarProps) {
+  const handlerComments = async () => {
+    await instance.post(`/party/rooms/${roomId}/comments`);
+    fetchRoomDetail();
+  };
+
+  if (!myNickname || roomStatus === 'FINISH') {
+    return <> </>;
+  }
+
+  return (
+    <div>
+      <form onSubmit={handlerComments}>
+        <input type='text' />
+        <button type='submit'>댓글</button>
+      </form>
+    </div>
+  );
+}

--- a/components/party/roomDetail/PartyDetailProfile.tsx
+++ b/components/party/roomDetail/PartyDetailProfile.tsx
@@ -1,0 +1,62 @@
+import {
+  PartyRoomDetail,
+  PartyRoomStatus,
+  PartyRoomUser,
+} from 'types/partyTypes';
+import { dateToStringShort } from 'utils/handleTime';
+import PartyRoomDetailButton from './PartyDetailButton';
+
+type PartyDetailProfileProps = {
+  partyRoomDetail: PartyRoomDetail;
+  fetchRoomDetail: () => void;
+};
+
+type ProfileProps = {
+  partyRoomUser: PartyRoomUser;
+  roomStatus: PartyRoomStatus;
+};
+
+export default function PartyDetailProfile({
+  partyRoomDetail,
+  fetchRoomDetail,
+}: PartyDetailProfileProps) {
+  const { currentPeople, maxPeople, dueDate, roomId, roomStatus, roomUsers } =
+    partyRoomDetail;
+  // TODO: 방장에게 왕관 모양 씌워주기.
+  return (
+    <div>
+      <span>{`참여인원 : ${currentPeople}/${maxPeople}`}</span>
+      <span>{`마감기한 : ${dateToStringShort(new Date(dueDate))}`}</span>
+      {roomStatus !== 'OPEN' && <span>방장</span>}
+      {roomUsers.map((partyRoomUser) => (
+        <Profile
+          key={partyRoomUser.intraId}
+          partyRoomUser={partyRoomUser}
+          roomStatus={roomStatus}
+        />
+      ))}
+      <PartyRoomDetailButton.JoinRoom
+        roomId={roomId}
+        fetchRoomDetail={fetchRoomDetail}
+      />
+    </div>
+  );
+}
+
+function Profile({ partyRoomUser, roomStatus }: ProfileProps) {
+  const { intraId } = partyRoomUser;
+
+  return roomStatus === 'HIDDEN' || !intraId ? (
+    <></>
+  ) : roomStatus === 'OPEN' ? (
+    <>
+      <li>{partyRoomUser.nickname}</li>
+    </>
+  ) : (
+    <span>
+      <li key={intraId}>
+        <span>{partyRoomUser.nickname}</span>
+      </li>
+    </span>
+  );
+}

--- a/components/party/roomDetail/PartyDetailTitleBox.tsx
+++ b/components/party/roomDetail/PartyDetailTitleBox.tsx
@@ -1,22 +1,31 @@
-import { PartyRoomDetail } from 'types/partyTypes';
 import { getRemainTime } from 'utils/handleTime';
 import usePartyCategory from 'hooks/party/usePartyCategory';
 import PartyRoomDetailButton from './PartyDetailButton';
 
-export default function PartyDetailTitleBox(partyRoomDetail: PartyRoomDetail) {
+type PartyDetailTitleBoxProps = {
+  categoryId: number;
+  title: string;
+  roomId: number;
+  dueDate: string;
+};
+
+export default function PartyDetailTitleBox({
+  categoryId,
+  title,
+  roomId,
+  dueDate,
+}: PartyDetailTitleBoxProps) {
   const category = usePartyCategory().categories.find(
-    (category) => category.categoryId === partyRoomDetail.categoryId
+    (category) => category.categoryId === categoryId
   )?.categoryName;
 
   return (
     <>
-      <span>{'#' + category}</span>
+      <span>{`#${category}`}</span>
       <PartyRoomDetailButton.ShareRoom />
-      <span>{partyRoomDetail.title}</span>
-      <span>
-        {getRemainTime({ targetTime: new Date(partyRoomDetail.dueDate) })}
-      </span>
-      <PartyRoomDetailButton.ReportRoom roomId={partyRoomDetail.roomId} />
+      <span>{title}</span>
+      <span>{getRemainTime({ targetTime: new Date(dueDate) })}</span>
+      <PartyRoomDetailButton.ReportRoom roomId={roomId} />
     </>
   );
 }

--- a/components/party/roomDetail/PartyDetailTitleBox.tsx
+++ b/components/party/roomDetail/PartyDetailTitleBox.tsx
@@ -1,0 +1,22 @@
+import { PartyRoomDetail } from 'types/partyTypes';
+import { getRemainTime } from 'utils/handleTime';
+import usePartyCategory from 'hooks/party/usePartyCategory';
+import PartyRoomDetailButton from './PartyDetailButton';
+
+export default function PartyDetailTitleBox(partyRoomDetail: PartyRoomDetail) {
+  const category = usePartyCategory().categories.find(
+    (category) => category.categoryId === partyRoomDetail.categoryId
+  )?.categoryName;
+
+  return (
+    <>
+      <span>{'#' + category}</span>
+      <PartyRoomDetailButton.ShareRoom />
+      <span>{partyRoomDetail.title}</span>
+      <span>
+        {getRemainTime({ targetTime: new Date(partyRoomDetail.dueDate) })}
+      </span>
+      <PartyRoomDetailButton.ReportRoom roomId={partyRoomDetail.roomId} />
+    </>
+  );
+}

--- a/hooks/party/usePartyDetail.ts
+++ b/hooks/party/usePartyDetail.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { PartyRoomDetail } from 'types/partyTypes';
+import { instance } from 'utils/axios';
+
+const PartyButtonEvent = ({
+  roomId,
+  status,
+  comment = '',
+}: {
+  roomId: number;
+  status: 'JOIN' | 'LEAVE' | 'START' | 'COMMENT';
+  comment?: string;
+}) => {
+  const [partyRoomDetail, setPartyRoomDetail] = useState<PartyRoomDetail>({});
+  const [click, setClick] = useState(false);
+  const fetchRoomDetail = async () => {
+    instance.get(`/party/rooms/${roomId}`).then(({ data }) => {
+      setPartyRoomDetail(data);
+    });
+  };
+
+  useEffect(() => {
+    switch (status) {
+      case 'JOIN':
+        instance.post(`/party/rooms/${roomId}`);
+        break;
+      case 'LEAVE':
+        instance.patch(`/party/rooms/${roomId}`);
+        break;
+      case 'START':
+        instance.post(`/party/rooms/${roomId}/start`);
+        break;
+      case 'COMMENT':
+        instance
+          .post(`/party/rooms/${roomId}/comments`, { comment })
+          .catch((err) => {
+            console.error(err);
+          });
+        break;
+    }
+    fetchRoomDetail();
+  }, [partyRoomDetail]);
+  setClick(!click);
+
+  return { partyRoomDetail };
+};
+
+export default PartyButtonEvent;

--- a/pages/api/pingpong/party/rooms/[roomId]/categorys.ts
+++ b/pages/api/pingpong/party/rooms/[roomId]/categorys.ts
@@ -1,0 +1,24 @@
+import { PartyCategory } from 'types/partyTypes';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse<PartyCategory[]>
+) {
+  const categorys: PartyCategory[] = [
+    {
+      categoryId: 1,
+      categoryName: '보드게임',
+    },
+    {
+      categoryId: 2,
+      categoryName: '콘솔게임',
+    },
+    {
+      categoryId: 3,
+      categoryName: '기타',
+    },
+  ];
+
+  res.status(200).json(categorys);
+}

--- a/pages/api/pingpong/party/rooms/[roomId]/index.ts
+++ b/pages/api/pingpong/party/rooms/[roomId]/index.ts
@@ -1,0 +1,76 @@
+import { PartyRoomDetail, PartyRoomStatus } from 'types/partyTypes';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse<PartyRoomDetail>
+) {
+  const templetes: PartyRoomDetail[] = [];
+  const roomStatus: PartyRoomStatus[] = ['HIDDEN', 'OPEN', 'START', 'FINISH'];
+
+  for (let i = 1; i < 11; i++) {
+    const date = new Date().toString();
+    const create = i;
+
+    templetes.push({
+      roomId: i,
+      title: '파티룸 ' + i,
+      categoryId: 1,
+      currentPeople: 3,
+      minPeople: 3,
+      maxPeople: 5,
+      dueDate: date,
+      createDate: date,
+      myNickname: create === 1 ? 'host' : 'guest' + create,
+      hostNickname: 'host',
+      content: 'content is good',
+      roomStatus: roomStatus[i % 4],
+      roomUsers: [
+        {
+          userRoomId: 1,
+          nickname: 'host',
+          intraId: 'juha',
+        },
+        {
+          userRoomId: 2,
+          nickname: 'guest1',
+          intraId: 'wojeong',
+        },
+        {
+          userRoomId: 3,
+          nickname: 'guest2',
+          intraId: 'jeywon',
+        },
+      ],
+      comments: [
+        {
+          commentId: 1,
+          nickname: 'host',
+          content: 'host comment달았어요',
+          isHidden: false,
+          createDate: new Date(),
+        },
+        {
+          commentId: 2,
+          nickname: 'guest1',
+          content: 'guest1 comment달았어요',
+          isHidden: true,
+          createDate: new Date(),
+        },
+        {
+          commentId: 3,
+          nickname: 'hello world',
+          content: 'hello world comment달았어요',
+          isHidden: false,
+          createDate: new Date(),
+        },
+      ],
+    });
+  }
+
+  const detail = templetes.find(
+    (data) => _req.query.roomId === data.roomId.toString()
+  );
+
+  res.status(200).json(detail);
+}

--- a/pages/api/pingpong/party/rooms/[roomId]/start/index.ts
+++ b/pages/api/pingpong/party/rooms/[roomId]/start/index.ts
@@ -1,0 +1,8 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse<string>
+) {
+  res.status(201).json('good!');
+}

--- a/pages/party/[roomId]/index.tsx
+++ b/pages/party/[roomId]/index.tsx
@@ -1,0 +1,47 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { PartyRoomDetail } from 'types/partyTypes';
+import { instance } from 'utils/axios';
+import PartyDetailCommentBox from 'components/party/roomDetail/PartyDetailCommentBox';
+import PartyDetailProfile from 'components/party/roomDetail/PartyDetailProfile';
+import PartyDetailTitleBox from 'components/party/roomDetail/PartyDetailTitleBox';
+
+export default function PartyDetailPage() {
+  const roomId = useRouter().query.roomId;
+  const [partyRoomDetail, setPartyRoomDetail] = useState<
+    PartyRoomDetail | undefined
+  >(undefined);
+
+  useEffect(() => {
+    fetchRoomDetail();
+  }, []);
+
+  const fetchRoomDetail = () => {
+    instance
+      .get(`/party/rooms/${roomId}`)
+      .then(({ data }) => {
+        setPartyRoomDetail(data);
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  };
+
+  return partyRoomDetail && partyRoomDetail.roomStatus !== 'HIDDEN' ? (
+    <div>
+      <PartyDetailTitleBox {...partyRoomDetail} />
+      <PartyDetailProfile
+        partyRoomDetail={partyRoomDetail}
+        fetchRoomDetail={fetchRoomDetail}
+      />
+      <PartyDetailCommentBox
+        partyRoomDetail={partyRoomDetail}
+        fetchRoomDetail={fetchRoomDetail}
+      />
+    </div>
+  ) : partyRoomDetail === undefined ? (
+    <div>loading...</div>
+  ) : (
+    <div>방이 존재하지 않습니다.</div>
+  );
+}

--- a/types/modalTypes.ts
+++ b/types/modalTypes.ts
@@ -35,6 +35,8 @@ type StoreModal = 'MANUAL' | 'COIN_HISTORY';
 
 type TournamentModal = 'REGISTRY' | 'MANUAL';
 
+type PartyModal = 'REPORT';
+
 type AdminModal =
   | 'PROFILE'
   | 'USER-COIN'
@@ -52,7 +54,8 @@ type AdminModal =
   | 'COINPOLICY_EDIT'
   | 'CHECK_SEND_NOTI'
   | 'TOURNAMENT_BRAKET_EDIT'
-  | 'TOURNAMENT_PARTICIPANT_EDIT';
+  | 'TOURNAMENT_PARTICIPANT_EDIT'
+  | 'PARTY_EDIT';
 
 type ModalName =
   | null
@@ -113,6 +116,13 @@ export interface IRandomItem {
   color: RandomColors;
 }
 
+export interface PartyReportModalData {
+  name: 'COMMENT' | 'ROOM' | 'NOSHOW';
+  commentId?: number;
+  roomId?: number;
+  userIntraId?: number;
+}
+
 export interface Modal {
   modalName: ModalName;
   manual?: Manual;
@@ -142,4 +152,5 @@ export interface Modal {
   tournamentInfo?: TournamentInfo;
   tournament?: ITournament;
   tournamentId?: number;
+  partyReport?: PartyReportModalData;
 }

--- a/types/partyTypes.ts
+++ b/types/partyTypes.ts
@@ -1,4 +1,5 @@
 export type PartyRoomStatus = 'OPEN' | 'START' | 'FINISH' | 'HIDDEN' | 'FAIL';
+
 /**
  * @typedef {Object} PartyRoom
  *  @property {string} [creatorIntraId] - adminAPI로 조회시 존재
@@ -33,7 +34,7 @@ export type PartyRoomDetail = PartyRoom & {
  *  @property {string | null} [intraId] - Room 시작시 or Admin으로 조회시 존재
  */
 export type PartyRoomUser = {
-  roomUserId: number;
+  userRoomId: number;
   nickname: string;
   intraId: string | null;
 };
@@ -45,8 +46,6 @@ export type PartyRoomUser = {
 export type PartyComment = {
   commentId: number;
   nickname: string;
-  intraid: string | null;
-  isexist: boolean;
   content: string;
   isHidden: boolean;
   createDate: string;

--- a/utils/handleTime.ts
+++ b/utils/handleTime.ts
@@ -195,3 +195,35 @@ export const dateToKRLocaleTimeString = (d: Date) => {
     hour12: true,
   });
 };
+
+/**
+ *  타겟 시간과 비교 시간을 받아 남은 시간을 반환
+ *  @param {Date} targetTime
+ *  @param {Date} cmpTime default: 현재 시간
+ *  @return x년, x월, x일, x시간, x분 순으로 값이 있으면 그 값을 반환.
+ */
+export const getRemainTime = ({
+  targetTime,
+  cmpTime = new Date(),
+}: {
+  targetTime: Date;
+  cmpTime?: Date;
+}) => {
+  const year = targetTime.getFullYear() - cmpTime.getFullYear();
+  const month = targetTime.getMonth() - cmpTime.getMonth();
+  const day = targetTime.getDate() - cmpTime.getDate();
+  const hour = targetTime.getHours() - cmpTime.getHours();
+  const min = targetTime.getMinutes() - cmpTime.getMinutes();
+
+  return year > 0
+    ? `${year}년 남음`
+    : month > 0
+    ? `${month}개월 남음`
+    : day > 0
+    ? `${day}일 남음`
+    : hour > 0
+    ? `${hour}시간 남음`
+    : min > 0
+    ? `${min}분 남음`
+    : `마감`;
+};


### PR DESCRIPTION
 ## 📌 개요 
  - 파티 상세 페이지 로직 완성

 ## 💻 작업사항
  - 파티 상세 페이지를 title, profile, comment로 크게 3개의 컴포넌트로 나누어 작성
  - 버튼은 PartyButton 컴포넌트에 몰아 넣었습니다.
  - 각 컴포넌트에서 필요한 컴포넌트는 각 컴포넌트에 정의하였습니다.