### PR TITLE
[Fix] 지원서 보기/수정 페이지 api 응답 형식에 맞게 수정

### DIFF
--- a/components/recruit/Application/applicationFormItems/MultiCheckForm.tsx
+++ b/components/recruit/Application/applicationFormItems/MultiCheckForm.tsx
@@ -34,7 +34,9 @@ function MultiCheckForm(props: IitemProps) {
               value={check.id}
               control={
                 <Checkbox
-                  defaultChecked={answer?.checkedList?.includes(check.id)}
+                  defaultChecked={answer?.checkedList
+                    ?.map((check) => check.checkListId)
+                    .includes(check.id)}
                 />
               }
               label={check.contents}

--- a/components/recruit/Application/applicationFormItems/SingleCheckForm.tsx
+++ b/components/recruit/Application/applicationFormItems/SingleCheckForm.tsx
@@ -28,7 +28,8 @@ function SingleCheckForm(props: IitemProps) {
   };
 
   useEffect(() => {
-    if (answer && answer.checkedList) setSingleCheck(answer?.checkedList);
+    if (answer && answer.checkedList)
+      setSingleCheck(answer?.checkedList.map((check) => check.checkListId));
   }, [answer]);
 
   return (

--- a/types/recruit/recruitments.d.ts
+++ b/types/recruit/recruitments.d.ts
@@ -55,14 +55,15 @@ export interface IRecruitmentDetail {
 export interface IApplicantAnswer {
   questionId: number;
   inputType: recruitmentQuestionTypes;
-  checkedList?: number[];
-  answer?: string;
+  checkedList: { checkListId: number; content: string }[];
+  answer: string | null;
 }
 
 export type ApplicationFormType = 'APPLY' | 'VIEW' | 'EDIT';
+
 export interface IUserApplicationInfo {
   applicationId: number;
-  endDate: string;
+  endTime: string;
   title: string;
   content: string;
 }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - #1371 
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 지원서 보기/수정 페이지에서 인터페이스 속성이 맞지 않아 제출한 지원서 내용이 보이지 않던 문제 수정했습니다.
  - 내 응답의 checkedList는 체크박스 id만 들어오던 방식에서 => 체크박스 id + 해당 항목 내용이 같이 들어오는 것으로 수정됐습니다.
  - 내가 제출한 지원서 상세보기 api에서
    - check박스 응답은 answer를 null로
    - text 응답은 checkedList를 [] 빈 배열로 응답
    - 따라서 기존의 속성의 옵션 설정 없앴습니다.
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
