### PR TITLE
[Bug] router bug #1538

### DIFF
--- a/components/LoginChecker.tsx
+++ b/components/LoginChecker.tsx
@@ -7,7 +7,7 @@ interface LoginCheckerProps {
 }
 
 export default function LoginChecker({ children }: LoginCheckerProps) {
-  // return <>{children}</>;
+  return <>{children}</>;
 
   const [isLoading, loggedIn] = useLoginCheck();
   // return <>{children}</>;

--- a/components/agenda/Form/CreateTeamForm.tsx
+++ b/components/agenda/Form/CreateTeamForm.tsx
@@ -113,7 +113,9 @@ const SubmitTeamForm = (
           if (isEdit) {
             onProceed && onProceed();
           } else {
-            router.push(`/agenda/${agendaKey}/${res.teamKey}`);
+            router.push(
+              `/agenda/detail/team?agenda_key=${agendaKey}&team_key=${res.teamKey}`
+            );
           }
         },
         (err: string) => {

--- a/components/agenda/Form/CreateTeamForm.tsx
+++ b/components/agenda/Form/CreateTeamForm.tsx
@@ -10,12 +10,12 @@ import CheckBoxInput from 'components/agenda/Input/CheckboxInput';
 import DescriptionInput from 'components/agenda/Input/DescriptionInput';
 import SelectInput from 'components/agenda/Input/SelectInput';
 import TitleInput from 'components/agenda/Input/TitleInput';
+import { useModal } from 'components/agenda/modal/useModal';
+import AgendaLoading from 'components/agenda/utils/AgendaLoading';
 import useAgendaTeamKey from 'hooks/agenda/useAgendaTeamKey';
 import useFetchRequest from 'hooks/agenda/useFetchRequest';
 import styles from 'styles/agenda/Form/Form.module.scss';
-import { useModal } from '../modal/useModal';
-import AgendaLoading from '../utils/AgendaLoading';
-
+AgendaLoading;
 const teamlocation = ['SEOUL', 'GYEONGSAN', 'NIX'];
 interface CreateTeamFormProps {
   location: AgendaLocation | null;

--- a/components/agenda/Form/SubmitAgendaForm.tsx
+++ b/components/agenda/Form/SubmitAgendaForm.tsx
@@ -148,7 +148,7 @@ const SubmitAgendaForm = async (
             onProceed && onProceed();
           if (!isEdit) {
             console.log(res.data.agendaKey);
-            router.push(`/agenda/${res.data.agendaKey}`);
+            router.push(`/agenda/detail?agenda_key=${res.data.agendaKey}`);
           }
         })
         .catch((err) => {

--- a/components/agenda/Home/AgendaList.tsx
+++ b/components/agenda/Home/AgendaList.tsx
@@ -56,7 +56,7 @@ const AgendaListItem = ({
   setSelectedItem?: (key: number) => void;
 }) => {
   const router = useRouter();
-  const href = `/agenda/${agendaInfo.agendaKey}`;
+  const href = `/agenda/detail?agenda_key=${agendaInfo.agendaKey}`;
   return (
     <button
       className={`${styles.agendaListItemBtn} ${

--- a/components/agenda/Home/MyTeamInfo.tsx
+++ b/components/agenda/Home/MyTeamInfo.tsx
@@ -17,14 +17,8 @@ const MyTeamInfo = ({
     return <div>참가중인 일정이 없습니다.</div>;
   }
   const startDate = new Date(myTeamInfo.agendaStartTime as string);
-
   return (
-    <Link
-      href={`/agenda/detail?agenda_key=${myTeamInfo.agendaKey}${
-        myTeamInfo.teamKey ? '/' + myTeamInfo.teamKey : ''
-      }`}
-      key={idx}
-    >
+    <Link href={`/agenda/detail?agenda_key=${myTeamInfo.agendaKey}`} key={idx}>
       <div className={styles.Container} key={idx}>
         <div className={agendastyles.agendaDateBox}>
           <div className={agendastyles.agendaStartDateMonth}>

--- a/components/agenda/Home/MyTeamInfo.tsx
+++ b/components/agenda/Home/MyTeamInfo.tsx
@@ -20,7 +20,7 @@ const MyTeamInfo = ({
 
   return (
     <Link
-      href={`/agenda/${myTeamInfo.agendaKey}${
+      href={`/agenda/detail?agenda_key=${myTeamInfo.agendaKey}${
         myTeamInfo.teamKey ? '/' + myTeamInfo.teamKey : ''
       }`}
       key={idx}

--- a/components/agenda/Layout/MenuBar.tsx
+++ b/components/agenda/Layout/MenuBar.tsx
@@ -43,7 +43,7 @@ const MenuBar = ({ headerstate }: { headerstate: HeaderContextState }) => {
       >
         <MenuBarContent
           content={`Hello. ${user?.intraId}`}
-          href={`/agenda/profile/${user?.intraId}`}
+          href={`/agenda/profile/user?id=${user?.intraId}`}
           as='h2'
         />
         <MenuBarContent content='Agenda' href='/agenda' as='h1' />

--- a/components/agenda/agendaDetail/AgendaInfo.tsx
+++ b/components/agenda/agendaDetail/AgendaInfo.tsx
@@ -25,7 +25,7 @@ const hostMode = ({ router, agendaKey }: CallbackProps) => {
 };
 
 const subscribeTeam = ({ router, agendaKey }: CallbackProps) => {
-  router.push(`/agenda/${agendaKey}/create-team`);
+  router.push(`/agenda/detail/team/create?agenda_key=${agendaKey}`);
 };
 
 const submitResults = ({ router, agendaKey }: CallbackProps) => {

--- a/components/agenda/agendaDetail/AgendaInfo.tsx
+++ b/components/agenda/agendaDetail/AgendaInfo.tsx
@@ -52,7 +52,7 @@ const copyLink = () => {
 };
 
 const hostMode = ({ router, agendaKey }: CallbackProps) => {
-  router.push(`/agenda/${agendaKey}/host/modify`);
+  router.push(`/agenda/detail/host?agenda_key=${agendaKey}`);
 };
 
 const subscribeTeam = ({ router, agendaKey }: CallbackProps) => {

--- a/components/agenda/agendaDetail/AgendaInfo.tsx
+++ b/components/agenda/agendaDetail/AgendaInfo.tsx
@@ -29,7 +29,7 @@ const subscribeTeam = ({ router, agendaKey }: CallbackProps) => {
 };
 
 const submitResults = ({ router, agendaKey }: CallbackProps) => {
-  router.push(`/agenda/${agendaKey}/host/result`);
+  router.push(`/agenda/detail/host/result?agenda_key=${agendaKey}`);
 };
 
 export default function AgendaInfo({

--- a/components/agenda/agendaDetail/tabs/AgendaAnnouncements.tsx
+++ b/components/agenda/agendaDetail/tabs/AgendaAnnouncements.tsx
@@ -1,23 +1,18 @@
 import { useRouter } from 'next/router';
 import { AnnouncementProps } from 'types/agenda/agendaDetail/announcementTypes';
 import AnnouncementItem from 'components/agenda/agendaDetail/tabs/AnnouncementItem';
-import { UploadBtn } from 'components/agenda/button/UploadBtn';
 import PageNation from 'components/Pagination';
 import usePageNation from 'hooks/agenda/usePageNation';
 import styles from 'styles/agenda/agendaDetail/tabs/AgendaAnnouncements.module.scss';
 
 export default function AgendaAnnouncements({ isHost }: { isHost: boolean }) {
   const router = useRouter();
-  const { agendaKey } = router.query;
+  const agendaKey = router.query.agenda_key;
 
   const { content, PagaNationElementProps } = usePageNation<AnnouncementProps>({
     url: `/announcement`,
     params: { agenda_key: agendaKey },
   });
-
-  const newAnnouncement = () => {
-    router.push(`/agenda/${agendaKey}/host/createAnnouncement`);
-  };
 
   return (
     <>
@@ -36,12 +31,6 @@ export default function AgendaAnnouncements({ isHost }: { isHost: boolean }) {
           <div className={styles.container}>공지사항이 없습니다.</div>
         )}
         <PageNation {...PagaNationElementProps} />
-
-        {isHost ? (
-          <div className={styles.buttonWarp}>
-            <UploadBtn text='공지사항 추가' onClick={newAnnouncement} />
-          </div>
-        ) : null}
       </div>
     </>
   );

--- a/components/agenda/agendaDetail/tabs/AgendaAnnouncements.tsx
+++ b/components/agenda/agendaDetail/tabs/AgendaAnnouncements.tsx
@@ -1,19 +1,22 @@
-import { useRouter } from 'next/router';
 import { AnnouncementProps } from 'types/agenda/agendaDetail/announcementTypes';
 import AnnouncementItem from 'components/agenda/agendaDetail/tabs/AnnouncementItem';
+import AgendaLoading from 'components/agenda/utils/AgendaLoading';
 import PageNation from 'components/Pagination';
+import useAgendaKey from 'hooks/agenda/useAgendaKey';
 import usePageNation from 'hooks/agenda/usePageNation';
 import styles from 'styles/agenda/agendaDetail/tabs/AgendaAnnouncements.module.scss';
 
 export default function AgendaAnnouncements({ isHost }: { isHost: boolean }) {
-  const router = useRouter();
-  const agendaKey = router.query.agenda_key;
+  const agendaKey = useAgendaKey();
 
   const { content, PagaNationElementProps } = usePageNation<AnnouncementProps>({
     url: `/announcement`,
     params: { agenda_key: agendaKey },
   });
 
+  if (!agendaKey || !content) {
+    return <AgendaLoading />;
+  }
   return (
     <>
       <div className={styles.announcementsList}>

--- a/components/agenda/agendaDetail/tabs/ParticipantTeam.tsx
+++ b/components/agenda/agendaDetail/tabs/ParticipantTeam.tsx
@@ -4,10 +4,12 @@ import {
   ParticipantTeamProps,
   PeopleCount,
 } from 'types/agenda/agendaDetail/tabs/participantTypes';
+import AgendaLoading from 'components/agenda/utils/AgendaLoading';
 import { countCoalitions } from 'components/agenda/utils/coalition/countCoalitions';
 import { getCoalitionEnum } from 'components/agenda/utils/coalition/getCoalitionEnum';
 import ColorList from 'components/agenda/utils/ColorList';
 import TeamLeaderIcon from 'public/image/agenda/rock-and-roll-hand.svg';
+import useAgendaKey from 'hooks/agenda/useAgendaKey';
 import styles from 'styles/agenda/agendaDetail/tabs/ParticipantTeam.module.scss';
 
 const totalPeople = (peopleCount: PeopleCount) => {
@@ -22,8 +24,7 @@ export default function ParticipantTeam({
   maxMateCount,
   coalitions,
 }: ParticipantTeamProps) {
-  const router = useRouter();
-  const agendaKey = router.query.agenda_key;
+  const agendaKey = useAgendaKey();
   const coalitionEnum = getCoalitionEnum(coalitions);
   const peopleCount = countCoalitions(coalitionEnum);
 
@@ -51,6 +52,9 @@ export default function ParticipantTeam({
     />
   );
 
+  if (!agendaKey) {
+    return <AgendaLoading />;
+  }
   return (
     <>
       {teamKey ? (

--- a/components/agenda/agendaDetail/tabs/ParticipantTeam.tsx
+++ b/components/agenda/agendaDetail/tabs/ParticipantTeam.tsx
@@ -23,7 +23,7 @@ export default function ParticipantTeam({
   coalitions,
 }: ParticipantTeamProps) {
   const router = useRouter();
-  const { agendaKey } = router.query;
+  const agendaKey = router.query.agenda_key;
   const coalitionEnum = getCoalitionEnum(coalitions);
   const peopleCount = countCoalitions(coalitionEnum);
 
@@ -56,7 +56,7 @@ export default function ParticipantTeam({
       {teamKey ? (
         <Link
           className={styles.participantTeamContainer}
-          href={`/agenda/${agendaKey}/${teamKey}`}
+          href={`/agenda/detail/team?agenda_key=${agendaKey}&team_key=${teamKey}`}
         >
           {content}
           {colorList}

--- a/components/agenda/agendaDetail/tabs/ParticipantTeamList.tsx
+++ b/components/agenda/agendaDetail/tabs/ParticipantTeamList.tsx
@@ -12,7 +12,7 @@ export default function ParticipantTeamList({
   myTeam,
 }: ParticipantTeamListProps) {
   const router = useRouter();
-  const { agendaKey } = router.query;
+  const agendaKey = router.query.agenda_key;
 
   const {
     content: openTeams,

--- a/components/agenda/agendaDetail/tabs/ParticipantTeamList.tsx
+++ b/components/agenda/agendaDetail/tabs/ParticipantTeamList.tsx
@@ -1,8 +1,9 @@
-import { useRouter } from 'next/router';
 import { ParticipantTeamListProps } from 'types/agenda/agendaDetail/tabs/participantTypes';
 import { TeamDataProps } from 'types/agenda/team/teamDataTypes';
 import ParticipantTeam from 'components/agenda/agendaDetail/tabs/ParticipantTeam';
+import AgendaLoading from 'components/agenda/utils/AgendaLoading';
 import PageNation from 'components/Pagination';
+import useAgendaKey from 'hooks/agenda/useAgendaKey';
 import usePageNation from 'hooks/agenda/usePageNation';
 import styles from 'styles/agenda/agendaDetail/tabs/ParticipantTeamList.module.scss';
 
@@ -11,8 +12,7 @@ export default function ParticipantTeamList({
   maxPeople,
   myTeam,
 }: ParticipantTeamListProps) {
-  const router = useRouter();
-  const agendaKey = router.query.agenda_key;
+  const agendaKey = useAgendaKey();
 
   const {
     content: openTeams,
@@ -30,16 +30,15 @@ export default function ParticipantTeamList({
     params: { agenda_key: agendaKey },
   });
 
-  const openTeamsCount = openTeams ? openTeams.length : 0;
-  const confirmedTeamsCount = confirmedTeams ? confirmedTeams.length : 0;
-
-  if (!agendaKey) {
-    return <div>Loading...</div>;
-  }
   const noParticipants = (
     <div className={styles.noParticipants}>팀이 없습니다.</div>
   );
+  const openTeamsCount = openTeams ? openTeams.length : 0;
+  const confirmedTeamsCount = confirmedTeams ? confirmedTeams.length : 0;
 
+  if (!agendaKey || !openTeams || !confirmedTeams) {
+    return <AgendaLoading />;
+  }
   return (
     <>
       <div className={styles.participantsWarp}>

--- a/components/agenda/agendaDetail/tabs/ParticipantsList.tsx
+++ b/components/agenda/agendaDetail/tabs/ParticipantsList.tsx
@@ -1,16 +1,16 @@
-import { useRouter } from 'next/router';
 import {
   numberProps,
   ParticipantProps,
 } from 'types/agenda/agendaDetail/tabs/participantTypes';
 import Participant from 'components/agenda/agendaDetail/tabs/Participant';
+import AgendaLoading from 'components/agenda/utils/AgendaLoading';
 import PageNation from 'components/Pagination';
+import useAgendaKey from 'hooks/agenda/useAgendaKey';
 import usePageNation from 'hooks/agenda/usePageNation';
 import styles from 'styles/agenda/agendaDetail/tabs/ParticipantsList.module.scss';
 
 export default function ParticipantsList({ max }: numberProps) {
-  const router = useRouter();
-  const agendaKey = router.query.agenda_key;
+  const agendaKey = useAgendaKey();
 
   const { content: participants, PagaNationElementProps } =
     usePageNation<ParticipantProps>({
@@ -19,10 +19,10 @@ export default function ParticipantsList({ max }: numberProps) {
     });
 
   const curPeople = participants ? participants.length : 0;
-  if (!participants) {
-    return <div className={styles.noParticipants}>Loading...</div>;
-  }
 
+  if (!agendaKey || !participants) {
+    return <AgendaLoading />;
+  }
   return (
     <>
       <div className={styles.participantsTitle}>

--- a/components/agenda/agendaDetail/tabs/ParticipantsList.tsx
+++ b/components/agenda/agendaDetail/tabs/ParticipantsList.tsx
@@ -10,7 +10,7 @@ import styles from 'styles/agenda/agendaDetail/tabs/ParticipantsList.module.scss
 
 export default function ParticipantsList({ max }: numberProps) {
   const router = useRouter();
-  const { agendaKey } = router.query;
+  const agendaKey = router.query.agenda_key;
 
   const { content: participants, PagaNationElementProps } =
     usePageNation<ParticipantProps>({

--- a/components/agenda/teamDetail/TeamInfo.tsx
+++ b/components/agenda/teamDetail/TeamInfo.tsx
@@ -19,7 +19,7 @@ const TeamInfo = ({
 }: TeamInfoProps) => {
   // EditTeam UI <-> TeamInfo UI 전환
   const router = useRouter();
-  const { agendaKey } = router.query;
+  const agendaKey = router.query.agenda_key;
   const [convert, setConvert] = useState(true);
 
   const handleConvert = () => {

--- a/components/agenda/teamDetail/TeamInfo.tsx
+++ b/components/agenda/teamDetail/TeamInfo.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { TeamInfoProps } from 'types/agenda/teamDetail/TeamInfoTypes';
 import { colorMapping } from 'types/agenda/utils/colorList';
@@ -7,8 +6,9 @@ import { ShareBtn } from 'components/agenda/button/Buttons';
 import CreateTeamForm from 'components/agenda/Form/CreateTeamForm';
 import TeamButtons from 'components/agenda/teamDetail/TeamButtons';
 import EditIcon from 'public/image/agenda/edit.svg';
+import useAgendaKey from 'hooks/agenda/useAgendaKey';
 import styles from 'styles/agenda/TeamDetail/TeamInfo.module.scss';
-
+import AgendaLoading from '../utils/AgendaLoading';
 const TeamInfo = ({
   teamDetail,
   shareTeamInfo,
@@ -18,13 +18,16 @@ const TeamInfo = ({
   submitTeamForm,
 }: TeamInfoProps) => {
   // EditTeam UI <-> TeamInfo UI 전환
-  const router = useRouter();
-  const agendaKey = router.query.agenda_key;
   const [convert, setConvert] = useState(true);
+  const agendaKey = useAgendaKey();
 
   const handleConvert = () => {
     setConvert(!convert);
   };
+
+  if (!agendaKey) {
+    return <AgendaLoading />;
+  }
   return convert ? (
     /* TeamInfo */
     <>

--- a/components/agenda/teamDetail/TeamInfo.tsx
+++ b/components/agenda/teamDetail/TeamInfo.tsx
@@ -5,10 +5,11 @@ import { TeamStatus, Authority } from 'constants/agenda/agenda';
 import { ShareBtn } from 'components/agenda/button/Buttons';
 import CreateTeamForm from 'components/agenda/Form/CreateTeamForm';
 import TeamButtons from 'components/agenda/teamDetail/TeamButtons';
+import AgendaLoading from 'components/agenda/utils/AgendaLoading';
 import EditIcon from 'public/image/agenda/edit.svg';
 import useAgendaKey from 'hooks/agenda/useAgendaKey';
 import styles from 'styles/agenda/TeamDetail/TeamInfo.module.scss';
-import AgendaLoading from '../utils/AgendaLoading';
+
 const TeamInfo = ({
   teamDetail,
   shareTeamInfo,

--- a/components/agenda/utils/AgendaLoading.tsx
+++ b/components/agenda/utils/AgendaLoading.tsx
@@ -1,0 +1,7 @@
+import styles from 'styles/agenda/utils/AgendaLoading.module.scss';
+
+const AgendaLoading = () => {
+  return <div className={styles.container}>Lodaing...</div>;
+};
+
+export default AgendaLoading;

--- a/components/agenda/utils/PageController.tsx
+++ b/components/agenda/utils/PageController.tsx
@@ -96,7 +96,9 @@ const PageController = ({
             )
               return;
             data.length && data[current]
-              ? handleNavigation('/agenda/' + data[current].agendaKey)
+              ? handleNavigation(
+                  '/agenda/detail?agenda_key=' + data[current].agendaKey
+                )
               : null;
           }}
           className={styles.toClick}

--- a/hooks/agenda/useAgendaInfo.ts
+++ b/hooks/agenda/useAgendaInfo.ts
@@ -2,15 +2,16 @@ import { useQuery } from 'react-query';
 import { AgendaDataProps } from 'types/agenda/agendaDetail/agendaTypes';
 import { instanceInAgenda } from 'utils/axios';
 
-export const useAgendaInfo = (agendaKey: string) => {
+export const useAgendaInfo = (agendaKey?: string) => {
   const { data, isError } = useQuery<AgendaDataProps>(
-    agendaKey,
+    ['agendaInfo', agendaKey],
     () =>
       instanceInAgenda.get('?agenda_key=' + agendaKey).then((res) => {
         res.data.agendaKey = agendaKey;
         return res.data;
       }),
     {
+      enabled: !!agendaKey, // agendaKey가 존재할 때만 쿼리 실행
       staleTime: 60 * 1000 * 10, // 10분 동안은 캐시를 사용
       cacheTime: 60 * 1000 * 10, // 10분 동안 캐시를 유지
       retry: 1, // 에러가 났을 때 1번 재시도

--- a/hooks/agenda/useAgendaKey.ts
+++ b/hooks/agenda/useAgendaKey.ts
@@ -1,0 +1,18 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+const useAgendaKey = () => {
+  const router = useRouter();
+  const [agendaKey, setAgendaKey] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (router.isReady) {
+      const key = router.query.agenda_key as string;
+      setAgendaKey(key);
+    }
+  }, [router.isReady, router.query.agenda_key]);
+
+  return agendaKey;
+};
+
+export default useAgendaKey;

--- a/hooks/agenda/useAgendaTeamKey.ts
+++ b/hooks/agenda/useAgendaTeamKey.ts
@@ -8,7 +8,7 @@ const useAgendaTeamKey = () => {
   useEffect(() => {
     if (router.isReady) {
       const key = router.query.team_key as string;
-      setTeamKey(key);
+      setTeamKey(key || 'no-team'); // 팀 키가 없으면 'no-team' 반환
     }
   }, [router.isReady, router.query.agenda_key]);
 

--- a/hooks/agenda/useAgendaTeamKey.ts
+++ b/hooks/agenda/useAgendaTeamKey.ts
@@ -1,0 +1,18 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+const useAgendaTeamKey = () => {
+  const router = useRouter();
+  const [teamKey, setTeamKey] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (router.isReady) {
+      const key = router.query.team_key as string;
+      setTeamKey(key);
+    }
+  }, [router.isReady, router.query.agenda_key]);
+
+  return teamKey;
+};
+
+export default useAgendaTeamKey;

--- a/hooks/agenda/useFetchGet.ts
+++ b/hooks/agenda/useFetchGet.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState , useCallback } from 'react';
 import { instanceInAgenda } from 'utils/axios';
 
 const useFetchGet = <T>(url: string, params?: Record<string, any>) => {
@@ -6,7 +6,11 @@ const useFetchGet = <T>(url: string, params?: Record<string, any>) => {
   const [status, setStatus] = useState<number>(0);
   const [error, setError] = useState<string | null>(null);
 
-  const getData = async () => {
+  const getData = useCallback(async () => {
+    if (params && params.agenda_key === undefined) {
+      return;
+    }
+
     try {
       const res = await instanceInAgenda.get(url, { params });
       setStatus(res.status);
@@ -17,11 +21,12 @@ const useFetchGet = <T>(url: string, params?: Record<string, any>) => {
       console.error(error);
       setError('get error');
     }
-  };
+  }, [url, params]);
 
   useEffect(() => {
-    if (url) {
-      getData();
+    // URL이 있고 params가 없거나, agenda_key가 있는 경우에도 getData 호출 가능
+    if (url && (!params || (params && params.agenda_key))) {
+      getData(); // 조건에 맞을 때만 getData 호출
     }
   }, [url, JSON.stringify(params)]);
 

--- a/hooks/agenda/usePageNation.ts
+++ b/hooks/agenda/usePageNation.ts
@@ -25,6 +25,10 @@ const usePageNation = <T>({
 
   const getData = useCallback(
     async (page: number, size: number) => {
+      if (params && params.agenda_key === undefined) {
+        return { content: null };
+      }
+
       const res = await instanceInAgenda.get(url, { params });
       const content = res.data.content ? res.data.content : [];
       const totalSize = res.data.totalSize ? res.data.totalSize : 0;
@@ -57,10 +61,13 @@ const usePageNation = <T>({
       setContent(data.content);
     };
 
-    if (!status.current || Math.floor(status.current / 100) !== 2) {
+    if (
+      (!params || params.agenda_key) &&
+      (!status.current || Math.floor(status.current / 100) !== 2)
+    ) {
       fetchData();
     }
-  }, [getData, size]); // getData와 size에 의존
+  }, [getData, size, params]); // getData와 size에 의존
 
   const PagaNationElementProps = {
     curPage: currentPage.current,

--- a/pages/agenda/detail/host/createAnnouncement.tsx
+++ b/pages/agenda/detail/host/createAnnouncement.tsx
@@ -1,11 +1,16 @@
 import { useRouter } from 'next/router';
 import AnnouncementForm from 'components/agenda/Form/AnnouncementForm';
+import AgendaLoading from 'components/agenda/utils/AgendaLoading';
+import useAgendaKey from 'hooks/agenda/useAgendaKey';
 import styles from 'styles/agenda/agendaDetail/tabs/createAnnouncement.module.scss';
 
 const CreateAnnouncement = () => {
   const router = useRouter();
-  const agendaKey = router.query.agenda_key;
+  const agendaKey = useAgendaKey();
 
+  if (!agendaKey) {
+    return <AgendaLoading />;
+  }
   return (
     <div className={styles.container}>
       <h2 className={styles.title}>공지사항</h2>

--- a/pages/agenda/detail/host/createAnnouncement.tsx
+++ b/pages/agenda/detail/host/createAnnouncement.tsx
@@ -4,7 +4,7 @@ import styles from 'styles/agenda/agendaDetail/tabs/createAnnouncement.module.sc
 
 const CreateAnnouncement = () => {
   const router = useRouter();
-  const { agendaKey } = router.query;
+  const agendaKey = router.query.agenda_key;
 
   return (
     <div className={styles.container}>
@@ -12,7 +12,7 @@ const CreateAnnouncement = () => {
       <AnnouncementForm
         stringKey={agendaKey as string}
         onProceed={() => {
-          router.push(`/agenda/${agendaKey}`);
+          router.push(`/agenda/detail?agenda_key=${agendaKey}`);
         }}
       />
     </div>

--- a/pages/agenda/detail/host/index.tsx
+++ b/pages/agenda/detail/host/index.tsx
@@ -5,14 +5,16 @@ import { toastState } from 'utils/recoil/toast';
 import { AgendaStatus } from 'constants/agenda/agenda';
 import { UploadBtn } from 'components/agenda/button/UploadBtn';
 import { useModal } from 'components/agenda/modal/useModal';
+import AgendaLoading from 'components/agenda/utils/AgendaLoading';
 import { useAgendaInfo } from 'hooks/agenda/useAgendaInfo';
+import useAgendaKey from 'hooks/agenda/useAgendaKey';
 import useFetchRequest from 'hooks/agenda/useFetchRequest';
 import { useUser } from 'hooks/takgu/Layout/useUser';
 import styles from 'styles/agenda/pages/agendakey/host/modify.module.scss';
 
 const ModifyAgenda = () => {
   const router = useRouter();
-  const agendaKey = router.query.agenda_key;
+  const agendaKey = useAgendaKey();
   const agendaData = useAgendaInfo(agendaKey as string);
   const user = useUser();
   const { sendRequest } = useFetchRequest();
@@ -106,6 +108,9 @@ const ModifyAgenda = () => {
     }
   }, [agendaData, user, router]);
 
+  if (!agendaKey) {
+    return <AgendaLoading />;
+  }
   return (
     <>
       <div className={styles.container}>

--- a/pages/agenda/detail/host/index.tsx
+++ b/pages/agenda/detail/host/index.tsx
@@ -7,7 +7,7 @@ import styles from 'styles/agenda/pages/CreateAgenda.module.scss';
 
 const ModifyAgenda = () => {
   const router = useRouter();
-  const { agendaKey } = router.query;
+  const agendaKey = router.query.agenda_key;
   const data = useAgendaInfo(agendaKey as string);
 
   return (
@@ -24,7 +24,7 @@ const ModifyAgenda = () => {
             data={data}
             stringKey={agendaKey as string}
             onProceed={() => {
-              router.push(`/agenda/${agendaKey}`);
+              router.push(`/agenda/detail?agenda_key=${agendaKey}`);
             }}
           />
         )}

--- a/pages/agenda/detail/host/index.tsx
+++ b/pages/agenda/detail/host/index.tsx
@@ -1,33 +1,120 @@
 import { useRouter } from 'next/router';
-import { CancelBtn } from 'components/agenda/button/Buttons';
-import AgendaForm from 'components/agenda/Form/AgendaForm';
-import { saveLocal } from 'pages/agenda/create';
+import { useEffect } from 'react';
+import { useSetRecoilState } from 'recoil';
+import { toastState } from 'utils/recoil/toast';
+import { AgendaStatus } from 'constants/agenda/agenda';
+import { UploadBtn } from 'components/agenda/button/UploadBtn';
+import { useModal } from 'components/agenda/modal/useModal';
 import { useAgendaInfo } from 'hooks/agenda/useAgendaInfo';
-import styles from 'styles/agenda/pages/CreateAgenda.module.scss';
+import useFetchRequest from 'hooks/agenda/useFetchRequest';
+import { useUser } from 'hooks/takgu/Layout/useUser';
+import styles from 'styles/agenda/pages/agendakey/host/modify.module.scss';
 
 const ModifyAgenda = () => {
   const router = useRouter();
   const agendaKey = router.query.agenda_key;
-  const data = useAgendaInfo(agendaKey as string);
+  const agendaData = useAgendaInfo(agendaKey as string);
+  const user = useUser();
+  const { sendRequest } = useFetchRequest();
+  const { openModal } = useModal();
+  const agendaStatus = agendaData?.agendaStatus;
+  const setSnackbar = useSetRecoilState(toastState);
+
+  const handleClick = (description: string, onProceed: () => void) => {
+    openModal({
+      type: 'proceedCheck',
+      description: description,
+      onProceed: onProceed,
+    });
+  };
+
+  const newAnnouncement = () => {
+    router.push(
+      `/agenda/detail/host/createAnnouncement?agenda_key=${agendaKey}`
+    );
+  };
+
+  const confirmAgenda = () => {
+    if (agendaStatus && agendaStatus === AgendaStatus.OPEN) {
+      handleClick('행사를 확정하시겠습니까?', () => {
+        sendRequest('PATCH', `confirm`, {}, { agenda_key: agendaKey });
+        router.push(`/agenda/detail?agenda_key=${agendaKey}`);
+      });
+    } else {
+      setSnackbar({
+        toastName: `status error`,
+        severity: 'error',
+        message: `🔥 행사 모집중 상태에서만 확정이 가능합니다. 🔥`,
+        clicked: true,
+      });
+    }
+  };
+
+  const cancelAgenda = () => {
+    if (agendaStatus && agendaStatus === AgendaStatus.OPEN) {
+      handleClick('행사를 취소하시겠습니까?', () => {
+        sendRequest('PATCH', `cancel`, {}, { agenda_key: agendaKey });
+        router.push(`/agenda`);
+      });
+    } else {
+      setSnackbar({
+        toastName: `status error`,
+        severity: 'error',
+        message: `🔥 행사 모집중 상태에서만 취소가 가능합니다. 🔥`,
+        clicked: true,
+      });
+    }
+  };
+
+  const resultAgenda = () => {
+    if (agendaStatus && agendaStatus === AgendaStatus.CONFIRM) {
+      handleClick('행사를 상 입력 없이 종료하시겠습니까?', () => {
+        sendRequest('PATCH', 'finish', {}, { agenda_key: agendaKey });
+        router.push(`/agenda/detail?agenda_key=${agendaKey}`);
+      });
+    } else {
+      setSnackbar({
+        toastName: `status error`,
+        severity: 'error',
+        message: `🔥 행사가 진행중인 상태에서만 종료가 가능합니다. 🔥`,
+        clicked: true,
+      });
+    }
+  };
+
+  const resultFormAgenda = () => {
+    if (agendaStatus && agendaStatus === AgendaStatus.CONFIRM) {
+      handleClick('행사 종료 후 상 입력을 하시겠습니까?', () => {
+        router.push(`/agenda/detail/host/result?agenda_key=${agendaKey}`);
+      });
+    } else {
+      setSnackbar({
+        toastName: `status error`,
+        severity: 'error',
+        message: `🔥 행사가 진행중인 상태에서만 종료가 가능합니다. 🔥`,
+        clicked: true,
+      });
+    }
+  };
+
+  useEffect(() => {
+    if (agendaData && user) {
+      if (agendaData.agendaHost !== user.intraId) {
+        alert('주최자만 접근 가능한 페이지입니다.');
+        router.back();
+      }
+    }
+  }, [agendaData, user, router]);
 
   return (
     <>
       <div className={styles.container}>
-        <div>
-          <CancelBtn onClick={saveLocal} />
-        </div>
-        <h2 className={styles.title}>아젠다 수정하기</h2>
-        <p className={styles.description}>당부사항</p>
-        {data && (
-          <AgendaForm
-            isEdit={true}
-            data={data}
-            stringKey={agendaKey as string}
-            onProceed={() => {
-              router.push(`/agenda/detail?agenda_key=${agendaKey}`);
-            }}
-          />
-        )}
+        <UploadBtn text='공지사항 추가하기' onClick={newAnnouncement} />
+        <UploadBtn text='참가인원 및 진행 확정' onClick={confirmAgenda} />
+        <UploadBtn text='행사 취소하기' onClick={cancelAgenda} />
+
+        <UploadBtn text='행사 종료하기' onClick={resultAgenda} />
+        <UploadBtn text='상 입력 후 종료하기' onClick={resultFormAgenda} />
       </div>
     </>
   );

--- a/pages/agenda/detail/host/result.tsx
+++ b/pages/agenda/detail/host/result.tsx
@@ -83,7 +83,7 @@ const SubmitAgendaResult = () => {
   const [awardList, setAwardList] = useState<AwardListProps[]>([
     { award: '참가상', teams: [] },
   ]);
-  const { agendaKey: agenda_key } = router.query;
+  const { agenda_key } = router.query;
   const setSnackbar = useSetRecoilState(toastState);
   const { openModal, closeModal } = useModal();
 

--- a/pages/agenda/detail/host/result.tsx
+++ b/pages/agenda/detail/host/result.tsx
@@ -7,6 +7,8 @@ import { instanceInAgenda } from 'utils/axios';
 import { toastState } from 'utils/recoil/toast';
 import AgendaResultForm from 'components/agenda/Form/AgendaResultForm';
 import { useModal } from 'components/agenda/modal/useModal';
+import AgendaLoading from 'components/agenda/utils/AgendaLoading';
+import useAgendaKey from 'hooks/agenda/useAgendaKey';
 import useFetchGet from 'hooks/agenda/useFetchGet';
 import styles from 'styles/agenda/pages/agendakey/host/result.module.scss';
 
@@ -83,7 +85,7 @@ const SubmitAgendaResult = () => {
   const [awardList, setAwardList] = useState<AwardListProps[]>([
     { award: '참가상', teams: [] },
   ]);
-  const { agenda_key } = router.query;
+  const agenda_key = useAgendaKey();
   const setSnackbar = useSetRecoilState(toastState);
   const { openModal, closeModal } = useModal();
 
@@ -112,7 +114,7 @@ const SubmitAgendaResult = () => {
       });
       return;
     }
-    console.log(awardList);
+
     const msg = awardlistToString(awardList);
     openModal({
       type: 'proceedCheck',
@@ -127,6 +129,10 @@ const SubmitAgendaResult = () => {
       },
     });
   };
+
+  if (!agenda_key) {
+    return <AgendaLoading />;
+  }
   return (
     <div className={styles.container}>
       <AgendaResultForm

--- a/pages/agenda/detail/index.tsx
+++ b/pages/agenda/detail/index.tsx
@@ -15,7 +15,7 @@ const getIsHost = (intraId: string, agendaData?: AgendaDataProps | null) => {
 
 const AgendaDetail = () => {
   const router = useRouter();
-  const { agendaKey } = router.query;
+  const agendaKey = useRouter().query.agenda_key;
   const agendaData = useAgendaInfo(agendaKey as string);
 
   const { data: myTeam, status: myTeamStatus } = useFetchGet<TeamDataProps>(

--- a/pages/agenda/detail/index.tsx
+++ b/pages/agenda/detail/index.tsx
@@ -1,10 +1,10 @@
-import { useRouter } from 'next/router';
 import { AgendaDataProps } from 'types/agenda/agendaDetail/agendaTypes';
 import { TeamDataProps } from 'types/agenda/team/teamDataTypes';
 import AgendaInfo from 'components/agenda/agendaDetail/AgendaInfo';
 import AgendaTab from 'components/agenda/agendaDetail/AgendaTab';
 import { useUser } from 'hooks/agenda/Layout/useUser';
 import { useAgendaInfo } from 'hooks/agenda/useAgendaInfo';
+import useAgendaKey from 'hooks/agenda/useAgendaKey';
 import useFetchGet from 'hooks/agenda/useFetchGet';
 import styles from 'styles/agenda/agendaDetail/AgendaDetail.module.scss';
 
@@ -14,8 +14,7 @@ const getIsHost = (intraId: string, agendaData?: AgendaDataProps | null) => {
 };
 
 const AgendaDetail = () => {
-  const router = useRouter();
-  const agendaKey = useRouter().query.agenda_key;
+  const agendaKey = useAgendaKey();
   const agendaData = useAgendaInfo(agendaKey as string);
 
   const { data: myTeam, status: myTeamStatus } = useFetchGet<TeamDataProps>(

--- a/pages/agenda/detail/team/create.tsx
+++ b/pages/agenda/detail/team/create.tsx
@@ -1,12 +1,14 @@
 import { useRouter } from 'next/router';
 import { AgendaDataProps } from 'types/agenda/agendaDetail/agendaTypes';
 import CreateTeamForm from 'components/agenda/Form/CreateTeamForm';
+import AgendaLoading from 'components/agenda/utils/AgendaLoading';
+import useAgendaKey from 'hooks/agenda/useAgendaKey';
 import useFetchGet from 'hooks/agenda/useFetchGet';
 import styles from 'styles/agenda/pages/create-team.module.scss';
 
 const CreateTeam = () => {
   const router = useRouter();
-  const agendaKey = router.query.agenda_key as string;
+  const agendaKey = useAgendaKey();
 
   const agendaInfo = useFetchGet<AgendaDataProps>(`/`, {
     agenda_key: agendaKey,
@@ -17,9 +19,8 @@ const CreateTeam = () => {
   };
 
   if (!agendaKey || !agendaInfo) {
-    return <p>Loading...</p>;
+    return <AgendaLoading />;
   }
-
   return (
     <div className={styles.pageContainer}>
       <div className={styles.container}>

--- a/pages/agenda/detail/team/create.tsx
+++ b/pages/agenda/detail/team/create.tsx
@@ -1,16 +1,24 @@
 import { useRouter } from 'next/router';
+import { AgendaDataProps } from 'types/agenda/agendaDetail/agendaTypes';
 import CreateTeamForm from 'components/agenda/Form/CreateTeamForm';
-import { useAgendaInfo } from 'hooks/agenda/useAgendaInfo';
+import useFetchGet from 'hooks/agenda/useFetchGet';
 import styles from 'styles/agenda/pages/create-team.module.scss';
 
 const CreateTeam = () => {
   const router = useRouter();
-  const { agendaKey } = router.query;
-  const agendaInfo = useAgendaInfo(agendaKey as string);
+  const agendaKey = router.query.agenda_key as string;
+
+  const agendaInfo = useFetchGet<AgendaDataProps>(`/`, {
+    agenda_key: agendaKey,
+  }).data;
 
   const backPage = () => {
     router.back();
   };
+
+  if (!agendaKey || !agendaInfo) {
+    return <p>Loading...</p>;
+  }
 
   return (
     <div className={styles.pageContainer}>

--- a/pages/agenda/detail/team/index.tsx
+++ b/pages/agenda/detail/team/index.tsx
@@ -6,15 +6,18 @@ import { TeamDetailProps } from 'types/agenda/teamDetail/TeamDetailTypes';
 import { Authority } from 'constants/agenda/agenda';
 import AgendaInfo from 'components/agenda/agendaDetail/AgendaInfo';
 import TeamInfo from 'components/agenda/teamDetail/TeamInfo';
+import AgendaLoading from 'components/agenda/utils/AgendaLoading';
 import { useUser } from 'hooks/agenda/Layout/useUser';
+import useAgendaKey from 'hooks/agenda/useAgendaKey';
+import useAgendaTeamKey from 'hooks/agenda/useAgendaTeamKey';
 import useFetchGet from 'hooks/agenda/useFetchGet';
 import useFetchRequest from 'hooks/agenda/useFetchRequest';
 import styles from 'styles/agenda/TeamDetail/TeamDetail.module.scss';
 
 export default function TeamDetail() {
   const router = useRouter();
-  const agendaKey = router.query.agenda_key;
-  const teamUID = router.query.team_key;
+  const agendaKey = useAgendaKey();
+  const teamUID = useAgendaTeamKey();
 
   /**
    * API GET DATA
@@ -90,6 +93,9 @@ export default function TeamDetail() {
     );
   };
 
+  if (!agendaKey || !agendaData || !teamDetail) {
+    return <AgendaLoading />;
+  }
   return (
     <div className={styles.teamDetail}>
       {agendaData && (

--- a/pages/agenda/detail/team/index.tsx
+++ b/pages/agenda/detail/team/index.tsx
@@ -14,7 +14,7 @@ import styles from 'styles/agenda/TeamDetail/TeamDetail.module.scss';
 export default function TeamDetail() {
   const router = useRouter();
   const agendaKey = router.query.agenda_key;
-  const teamUID = router.query.tema_key;
+  const teamUID = router.query.team_key;
 
   /**
    * API GET DATA
@@ -78,7 +78,7 @@ export default function TeamDetail() {
       () => {
         // 팀 폭파 API : 아젠다 디테일 페이지로 이동
         if (url === 'team/cancel') {
-          router.push(`/agenda/${agendaKey}`);
+          router.push(`/agenda/detail?agenda_key=${agendaKey}`);
         } else {
           // 그 외 API : 팀 상세 데이터 갱신
           getTeamDetail();

--- a/pages/agenda/detail/team/index.tsx
+++ b/pages/agenda/detail/team/index.tsx
@@ -13,8 +13,8 @@ import styles from 'styles/agenda/TeamDetail/TeamDetail.module.scss';
 
 export default function TeamDetail() {
   const router = useRouter();
-  const { agendaKey } = router.query;
-  const { teamUID } = router.query;
+  const agendaKey = router.query.agenda_key;
+  const teamUID = router.query.tema_key;
 
   /**
    * API GET DATA
@@ -81,7 +81,6 @@ export default function TeamDetail() {
           router.push(`/agenda/${agendaKey}`);
         } else {
           // 그 외 API : 팀 상세 데이터 갱신
-
           getTeamDetail();
         }
       },
@@ -94,7 +93,10 @@ export default function TeamDetail() {
   return (
     <div className={styles.teamDetail}>
       {agendaData && (
-        <Link href={`/agenda/${agendaKey}`} className={styles.agendaLink}>
+        <Link
+          href={`/agenda/detail?agenda_key=${agendaKey}`}
+          className={styles.agendaLink}
+        >
           <AgendaInfo agendaData={agendaData} />
         </Link>
       )}

--- a/pages/agenda/profile/index.tsx
+++ b/pages/agenda/profile/index.tsx
@@ -4,7 +4,7 @@ import { useUser } from 'hooks/agenda/Layout/useUser';
 const Index = () => {
   const router = useRouter();
   const { intraId } = useUser() || {};
-  router.push('/agenda/profile/' + intraId);
+  router.push(`/agenda/profile/user?id=${intraId}`);
 };
 
 export default Index;

--- a/pages/agenda/profile/user.tsx
+++ b/pages/agenda/profile/user.tsx
@@ -7,6 +7,7 @@ import CurrentList from 'components/agenda/Profile/CurrentList';
 import HistoryList from 'components/agenda/Profile/HistoryList';
 import ProfileCard from 'components/agenda/Profile/ProfileCard';
 import Ticket from 'components/agenda/Ticket/Ticket';
+import AgendaLoading from 'components/agenda/utils/AgendaLoading';
 import PageNation from 'components/Pagination';
 import { useUser } from 'hooks/agenda/Layout/useUser';
 import useFetchGet from 'hooks/agenda/useFetchGet';
@@ -53,6 +54,9 @@ const AgendaProfile = () => {
     url: `/profile/history/list/${intraId}`,
   });
 
+  if (!intraId || !userIntraId) {
+    return <AgendaLoading />;
+  }
   return (
     <>
       <div className={styles.agendaProfileContainer}>

--- a/pages/agenda/profile/user.tsx
+++ b/pages/agenda/profile/user.tsx
@@ -14,8 +14,7 @@ import usePageNation from 'hooks/agenda/usePageNation';
 import styles from 'styles/agenda/Profile/AgendaProfile.module.scss';
 
 const AgendaProfile = () => {
-  const router = useRouter();
-  const { intraId } = router.query; // URL 상의 intraId
+  const intraId = useRouter().query.id;
   const userIntraId = useUser()?.intraId; // 현재 나의 intraId
   const isMyProfile = intraId === userIntraId ? true : false;
 
@@ -53,8 +52,6 @@ const AgendaProfile = () => {
   } = usePageNation<HistoryItemProps>({
     url: `/profile/history/list/${intraId}`,
   });
-
-  console.log(profileData);
 
   return (
     <>

--- a/stories/agenda/Form/CreateTeam.stories.tsx
+++ b/stories/agenda/Form/CreateTeam.stories.tsx
@@ -1,5 +1,7 @@
+/** router 쿼리로 바꾸는 도중에 에러 떠서 모두 주석 처리 함 */
+
 import type { Meta, StoryObj } from '@storybook/react';
-import CreateTeam from 'pages/agenda/[agendaKey]/create-team';
+import CreateTeam from 'pages/agenda/detail/team/create';
 
 const meta: Meta = {
   title: 'Agenda/Form/create-team',

--- a/stories/agenda/Form/SubmitAgendaResult.stories.tsx
+++ b/stories/agenda/Form/SubmitAgendaResult.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import SubmitAgendaResult from 'pages/agenda/[agendaKey]/host/result';
+import SubmitAgendaResult from 'pages/agenda/detail/host/result';
 
 const meta: Meta = {
   title: 'Agenda/Form/submit-agenda-result',

--- a/styles/agenda/utils/AgendaLoading.module.scss
+++ b/styles/agenda/utils/AgendaLoading.module.scss
@@ -1,0 +1,5 @@
+@import 'styles/agenda/common.scss';
+
+.contianer {
+  @include container(1);
+}


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 동적 라우팅 버그로 인해 쿼리 사용
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 기존에 동적 라우팅으로 인해 새로고침을 할 시, 에러가 발생하여 index페이지로 이동하는 버그가 생겼습니다. 
  - 동적 라우팅을 사용하지 않고, 페이지 라우팅 + 쿼리문을 사용하여 문제를 해결했습니다. 
---
### 작업 사항
1. 동적 라우팅 페이지를 페이지 라우팅으로 변경
2. router.push / Link href 등의 페이지 이동 안에 쿼리문 넣는 작업
3. 특정 페이지에서 쿼리의 데이터를 참고(router.query.agenda_key)하여 해당 페이지의 데이터 및 UI를 띄우기
4. useAgendaKey() / useAgendaTeamKey() Hooks 만들기 : 렌더링 모두 되었을 시, agenda_key와 team_key를 가져오기
5. 아젠다 로딩 페이지 생성 및 완전히 데이터 나오지 처리 되지 않았을 시 나오게 설정 (후에 UI 개선)
6. 기존의 hooks에 예외 처리 추가 : agenda_key가 undefined로 들어 갈 시 등의 로직 추가
7. 쿼리문 데이터 받아오기 + 기존의 hooks 사용 잘되는지 테스트 및 여러 에러들 수정
---
- **특이 사항 발생**
   - 쿼리 데이터 받기(ex: router.query.agend_key) 문제가 발생했습니다.-> error: queryFn
   - 가끔씩 완전히 렌더링이 안된 상태에서 데이터를 받는 경우가 있어 쿼리 데이터를 undefined로 가져 오는 오류가 생겼습니다. 
   - 따라서 완전히 렌더링 후 router.isReady -> 렌더링 다 되었을 시, 가져오는 방법으로 수정했습니다.
   - **쿼리 데이터를 가져오는 방법 또한 비동기!!로 동작**하여 가져 온 쿼리 데이터를 API 호출에 사용해야 하는데(ex: agenda_key) 문제가 생겼습니다. 
   - 즉, 쿼리의 데이터를 비동기로 가져오고 (ex: agenda_key) + 비동기로 가져온 데이터를 비동기 hooks로 API 호출 (ex: useFetchGet) 해야하는 상황이 생겼습니다. -> 해결은 했는데 배포 후에 다시 한번 확인해봐야 될것 같아요! 👍
 
