### PR TITLE
[Bug] 팀 상세 페이지 토스트 에러 #1522

### DIFF
--- a/components/agenda/teamDetail/TeamButtons.tsx
+++ b/components/agenda/teamDetail/TeamButtons.tsx
@@ -76,7 +76,7 @@ const TeamButtons = ({
           label: '팀 나가기',
           description: '확인 버튼을 누르면, 팀에서 나가게 됩니다.',
           onProceed: () =>
-            manageTeamDetail && manageTeamDetail('PATCH', 'team/cancel'),
+            manageTeamDetail && manageTeamDetail('PATCH', 'team/drop'),
         });
       } else if (authority === Authority.LEADER) {
         return renderButton(

--- a/hooks/useAxiosWithToast.ts
+++ b/hooks/useAxiosWithToast.ts
@@ -87,7 +87,7 @@ export default function useAxiosWithToast(instance: AxiosInstance) {
           setSnackbar({
             toastName: `response default`,
             severity: 'success',
-            message: `${message || '성공했습니다.'}'`,
+            message: `${message} 👍`,
             clicked: true,
           });
       }

--- a/pages/agenda/[agendaKey]/[teamUID]/index.tsx
+++ b/pages/agenda/[agendaKey]/[teamUID]/index.tsx
@@ -61,7 +61,7 @@ export default function TeamDetail() {
   const sendRequest = useFetchRequest().sendRequest;
 
   const shareTeamInfo = () => {
-    alert('공유하기');
+    alert('링크가 복사되었습니다.');
     const url = window.location.href;
     navigator.clipboard.writeText(url);
   };

--- a/utils/agenda/getAgendaSnackBarInfo.ts
+++ b/utils/agenda/getAgendaSnackBarInfo.ts
@@ -62,9 +62,13 @@ export default function getAgendaSnackBarInfo(
         severity: 'info',
         message: '팀이 폭파되었습니다.',
       },
+      '/team/drop': {
+        severity: 'info',
+        message: '팀에서 나갔습니다.',
+      },
       '/team/confirm': {
         severity: 'success',
-        message: '대회 정보가 성공적으로 확정되었습니다.',
+        message: '팀이 성공적으로 확정되었습니다.',
       },
       '/ticket': {
         severity: 'success',
@@ -77,6 +81,6 @@ export default function getAgendaSnackBarInfo(
   if (result) {
     return { severity: result.severity, message: result.message };
   } else {
-    return { severity: 'default', message: '뭔진 모르겠지만 성공!.' };
+    return { severity: 'default', message: '성공했습니다.' };
   }
 }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 팀 상세 페이지 토스트 에러
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
- 개인이 팀에서 나갈 시,  API 변경 + 토스트 메시지 변경 
  - 팀 상세 페이지에서 팀장일 때, 폭파하기를 하면 -> API: team/cancel -> 토스트 메시지: 팀을 폭파했습니다.
  - 팀 상세 페이지에서 팀원일 때, 나가기를 하면 -> API: team/drop -> 토스트 메시지: 팀에서 나갔습니다. 

- 링크 복사 alert 메시지 변경 :  alert('링크가 복사되었습니다.');

- 토스트 메시지 살짝 변경 사항
  - admin 페이지에서 나오는 토스트 메시지 '성공했습니다'로 변경
  - 팀 확정 메시지 변경 :  `message: '팀이 성공적으로 확정되었습니다.`