### PR TITLE
[Feat] 수정 modal 추가 및 클릭 이벤트 에러 처리 #1481

### DIFF
--- a/components/agenda/modal/AgendaModalProvider.tsx
+++ b/components/agenda/modal/AgendaModalProvider.tsx
@@ -1,5 +1,6 @@
 import { useRecoilState } from 'recoil';
 import { agendaModalState } from 'utils/recoil/agenda/modalState';
+import ModifyModal from 'components/agenda/modal/ModifyModal';
 import NoticeModal from 'components/agenda/modal/NoticeModal';
 import ProceedCheckModal from 'components/agenda/modal/ProceedCheckModal';
 import { useModal } from 'components/agenda/modal/useModal';
@@ -10,7 +11,6 @@ const AgendaModalProvider = () => {
   const { closeModal } = useModal();
 
   let modalContent;
-
   if (modalProps) {
     switch (modalProps.type) {
       case 'proceedCheck':
@@ -23,11 +23,20 @@ const AgendaModalProvider = () => {
         modalContent = null;
     }
   }
+  const closeModalHandler = (e: React.MouseEvent) => {
+    if (e.target instanceof HTMLDivElement && e.target.id === 'modalOutside') {
+      closeModal();
+    }
+  };
 
   return (
     <>
       {modalProps && (
-        <div className={styles.backdrop} id='modalOutside' onClick={closeModal}>
+        <div
+          className={styles.backdrop}
+          id='modalOutside'
+          onClick={closeModalHandler}
+        >
           {modalContent}
         </div>
       )}

--- a/components/agenda/modal/AgendaModalProvider.tsx
+++ b/components/agenda/modal/AgendaModalProvider.tsx
@@ -19,6 +19,9 @@ const AgendaModalProvider = () => {
       case 'notice':
         modalContent = <NoticeModal {...modalProps} />;
         break;
+      case 'modify':
+        modalContent = <ModifyModal {...modalProps} />;
+        break;
       default:
         modalContent = null;
     }

--- a/components/agenda/modal/ModifyModal.tsx
+++ b/components/agenda/modal/ModifyModal.tsx
@@ -1,0 +1,33 @@
+import { agendaModal } from 'types/agenda/modalTypes';
+import ModifyAgendaForm from 'components/agenda/Form/ModifyAgendaForm';
+import { useModal } from 'components/agenda/modal/useModal';
+import { submitTeamForm } from 'pages/agenda/create';
+import styles from 'styles/agenda/modal/modal.module.scss';
+
+const ModifyModal = (props: agendaModal) => {
+  const { title, description, onCancel, onProceed, data } = props;
+  const { handleCancel, handleProceed } = useModal();
+  return (
+    <>
+      <div className={`${styles.modalContainer} ${styles.wide}`}>
+        {title && (
+          <div className={styles.titleContainer}>
+            <h1>{title}</h1>
+          </div>
+        )}
+        <div className={`${styles.contentContainer} ${styles.left}`}>
+          {description}
+        </div>
+        <div className={styles.formContainer}>
+          <ModifyAgendaForm data={data} handleSubmit={submitTeamForm} />
+        </div>
+        <div className={styles.buttonContainer}>
+          <button onClick={() => handleCancel(onCancel)}>취소</button>
+          <button onClick={() => handleProceed(onProceed)}>수정</button>{' '}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ModifyModal;

--- a/components/agenda/modal/ModifyModal.tsx
+++ b/components/agenda/modal/ModifyModal.tsx
@@ -1,11 +1,16 @@
 import { agendaModal } from 'types/agenda/modalTypes';
-import ModifyAgendaForm from 'components/agenda/Form/ModifyAgendaForm';
 import { useModal } from 'components/agenda/modal/useModal';
-import { submitTeamForm } from 'pages/agenda/create';
 import styles from 'styles/agenda/modal/modal.module.scss';
 
-const ModifyModal = (props: agendaModal) => {
-  const { title, description, onCancel, onProceed, data } = props;
+const ModifyModal = (
+  props: agendaModal & {
+    FormComponent: React.ComponentType<{
+      data: any;
+    }>;
+  }
+) => {
+  const { title, description, onCancel, onProceed, FormComponent, data } =
+    props;
   const { handleCancel, handleProceed } = useModal();
   return (
     <>
@@ -19,7 +24,7 @@ const ModifyModal = (props: agendaModal) => {
           {description}
         </div>
         <div className={styles.formContainer}>
-          <ModifyAgendaForm data={data} handleSubmit={submitTeamForm} />
+          <FormComponent data={data} />
         </div>
         <div className={styles.buttonContainer}>
           <button onClick={() => handleCancel(onCancel)}>취소</button>

--- a/components/agenda/modal/NoticeModal.tsx
+++ b/components/agenda/modal/NoticeModal.tsx
@@ -1,9 +1,10 @@
 import { agendaModal } from 'types/agenda/modalTypes';
+import { useModal } from 'components/agenda/modal/useModal';
 import styles from 'styles/agenda/modal/modal.module.scss';
-import { useModal } from './useModal';
 
 const NoticeModal = (props: agendaModal) => {
   const { title, description, onProceed } = props;
+  const { handleProceed } = useModal();
 
   return (
     <>
@@ -17,7 +18,7 @@ const NoticeModal = (props: agendaModal) => {
           <p>{description}</p>
         </div>
         <div className={styles.buttonContainer}>
-          <button onClick={onProceed}>확인</button>
+          <button onClick={() => handleProceed(onProceed)}>확인</button>{' '}
         </div>
       </div>
     </>

--- a/components/agenda/modal/NoticeModal.tsx
+++ b/components/agenda/modal/NoticeModal.tsx
@@ -18,7 +18,7 @@ const NoticeModal = (props: agendaModal) => {
           <p>{description}</p>
         </div>
         <div className={styles.buttonContainer}>
-          <button onClick={() => handleProceed(onProceed)}>확인</button>{' '}
+          <button onClick={() => handleProceed(onProceed)}>확인</button>
         </div>
       </div>
     </>

--- a/components/agenda/modal/ProceedCheckModal.tsx
+++ b/components/agenda/modal/ProceedCheckModal.tsx
@@ -1,4 +1,5 @@
 import { agendaModal } from 'types/agenda/modalTypes';
+import { useModal } from 'components/agenda/modal/useModal';
 import styles from 'styles/agenda/modal/modal.module.scss';
 
 const ProceedCheckModal = (props: agendaModal) => {
@@ -13,6 +14,8 @@ const ProceedCheckModal = (props: agendaModal) => {
     cancelText,
     extraButtons,
   } = props;
+
+  const { handleProceed, handleCancel } = useModal();
 
   return (
     <>
@@ -39,8 +42,12 @@ const ProceedCheckModal = (props: agendaModal) => {
           )}
         </div>
         <div className={styles.buttonContainer}>
-          <button onClick={onCancel}>{cancelText || '취소'}</button>
-          <button onClick={onProceed}>{proceedText || '확인'}</button>
+          <button onClick={() => handleCancel(onCancel)}>
+            {cancelText || '취소'}
+          </button>
+          <button onClick={() => handleProceed(onProceed)}>
+            {proceedText || '확인'}
+          </button>{' '}
         </div>
       </div>
     </>

--- a/components/agenda/modal/useModal.tsx
+++ b/components/agenda/modal/useModal.tsx
@@ -9,9 +9,19 @@ export const useModal = () => {
     setModalState(props);
   };
 
-  const closeModal = (e: React.MouseEvent) => {
+  const closeModal = () => {
     setModalState(null);
   };
 
-  return { openModal, closeModal };
+  const handleCancel = (onCancel?: () => void) => {
+    if (onCancel) onCancel();
+    closeModal();
+  };
+
+  const handleProceed = (onProceed?: () => void) => {
+    if (onProceed) onProceed();
+    closeModal();
+  };
+
+  return { openModal, closeModal, handleCancel, handleProceed };
 };

--- a/types/agenda/modalTypes.ts
+++ b/types/agenda/modalTypes.ts
@@ -1,4 +1,4 @@
-type AgendaModalType = 'notice' | 'proceedCheck';
+type AgendaModalType = 'notice' | 'proceedCheck' | 'modify';
 export interface agendaModal {
   type: AgendaModalType;
   title?: string;
@@ -11,4 +11,6 @@ export interface agendaModal {
   cancelText?: string;
   // 추가 버튼이 필요할 때
   extraButtons?: { text: string; callback: (e: React.MouseEvent) => void }[];
+  FormComponent?: React.FC<any>;
+  data?: any;
 }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 수정 modal 추가 및 클릭 이벤트 에러 처리
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  1. 수정 기본 모달 추가
  - 기존 title, description, onCancel, onProceed 가 동작하는 모달에 필요한 form 컴포넌트를 넣어 사용할 수 있도록 변경
  - 폼 제출은 onProceed로 전달하는 함수에서 정의되어야 함
     ```jsx
     const ModifyModal = (
        props: agendaModal & {
          FormComponent: React.ComponentType<{
            data: any;
          }>;
        }
      ) => {
        ...
        return (
          <>
             ...
              <div className={styles.formContainer}>
                <FormComponent data={data} />
              </div>
             ...
          </>
        );
      };
     ```
   
  2. 클릭 이벤트 에러 해결
  - 모달 어디든 클릭 이벤트가 발생한 경우 모달이 닫히는 오류
  - modalOutside를 지정하고 이벤트가 발생했을 경우, modalOutside일 경우에만 모달 close
  - onCancel, onProceed와 modalClose를 모두 포함한 handleCancel, handleProceed을 정의
     - 버튼 클릭 -> 지정된 함수를 실행한 후 모달을 닫을 수 있도록 함

 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  - handleCancel, handleProceed 함수 내에서 onCancel, onProceed와 modalClose 호출
 
## 💡관련 Issue
- #1481 
