### PR TITLE
[Feat] 프론트엔드 테스트 시 로그인 조회하지 않도록 변경 #1455

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -29,7 +29,7 @@ type AppLayoutProps = {
   children: React.ReactNode;
 };
 
-export default function AppLayout({ children }: AppLayoutProps) {
+function AppLayoutBuild({ children }: AppLayoutProps) {
   const user = useUser();
   const presentPath = useRouter().asPath;
   const openCurrentMatch = useRecoilValue(openCurrentMatchState);
@@ -91,3 +91,75 @@ export default function AppLayout({ children }: AppLayoutProps) {
       return <>{children}</>;
   }
 }
+
+function AppLayoutDev({ children }: AppLayoutProps) {
+  // const user = useUser();
+  const presentPath = useRouter().asPath;
+  // const openCurrentMatch = useRecoilValue(openCurrentMatchState);
+
+  // useAxiosResponse();
+  // useGetUserSeason(presentPath);
+  // useSetAfterGameModal();
+  // useLiveCheck(presentPath);
+  // useAnnouncementCheck(presentPath);
+
+  // if (!user || !user.intraId) return null;
+
+  switch (true) {
+    case presentPath.includes('/takgu/admin'):
+      // if (!user.isAdmin) return <AdminReject />;
+      return <AdminLayout>{children}</AdminLayout>;
+
+    case presentPath.includes('/takgu/recruit'):
+      return <RecruitLayout>{children}</RecruitLayout>;
+
+    // case presentPath === '/takgu/statistics' && user.isAdmin:
+    //   return (
+    //     <UserLayout>
+    //       <Statistics />
+    //     </UserLayout>
+    //   );
+
+    case presentPath.includes('/takgu'):
+      return (
+        <>
+          <UserLayout>
+            <HeaderStateContext>
+              <Header />
+            </HeaderStateContext>
+            <PlayButton />
+            <div className={styles.topInfo}>
+              <Megaphone />
+              {/* {openCurrentMatch && <CurrentMatch />} */}
+              {presentPath === '/' && <MainPageProfile />}
+            </div>
+            {children}
+            <Footer />
+          </UserLayout>
+          <ModalProvider />
+        </>
+      );
+
+    case presentPath.includes('/agenda'):
+      return (
+        <>
+          <AgendaUserLayout>
+            <AgendaHeader />
+            {children}
+            <AgendaFooter />
+          </AgendaUserLayout>
+        </>
+      );
+    default:
+      return <>{children}</>;
+  }
+}
+
+let AppLayout;
+if (process.env.NODE_ENV === 'development') {
+  console.log('DEV MODE::: AppLayoutDev');
+  AppLayout = AppLayoutDev;
+} else {
+  AppLayout = AppLayoutBuild;
+}
+export default AppLayout;

--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,6 @@ const nextConfig = {
   reactStrictMode: false,
   env: {
     BASE_URL: process.env.BASE_URL,
-    NODE_ENV: process.env.NODE_ENV,
   },
   images: {
     domains: [

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,7 @@ const nextConfig = {
   reactStrictMode: false,
   env: {
     BASE_URL: process.env.BASE_URL,
+    NODE_ENV: process.env.NODE_ENV,
   },
   images: {
     domains: [


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 프론트엔트 테스트 시 로그인 토큰이 계속 필요한데요, 로그인하지 않고 테스트할 경우가 있습니다.
  - 로그인하지 않고 테스트할 수 있게... 리턴했습니다.
  - 
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - config : process.env.NODE_ENV를 받아오며, npm run dev로 돌릴 때 'development'로 세팅됩니다.
  - Layout.tsx : 이를 이용하여 appLayout이 빌드시와 데브서버 시 각각 다른 컴포넌트를 리턴하게 만들었습니다.. 
  현재는 useUser, useSeason등 api 콜 하고 setError하는 부분을 전부 주석처리한 코드를 리턴하는데, 
  이후 개발하면서는 useUser는 사용하게 될 것 같습니다.
  최종적으로는 takgu 레이아웃을 분리해 이 안에서만 useSeason 등 사용하게 하는 게 좋겠지만, 우선은 테스트 목적으로 작성했습니다.

 이게 맞는지는 잘 모르겠기 때문에 혹시라도 보시고 이건아니지 싶으시면 조언 부탁드립니다. 
