### PR TITLE
[Bug] 로그인 보상을 수령해도 계속 화면이 뜨는 이슈 #1525

### DIFF
--- a/components/takgu/modal/event/WelcomeModal.tsx
+++ b/components/takgu/modal/event/WelcomeModal.tsx
@@ -53,6 +53,7 @@ export default function WelcomeModal() {
       const res = await instance.post(`/pingpong/users/attendance`);
       const updatedcoin = res.data;
       if (!updatedcoin) return;
+      queryClient.invalidateQueries('user');
       setModal({
         modalName: 'COIN-ANIMATION',
         CoinResult: {


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 리액트 쿼리의 'user' 키에 대한 정보가 저장되어 있어서 보상을 수령했는지 업데이트가 안되고있는 상황이였습니다.
  - 보상받기를 눌렀을 때 'user' 키에 대한 캐시를 초기화시켜서 새롭게 받아올 수 있도록 만들었습니다.
  - **테스트를 실제로 해보기 어려운 상황이여서 토이프로젝트를 만들어서 동작을 확인하고 올립니다. 테스트를 해주시면 감사합니다.. 모든 user key 를 가지고있는 데이터가 다시 패칭되기 때문에 문제가 있을 수도 있다고 생각합니다 ...** 
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 캐시를 무효화하는 로직을 버튼을 클릭시 무효화 할 수 있도록 옮겼습니다.
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 
