### PR TITLE
[Fix] 모집 유저 기능의 mock api 제거

### DIFF
--- a/components/modal/recruitment/CancelModal.tsx
+++ b/components/modal/recruitment/CancelModal.tsx
@@ -3,7 +3,7 @@ import { AxiosResponse } from 'axios';
 import { useMutation } from 'react-query';
 import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
 import { Box, Button, Modal, Typography } from '@mui/material';
-import { mockInstance } from 'utils/mockAxios';
+import { instance } from 'utils/axios';
 import {
   applicationAlertState,
   applicationModalState,
@@ -24,7 +24,7 @@ function CancelModal(props: ICancelModalProps) {
 
   const { mutate } = useMutation(
     (applicationId: number | null): Promise<AxiosResponse> => {
-      return mockInstance.delete(
+      return instance.delete(
         `/recruitments/${recruitId}/applications/${applicationId}`
       );
     }

--- a/components/tournament/TournamentMegaphone.tsx
+++ b/components/tournament/TournamentMegaphone.tsx
@@ -3,7 +3,6 @@ import { useState, useEffect, useRef } from 'react';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 import { TournamentInfo } from 'types/tournamentTypes';
 import { instance } from 'utils/axios';
-import { mockInstance } from 'utils/mockAxios';
 import useInterval from 'hooks/useInterval';
 import styles from 'styles/Layout/MegaPhone.module.scss';
 
@@ -38,11 +37,10 @@ const TournamentMegaphone = () => {
   const router = useRouter();
 
   function getTournamentListHandler() {
-    return mockInstance
-      .get(`tournament?page=1&status=예정&size=5`)
-      .then((res) => {
-        setTournamentList(res.data.tournaments);
-      });
+    // // FIXME : mockInstance 사용 중이었던 점 확인 필요함
+    return instance.get(`tournament?page=1&status=예정&size=5`).then((res) => {
+      setTournamentList(res.data.tournaments);
+    });
   }
 
   const goTournamentPage = (event: React.MouseEvent<HTMLDivElement>) => {

--- a/hooks/recruit/useCheckRecruit.ts
+++ b/hooks/recruit/useCheckRecruit.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useQuery } from 'react-query';
-import { mockInstance } from 'utils/mockAxios';
+import { instance } from 'utils/axios';
 
 const useCheckRecruit = () => {
   const [isRecruiting, setIsRecruiting] = useState<boolean>(false);
@@ -8,7 +8,7 @@ const useCheckRecruit = () => {
     queryKey: ['checkRecruit'],
     staleTime: 1000 * 60 * 5, // 5분
     queryFn: async () => {
-      const res = await mockInstance.get('/recruitments');
+      const res = await instance.get('/recruitments');
       return res.data;
     },
   });

--- a/hooks/recruit/useCheckRecruit.ts
+++ b/hooks/recruit/useCheckRecruit.ts
@@ -8,7 +8,7 @@ const useCheckRecruit = () => {
     queryKey: ['checkRecruit'],
     staleTime: 1000 * 60 * 5, // 5분
     queryFn: async () => {
-      const res = await instance.get('/recruitments');
+      const res = await instance.get('/recruitments?page=1&size=1'); // 1개만 불러와서 존재 여부만 확인
       return res.data;
     },
   });

--- a/hooks/recruit/useGetRecruitResult.ts
+++ b/hooks/recruit/useGetRecruitResult.ts
@@ -1,6 +1,6 @@
 import { useQuery } from 'react-query';
 import { recruitmentResult } from 'types/recruit/recruitments';
-import { mockInstance } from 'utils/mockAxios';
+import { instance } from 'utils/axios';
 
 const useGetRecruitResult = (recruitId: string, applicationId?: number) => {
   const { data, isLoading, isError } = useQuery<recruitmentResult>({
@@ -14,7 +14,7 @@ const useGetRecruitResult = (recruitId: string, applicationId?: number) => {
           interviewDate: null,
         };
       }
-      const res = await mockInstance.get(
+      const res = await instance.get(
         `/recruitments/${recruitId}/applications/${applicationId}/result`
       );
       return res.data;

--- a/hooks/recruit/useInfiniteRecruitList.ts
+++ b/hooks/recruit/useInfiniteRecruitList.ts
@@ -1,14 +1,12 @@
 import { useEffect, useRef } from 'react';
 import { recruitmentListData } from 'types/recruit/recruitments';
+import { instance } from 'utils/axios';
 import { InfiniteScroll } from 'utils/infinityScroll';
-import { mockInstance } from 'utils/mockAxios';
 
 const fetchRecruitList = (page: number) => {
-  return mockInstance
-    .get(`/recruitments?page=${page}&size=${8}`)
-    .then((res) => {
-      return res.data;
-    });
+  return instance.get(`/recruitments?page=${page}&size=${8}`).then((res) => {
+    return res.data;
+  });
 };
 
 const useInfiniteRecruitList = () => {

--- a/hooks/recruit/useRecruitDetail.ts
+++ b/hooks/recruit/useRecruitDetail.ts
@@ -1,13 +1,13 @@
 import { useQuery } from 'react-query';
 import { IRecruitmentDetail } from 'types/recruit/recruitments';
-import { mockInstance } from 'utils/mockAxios';
+import { instance } from 'utils/axios';
 
 const useRecruitDetail = (recruitId: number) => {
   const { data, isLoading } = useQuery<IRecruitmentDetail>({
     queryKey: ['recruitDetail', recruitId],
     queryFn: async () => {
       if (Number.isNaN(recruitId)) return null;
-      const res = await mockInstance.get(`/recruitments/${recruitId}`);
+      const res = await instance.get(`/recruitments/${recruitId}`);
       return res.data;
     },
     refetchOnWindowFocus: false,

--- a/hooks/recruit/useRecruitDetailUser.ts
+++ b/hooks/recruit/useRecruitDetailUser.ts
@@ -1,12 +1,12 @@
 import { useQuery } from 'react-query';
 import { IRecruitmentDetailUser } from 'types/recruit/recruitments';
-import { mockInstance } from 'utils/mockAxios';
+import { instance } from 'utils/axios';
 
 const useRecruitDetailUser = (recruitId: number, applicationId: number) => {
   const { data, isLoading } = useQuery<IRecruitmentDetailUser>({
     queryKey: ['recruitDetailUser', recruitId, applicationId],
     queryFn: async () => {
-      const res = await mockInstance.get(
+      const res = await instance.get(
         `/recruitments/${recruitId}/applications/${applicationId}`
       );
       return res.data;

--- a/hooks/recruit/useUserApplicationForm.ts
+++ b/hooks/recruit/useUserApplicationForm.ts
@@ -4,7 +4,7 @@ import {
   ApplicationFormType,
   IApplicantAnswer,
 } from 'types/recruit/recruitments';
-import { mockInstance } from 'utils/mockAxios';
+import { instance } from 'utils/axios';
 
 function useUserApplicationForm(
   recruitId: number,
@@ -14,11 +14,11 @@ function useUserApplicationForm(
   const { mutate } = useMutation(
     (applicantAnswers: IApplicantAnswer[]): Promise<AxiosResponse> => {
       if (mode === 'APPLY' && applicationId === null) {
-        return mockInstance.post(`/recruitments/${recruitId}/applications`, {
+        return instance.post(`/recruitments/${recruitId}/applications`, {
           form: applicantAnswers,
         });
       }
-      return mockInstance.patch(
+      return instance.patch(
         `/recruitments/${recruitId}/applications/${applicationId}`,
         { form: applicantAnswers }
       );


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - #1326 
  - 모집 유저 기능에서 사용하고 있던 mock api를 제거했습니다.
  - `useCheckRecruit` 훅 오류 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 모집 유저 기능의 `mockInstance`를 제거했습니다 (관리자는 그대로 놔뒀어요!)
  - 저번 기수 작업이었던 `TournamentMegaphone`에 `mockInstance`를 사용하고 있던 부분이 남아있어서 수정했습니다. 바꾸면 안되는 부분인지 확인 필요합니다 @greatSweetMango 
  - 모집 중인 공고가 있는지 확인하는 `useCheckRecruit` 훅에서 query string을 빼고 요청해서 발생하던 500 에러를 수정했습니다.
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
