### PR TITLE
[Feat] 아젠다 에러페이지 세팅#1544

### DIFF
--- a/Layout/LayoutProvider.tsx
+++ b/Layout/LayoutProvider.tsx
@@ -4,6 +4,7 @@ import AdminAppLayout from 'Layout/AdminLayout';
 import AgendaAppLayout from 'Layout/AgendaLayout';
 import TakguAppLayout from 'Layout/TakguLayout';
 import { usePathname } from 'hooks/agenda/Layout/usePathname';
+import useAxiosAgendaError from 'hooks/useAxiosAgendaError';
 import useAxiosResponse from 'hooks/useAxiosResponse';
 
 type LayoutProviderProps = {
@@ -14,7 +15,8 @@ type LayoutProviderProps = {
 // 로그인 스테이트 등은 각 레이아웃에서 확인
 const LayoutProvider = ({ children }: LayoutProviderProps) => {
   useRecoilValue(loginState);
-  useAxiosResponse();
+  useAxiosResponse(); // takgu axios response interceptor
+  useAxiosAgendaError(); // agenda axios response interceptor
 
   const app = usePathname();
   switch (app) {

--- a/components/LoginChecker.tsx
+++ b/components/LoginChecker.tsx
@@ -8,7 +8,11 @@ interface LoginCheckerProps {
 
 export default function LoginChecker({ children }: LoginCheckerProps) {
   const [isLoading, loggedIn] = useLoginCheck();
-  // return <>{children}</>;
+  // dev 환경에서는 로그인 상태를 유지
+  // 만약 로그인 상태를 확인하고 싶다면, 아래 주석처리 필요
+  if (process.env.NODE_ENV === 'development') {
+    return <>{children}</>;
+  }
 
   return loggedIn ? (
     <>{children}</>

--- a/components/admin/agenda/announcements/AnnouncementTable.tsx
+++ b/components/admin/agenda/announcements/AnnouncementTable.tsx
@@ -59,7 +59,7 @@ export default function AnnouncementTable() {
   });
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [selectedAgendaKey, setSelectedAgendaKey] = useState<string>('');
-  const agendaList = useFetchGet('admin/list').data || [];
+  const agendaList = useFetchGet({ url: 'admin/list' }).data || [];
 
   useEffect(() => {
     if (agendaKey) {

--- a/components/admin/agenda/teamList/TeamTable.tsx
+++ b/components/admin/agenda/teamList/TeamTable.tsx
@@ -68,7 +68,7 @@ export default function TeamTable() {
 
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [selectedAgendaKey, setSelectedAgendaKey] = useState('');
-  const agendaList = useFetchGet(`admin/list`).data || [];
+  const agendaList = useFetchGet({ url: 'admin/list' }).data || [];
   const setSnackBar = useSetRecoilState(toastState);
 
   const buttonList: string[] = [styles.coin, styles.penalty];

--- a/components/agenda/Form/AdminTicketForm.tsx
+++ b/components/agenda/Form/AdminTicketForm.tsx
@@ -17,7 +17,7 @@ interface userFormProps {
 const AdminTicketForm = ({ stringKey, data, onProceed }: userFormProps) => {
   const { closeModal } = useModal();
   const sendRequest = useFetchRequest().sendRequest;
-  const agendaList = useFetchGet('admin/list').data || [];
+  const agendaList = useFetchGet({ url: 'admin/list' }).data || [];
 
   const [issuedFromKey, setIssuedFromKey] = useState(
     data.issuedFromKey ? data.issuedFromKey : ''

--- a/components/agenda/Form/TicketForm.tsx
+++ b/components/agenda/Form/TicketForm.tsx
@@ -12,7 +12,7 @@ interface userFormProps {
 const TicketForm = ({ stringKey }: userFormProps) => {
   const { closeModal } = useModal();
   const sendRequest = useFetchRequest().sendRequest;
-  const agendaList = useFetchGet('admin/list').data || [];
+  const agendaList = useFetchGet({ url: 'admin/list' }).data || [];
   const [selectedAgendaKey, setSelectedAgendaKey] = useState('');
 
   const handleSelectChange = (e: { target: { value: any } }) => {

--- a/components/agenda/Form/userForm.tsx
+++ b/components/agenda/Form/userForm.tsx
@@ -48,9 +48,9 @@ const UserForm = ({ stringKey }: userFormProps) => {
   const { closeModal } = useModal();
   const sendRequest = useFetchRequest().sendRequest;
 
-  const { data }: { data: dataType | null } = useFetchGet(
-    `profile/${stringKey}`
-  );
+  const { data }: { data: dataType | null } = useFetchGet({
+    url: `profile/${stringKey}`,
+  });
 
   if (!data) {
     return <div className={styles.modalContainer}>loading...</div>;

--- a/components/agenda/Home/AgendaInfo.tsx
+++ b/components/agenda/Home/AgendaInfo.tsx
@@ -45,7 +45,7 @@ const AgendaInfo = ({
           <div className={styles.agendaItemTimeWrapper}>
             <div className={styles.imageWrapper}>
               <Image
-                src={'/image/agenda/User.svg'}
+                src={'/image/agenda/user.svg'}
                 width={15}
                 height={15}
                 alt='count'

--- a/components/agenda/Home/MyAgendaBtn.tsx
+++ b/components/agenda/Home/MyAgendaBtn.tsx
@@ -30,7 +30,8 @@ const MyAgendaBtn = () => {
     }
   };
   const myList =
-    useFetchGet<MyTeamDataProps[]>('/profile/current/list')?.data || [];
+    useFetchGet<MyTeamDataProps[]>({ url: '/profile/current/list' })?.data ||
+    [];
   return (
     <div
       className={`${styles.myAgendaContainer} ${

--- a/components/agenda/Profile/AgendaUserSearchBar.tsx
+++ b/components/agenda/Profile/AgendaUserSearchBar.tsx
@@ -1,12 +1,67 @@
+import router from 'next/router';
 import { GoSearch } from 'react-icons/go';
+import { IoIosCloseCircle } from 'react-icons/io';
+import useSearchBar from 'hooks/useSearchBar';
 import styles from 'styles/agenda/Profile/AgendaUserSearchBar.module.scss';
 
 const AgendaUserSearchBar = () => {
+  const {
+    keyword,
+    setKeyword,
+    keywordHandler,
+    showDropDown,
+    setShowDropDown,
+    searchResult,
+    searchBarRef,
+    handleKeyDown,
+  } = useSearchBar();
+
+  const changeUser = (intraId: string) => {
+    setKeyword('');
+    setShowDropDown(false);
+    router.push(`/agenda/profile/user?id=${intraId}`);
+  };
+
   return (
-    <div className={styles.agendaUserSearchBar}>
-      <input type='text' placeholder='Search User' maxLength={12} />
-      <GoSearch className={styles.imageBox} />
-    </div>
+    <>
+      <div className={styles.warp} ref={searchBarRef}>
+        <div className={styles.agendaUserSearchBar}>
+          <input
+            type='text'
+            onChange={keywordHandler}
+            onKeyDown={handleKeyDown}
+            onFocus={() => setShowDropDown(true)}
+            placeholder='유저 검색하기'
+            maxLength={12}
+            value={keyword}
+          />
+          <div className={styles.icons}>
+            {keyword ? (
+              <span className={styles.reset} onClick={() => setKeyword('')}>
+                <IoIosCloseCircle />
+              </span>
+            ) : (
+              <span>
+                <GoSearch />
+              </span>
+            )}
+          </div>
+        </div>
+        {showDropDown && keyword && (
+          <div className={styles.dropdown}>
+            {searchResult.length ? (
+              searchResult.map((intraId: string) => (
+                <div onClick={() => changeUser(intraId)} key={intraId}>
+                  {intraId}
+                </div>
+              ))
+            ) : (
+              <div>검색 결과가 없습니다.</div>
+            )}
+          </div>
+        )}
+      </div>
+    </>
   );
 };
 

--- a/components/agenda/Profile/HistoryList.tsx
+++ b/components/agenda/Profile/HistoryList.tsx
@@ -41,80 +41,84 @@ const HistoryList = ({ historyListData, isHost }: HistoryListProps) => {
       <div className={styles.historyTitleText}>{historyTitle}</div>
       <div className={styles.historyItems}>
         {historyListData.length > 0 ? (
-          historyListData.map((historyData: HistoryItemProps) => {
-            const {
-              historyTeamMates,
-              totalPeople,
-              peopleCount,
-              startTime,
-              endTime,
-              timeString,
-            } = parsingHistoryData(historyData);
+          historyListData.map(
+            (historyData: HistoryItemProps, index: number) => {
+              const {
+                historyTeamMates,
+                totalPeople,
+                peopleCount,
+                startTime,
+                endTime,
+                timeString,
+              } = parsingHistoryData(historyData);
 
-            return (
-              <Link
-                href={`/agenda/${historyData.agendaKey}`}
-                className={styles.historyItem}
-                key={historyData.agendaId}
-              >
-                <div className={styles.agendaTitle}>
-                  {historyData.agendaTitle}
-                </div>
-
-                <div className={styles.tagWrapper}>
-                  {/* PROGRESS : tag mapping */}
-                  {historyData.isOfficial ? (
-                    <AgendaTag tagName='공식' />
-                  ) : (
-                    <AgendaTag tagName='비공식' />
-                  )}
-                  <AgendaTag tagName='팀' />
-                </div>
-
-                <div className={styles.timeWrapper}>
-                  <div className={styles.imageWrapper}>
-                    <TimeIcon />
+              return (
+                <Link
+                  href={`/agenda/detail?agenda_key=${historyData.agendaKey}`}
+                  className={styles.historyItem}
+                  key={`${historyData.agendaId}-${index}`}
+                >
+                  <div className={styles.agendaTitle}>
+                    {historyData.agendaTitle}
                   </div>
 
-                  <div className={styles.timeContent}>{timeString}</div>
-                </div>
+                  <div className={styles.tagWrapper}>
+                    {/* PROGRESS : tag mapping */}
+                    {historyData.isOfficial ? (
+                      <AgendaTag tagName='공식' />
+                    ) : (
+                      <AgendaTag tagName='비공식' />
+                    )}
+                    <AgendaTag tagName='팀' />
+                  </div>
 
-                {/* Team 정보 UI / host 경우 ❌ */}
-                {historyTeamMates && historyTeamMates.length > 0 ? (
-                  <>
-                    <hr className={styles.divider} />
-
-                    <div className={styles.teamName}>
-                      {historyData.teamName}
+                  <div className={styles.timeWrapper}>
+                    <div className={styles.imageWrapper}>
+                      <TimeIcon />
                     </div>
 
-                    <div className={styles.teamIntraIdWrapper}>
-                      <div className={styles.imageWrapper}>
-                        <TeamIcon />
+                    <div className={styles.timeContent}>{timeString}</div>
+                  </div>
+
+                  {/* Team 정보 UI / host 경우 ❌ */}
+                  {historyTeamMates && historyTeamMates.length > 0 ? (
+                    <>
+                      <hr className={styles.divider} />
+
+                      <div className={styles.teamName}>
+                        {historyData.teamName}
                       </div>
 
-                      {/* intra id mapping */}
-                      <div className={styles.intraIdWrapper}>
-                        {historyTeamMates.map((mate) => (
-                          <div key={`${historyData.agendaId}-${mate.intraId}`}>
-                            {mate.intraId}
-                          </div>
-                        ))}
-                      </div>
-                    </div>
+                      <div className={styles.teamIntraIdWrapper}>
+                        <div className={styles.imageWrapper}>
+                          <TeamIcon />
+                        </div>
 
-                    {/* coalition color mapping */}
-                    <div className={styles.coalitionWrapper}>
-                      <ColorList
-                        peopleCount={peopleCount}
-                        totalPeople={totalPeople}
-                      />
-                    </div>
-                  </>
-                ) : null}
-              </Link>
-            );
-          })
+                        {/* intra id mapping */}
+                        <div className={styles.intraIdWrapper}>
+                          {historyTeamMates.map((mate, index) => (
+                            <div
+                              key={`${historyData.agendaId}-${mate.intraId}-${index}`}
+                            >
+                              {mate.intraId}
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+
+                      {/* coalition color mapping */}
+                      <div className={styles.coalitionWrapper}>
+                        <ColorList
+                          peopleCount={peopleCount}
+                          totalPeople={totalPeople}
+                        />
+                      </div>
+                    </>
+                  ) : null}
+                </Link>
+              );
+            }
+          )
         ) : (
           <div className={styles.historyEmpty}>아젠다 기록이 없습니다.</div>
         )}

--- a/components/agenda/Profile/ProfileCard.tsx
+++ b/components/agenda/Profile/ProfileCard.tsx
@@ -196,26 +196,28 @@ const ProfileCard = ({
               <div className={styles.acheivementText}>Acheivements</div>
 
               <div className={styles.acheivementImageContainer}>
-                {achievements.map((data, index) => {
-                  const imageUrl = data.image;
+                {achievements.length
+                  ? achievements.map((data, index) => {
+                      const imageUrl = data.image;
 
-                  if (imageUrl) {
-                    const parsedUrl = imageUrl.replace(
-                      '/uploads',
-                      'https://cdn.intra.42.fr'
-                    );
+                      if (imageUrl) {
+                        const parsedUrl = imageUrl.replace(
+                          '/uploads',
+                          'https://cdn.intra.42.fr'
+                        );
 
-                    return (
-                      <div
-                        key={index}
-                        className={styles.acheivementImageWrapper}
-                      >
-                        <CustomImage src={parsedUrl} alt='achievement' />
-                      </div>
-                    );
-                  }
-                  return null;
-                })}
+                        return (
+                          <div
+                            key={index}
+                            className={styles.acheivementImageWrapper}
+                          >
+                            <CustomImage src={parsedUrl} alt='achievement' />
+                          </div>
+                        );
+                      }
+                      return null;
+                    })
+                  : ''}
               </div>
             </div>
           </div>

--- a/components/agenda/Profile/ProfileCard.tsx
+++ b/components/agenda/Profile/ProfileCard.tsx
@@ -7,7 +7,7 @@ import GithubIcon from 'public/image/agenda/github.svg';
 import useFetchRequest from 'hooks/agenda/useFetchRequest';
 import styles from 'styles/agenda/Profile/ProfileCard.module.scss';
 
-const ProfileImageCard = ({
+const ProfileCard = ({
   userIntraId,
   userContent,
   userGithub,
@@ -77,6 +77,7 @@ const ProfileImageCard = ({
     setProfileData(initialProfileData);
     handleFlip();
   };
+
   return (
     <div className={styles.profileImageCard}>
       <div
@@ -141,6 +142,7 @@ const ProfileImageCard = ({
           <div className={styles.profileImage}>
             <div className={styles.profileImageWrapper}>
               <CustomImage
+                key={imageUrl}
                 src={imageUrl}
                 alt='profile image'
                 addClass={styles.profileImageBox}
@@ -223,4 +225,4 @@ const ProfileImageCard = ({
   );
 };
 
-export default ProfileImageCard;
+export default ProfileCard;

--- a/components/agenda/Profile/ProfileCard.tsx
+++ b/components/agenda/Profile/ProfileCard.tsx
@@ -96,6 +96,7 @@ const ProfileCard = ({
                 name='userContent'
                 maxLength={50}
                 wrap='soft'
+                key={userIntraId}
                 value={profileData.userContent}
                 placeholder='상태 메시지를 입력하세요.'
                 className={styles.editDescription}
@@ -180,6 +181,7 @@ const ProfileCard = ({
                   href={`https://profile.intra.42.fr/users/${userIntraId}`}
                   target='_blank'
                   rel='noopener noreferrer'
+                  key={userIntraId}
                 >
                   <IntraIcon />
                 </a>
@@ -188,14 +190,19 @@ const ProfileCard = ({
           </div>
 
           <div className={styles.profileContent}>
-            <div className={styles.description}>{userContent}</div>
+            <div className={styles.description} key={userIntraId}>
+              {userContent}
+            </div>
 
             <hr className={styles.divider} />
 
             <div className={styles.acheivementContainer}>
               <div className={styles.acheivementText}>Acheivements</div>
 
-              <div className={styles.acheivementImageContainer}>
+              <div
+                className={styles.acheivementImageContainer}
+                key={userIntraId}
+              >
                 {achievements.length
                   ? achievements.map((data, index) => {
                       const imageUrl = data.image;

--- a/components/agenda/Ticket/Ticket.tsx
+++ b/components/agenda/Ticket/Ticket.tsx
@@ -9,7 +9,7 @@ interface TicketProps {
 }
 
 const Ticket = ({ type }: { type: string }) => {
-  const { data } = useFetchGet<TicketProps>('/ticket');
+  const { data } = useFetchGet<TicketProps>({ url: '/ticket' });
   const { openModal } = useModal();
 
   return (

--- a/components/agenda/agendaDetail/tabs/AgendaAnnouncements.tsx
+++ b/components/agenda/agendaDetail/tabs/AgendaAnnouncements.tsx
@@ -15,6 +15,7 @@ export default function AgendaAnnouncements() {
     url: `/announcement`,
     params: { agenda_key: agendaKey },
     size: 5,
+    isReady: Boolean(agendaKey),
   });
 
   if (!agendaKey || !content) {

--- a/components/agenda/agendaDetail/tabs/ParticipantTeamList.tsx
+++ b/components/agenda/agendaDetail/tabs/ParticipantTeamList.tsx
@@ -20,6 +20,7 @@ export default function ParticipantTeamList({
   } = usePageNation<TeamDataProps>({
     url: `team/open/list`,
     params: { agenda_key: agendaKey },
+    isReady: Boolean(agendaKey),
   });
 
   const {
@@ -28,6 +29,7 @@ export default function ParticipantTeamList({
   } = usePageNation<TeamDataProps>({
     url: `team/confirm/list`,
     params: { agenda_key: agendaKey },
+    isReady: Boolean(agendaKey),
   });
 
   const noParticipants = (

--- a/components/agenda/agendaDetail/tabs/ParticipantsList.tsx
+++ b/components/agenda/agendaDetail/tabs/ParticipantsList.tsx
@@ -16,6 +16,7 @@ export default function ParticipantsList({ max }: numberProps) {
     usePageNation<ParticipantProps>({
       url: `team/confirm/list`,
       params: { agenda_key: agendaKey },
+      isReady: Boolean(agendaKey),
     });
 
   const curPeople = participants ? participants.length : 0;

--- a/components/agenda/utils/CustomImage.tsx
+++ b/components/agenda/utils/CustomImage.tsx
@@ -22,6 +22,7 @@ const CustomImage = ({
   return src ? (
     <Image
       src={imgSrc}
+      key={imgSrc}
       alt={alt}
       width={30}
       height={30}

--- a/components/error/AgendaError.tsx
+++ b/components/error/AgendaError.tsx
@@ -1,13 +1,24 @@
 import { useEffect } from 'react';
-import { useResetRecoilState } from 'recoil';
+import { useRecoilState, useResetRecoilState, useSetRecoilState } from 'recoil';
+import { agendaErrorState } from 'utils/recoil/agendaError';
+import { loginState } from 'utils/recoil/login';
 import { modalState } from 'utils/recoil/takgu/modal';
 import useErrorPage from 'hooks/error/useErrorPage';
 import styles from 'styles/takgu/Error.module.scss';
 import ErrorEmoji from '/public/image/takgu/error_face.svg';
 
 export default function ErrorPage() {
-  const { error, goHome } = useErrorPage();
+  const { goHome } = useErrorPage();
+  const [error, setError] = useRecoilState(agendaErrorState);
+  const { msg, status } = error;
+  const setLoggedIn = useSetRecoilState<boolean>(loginState);
   const resetModal = useResetRecoilState(modalState);
+
+  if (status === 401) {
+    localStorage.removeItem('42gg-token');
+    setLoggedIn(false);
+    setError({ msg: '', status: 0 });
+  }
 
   useEffect(() => {
     resetModal();
@@ -18,10 +29,8 @@ export default function ErrorPage() {
       <div className={styles.errorContainer}>
         <div className={styles.title}>42GG</div>
         <div className={styles.error}>
-          {error === 'DK404'
-            ? '잘못된 요청입니다!'
-            : '데이터 요청에 실패하였습니다.'}
-          <div className={styles.errorCode}>({error})</div>
+          {msg}
+          <div className={styles.errorCode}>({status})</div>
           <div className={styles.emojiWrapper}>
             <div className={styles.threeDotImage}>
               <div></div>

--- a/components/error/AgendaError.tsx
+++ b/components/error/AgendaError.tsx
@@ -17,8 +17,16 @@ export default function ErrorPage() {
   if (status === 401) {
     localStorage.removeItem('42gg-token');
     setLoggedIn(false);
-    setError({ msg: '', status: 0 });
   }
+
+  const resetHandler = () => {
+    if (status === 401) {
+      localStorage.removeItem('42gg-token');
+      setLoggedIn(false);
+    }
+    setError({ msg: '', status: 0 });
+    goHome();
+  };
 
   useEffect(() => {
     resetModal();
@@ -40,7 +48,7 @@ export default function ErrorPage() {
             <ErrorEmoji />
           </div>
         </div>
-        <div className={styles.home} onClick={goHome}>
+        <div className={styles.home} onClick={resetHandler}>
           <div className={styles.positive}>
             <input type='button' value='🏠 홈으로 🏠' />
           </div>

--- a/components/error/AgendaError.tsx
+++ b/components/error/AgendaError.tsx
@@ -3,6 +3,7 @@ import { useRecoilState, useResetRecoilState, useSetRecoilState } from 'recoil';
 import { agendaErrorState } from 'utils/recoil/agendaError';
 import { loginState } from 'utils/recoil/login';
 import { modalState } from 'utils/recoil/takgu/modal';
+import { useRouter } from 'next/router';
 import useErrorPage from 'hooks/error/useErrorPage';
 import styles from 'styles/takgu/Error.module.scss';
 import ErrorEmoji from '/public/image/takgu/error_face.svg';
@@ -13,6 +14,7 @@ export default function ErrorPage() {
   const { msg, status } = error;
   const setLoggedIn = useSetRecoilState<boolean>(loginState);
   const resetModal = useResetRecoilState(modalState);
+  const router = useRouter();
 
   if (status === 401) {
     localStorage.removeItem('42gg-token');
@@ -53,6 +55,30 @@ export default function ErrorPage() {
             <input type='button' value='🏠 홈으로 🏠' />
           </div>
         </div>
+        {/* 개발용 토큰 넣기 버튼 */}
+        {process.env.NODE_ENV === 'development' && status === 401 ? (
+          <>
+            <input
+              placeholder='insert token'
+              type='text'
+              name='tokenInput'
+            ></input>
+            <button
+              onClick={(e: React.MouseEvent) => {
+                const target = document.querySelector(
+                  'input[name=tokenInput]'
+                ) as HTMLInputElement;
+                if (!target) return;
+
+                console.log(target.value);
+                localStorage.setItem('42gg-token', target.value);
+                router.reload();
+              }}
+            >
+              토큰 넣기
+            </button>
+          </>
+        ) : null}
       </div>
     </div>
   );

--- a/components/error/ErrorChecker.tsx
+++ b/components/error/ErrorChecker.tsx
@@ -1,4 +1,5 @@
 import { useRecoilValue } from 'recoil';
+import { agendaErrorState } from 'utils/recoil/agendaError';
 import { errorState } from 'utils/recoil/error';
 import AgendaErrorPage from 'components/error/AgendaError';
 import TakguErrorPage from 'components/error/Error';
@@ -12,17 +13,23 @@ interface ErrorCheckerProps {
 // 추후 takgu쪽과 디자인을 어느정도 맞춘 후 통합할 예정
 export default function ErrorChecker({ children }: ErrorCheckerProps) {
   const error = useRecoilValue(errorState);
-  const app = usePathname();
+  const agendaError = useRecoilValue(agendaErrorState);
 
-  return error === '' ? (
-    <>{children}</>
-  ) : app === 'takgu' ? (
-    <div className={styles.appContainer}>
-      <div className={styles.background}>
-        <TakguErrorPage />
-      </div>
-    </div>
-  ) : (
-    <AgendaErrorPage />
-  );
+  switch (true) {
+    case agendaError.msg !== '': {
+      return <AgendaErrorPage />;
+    }
+    case error !== '': {
+      return (
+        <div className={styles.appContainer}>
+          <div className={styles.background}>
+            <TakguErrorPage />
+          </div>
+        </div>
+      );
+    }
+    default: {
+      return <>{children}</>;
+    }
+  }
 }

--- a/hooks/agenda/Layout/useUser.ts
+++ b/hooks/agenda/Layout/useUser.ts
@@ -1,13 +1,10 @@
 import { useQuery } from 'react-query';
-import { useSetRecoilState } from 'recoil';
 import { User } from 'types/agenda/mainType';
 import { instanceInAgenda } from 'utils/axios';
-import { errorState } from 'utils/recoil/error';
 
 export const useUser = () => {
-  const setError = useSetRecoilState<string>(errorState);
   const { data, isError } = useQuery<User>(
-    'user',
+    'agendauser',
     () =>
       instanceInAgenda.get('/profile/info').then((res) => {
         return res.data;
@@ -18,7 +15,6 @@ export const useUser = () => {
     }
   );
   if (isError) {
-    setError('JB02');
     return undefined;
   }
   if (data) return data;

--- a/hooks/agenda/useFetchGet.ts
+++ b/hooks/agenda/useFetchGet.ts
@@ -1,13 +1,19 @@
 import { useEffect, useState, useCallback } from 'react';
 import { instanceInAgenda } from 'utils/axios';
 
-const useFetchGet = <T>(url: string, params?: Record<string, any>) => {
+interface FetchGetProps {
+  url: string;
+  isReady?: boolean;
+  params?: Record<string, any>;
+}
+
+const useFetchGet = <T>({ url, isReady = true, params }: FetchGetProps) => {
   const [data, setData] = useState<T | null>(null);
   const [status, setStatus] = useState<number>(0);
   const [error, setError] = useState<string | null>(null);
 
   const getData = useCallback(async () => {
-    if (params && params.agenda_key === undefined) {
+    if (isReady === false) {
       return;
     }
 
@@ -24,8 +30,7 @@ const useFetchGet = <T>(url: string, params?: Record<string, any>) => {
   }, [url, params]);
 
   useEffect(() => {
-    // URL이 있고 params가 없거나, agenda_key가 있는 경우에도 getData 호출 가능
-    if (url && (!params || (params && params.agenda_key))) {
+    if (url) {
       getData(); // 조건에 맞을 때만 getData 호출
     }
   }, [url, JSON.stringify(params)]);

--- a/hooks/agenda/useIntraId.ts
+++ b/hooks/agenda/useIntraId.ts
@@ -1,0 +1,18 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+const useIntraId = () => {
+  const router = useRouter();
+  const [intraId, setIntraId] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (router.isReady) {
+      const id = router.query.id as string;
+      setIntraId(id);
+    }
+  }, [router.isReady, router.query.id]);
+
+  return intraId;
+};
+
+export default useIntraId;

--- a/hooks/agenda/usePageNation.ts
+++ b/hooks/agenda/usePageNation.ts
@@ -1,34 +1,32 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { instanceInAgenda } from 'utils/axios';
 
-const usePageNation = <T>({
-  url,
-  size = 20,
-  useIdx,
-  params,
-}: {
+interface PageNationProps {
   url: string;
   params?: Record<string, any>;
   size?: number; // 페이지 사이즈
+  isReady?: boolean; // API 호출 가능 상태 확인
   useIdx?: boolean; // 인덱싱 추가 여부
-}) => {
+}
+
+const usePageNation = <T>({
+  url,
+  params,
+  size = 20,
+  isReady,
+  useIdx,
+}: PageNationProps) => {
   const currentPage = useRef<number>(1);
   const [content, setContent] = useState<T[] | null>(null);
   const status = useRef<number>(0);
   const totalPages = useRef(1);
 
-  // 기본 파라미터 설정
-  if (!size) size = 20;
   params = params || {};
   params.page = currentPage.current;
   params.size = size;
 
   const getData = useCallback(
     async (page: number, size: number) => {
-      if (params && params.agenda_key === undefined) {
-        return { content: null };
-      }
-
       const res = await instanceInAgenda.get(url, { params });
       const content = res.data.content ? res.data.content : [];
       const totalSize = res.data.totalSize ? res.data.totalSize : 0;
@@ -62,7 +60,7 @@ const usePageNation = <T>({
     };
 
     if (
-      (!params || params.agenda_key) &&
+      isReady == true &&
       (!status.current || Math.floor(status.current / 100) !== 2)
     ) {
       fetchData();

--- a/hooks/takgu/Layout/useAnnouncementCheck.ts
+++ b/hooks/takgu/Layout/useAnnouncementCheck.ts
@@ -41,16 +41,9 @@ const useAnnouncementCheck = (presentPath: string) => {
     }
   };
 
-  // const attendedHandler = () => {
-  //   if (user && user.isAttended === false && presentPath === '/') {
-  //     setModal({ modalName: 'EVENT-WELCOME' });
-  //   }
-  // };
-
   useEffect(() => {
     if (!user) return;
-    // attendedHandler();
-    if (user && user.isAttended === false && presentPath === '/') {
+    if (user && user.isAttended === false && presentPath === 'takgu') {
       setModal({ modalName: 'EVENT-WELCOME' });
     } else announcementHandler();
   }, [user, presentPath]);

--- a/hooks/takgu/Layout/useUser.ts
+++ b/hooks/takgu/Layout/useUser.ts
@@ -15,7 +15,7 @@ export const useUser = () => {
     }
   );
   if (isError) {
-    // setError('JB02');
+    setError('JB02');
     return undefined;
   }
   if (data) return data;

--- a/hooks/useAxiosAgendaError.ts
+++ b/hooks/useAxiosAgendaError.ts
@@ -13,7 +13,9 @@ export default function useAxiosAgendaError() {
   const refreshToken = Cookies.get('refresh_token') || '';
 
   const accessTokenHandler = async () => {
-    console.log('accessTokenHandler');
+    if (!refreshToken) {
+      return;
+    }
     try {
       const res = await instanceInAgenda.post(
         `/pingpong/users/accesstoken?refreshToken=${refreshToken}`
@@ -25,7 +27,6 @@ export default function useAxiosAgendaError() {
   };
 
   const errorResponseHandler = async (error: AxiosError) => {
-    console.log('errorResponseHandler', error);
     const defaultReturn = () => {
       if (isRecalling === true) {
         setLogin(false);

--- a/hooks/useAxiosAgendaError.ts
+++ b/hooks/useAxiosAgendaError.ts
@@ -55,20 +55,6 @@ export default function useAxiosAgendaError() {
           }
         } else return defaultReturn();
       }
-      case 400:
-        if (error.config.method === 'get') {
-          setError({
-            msg: '데이터를 가져올 수 없습니다.',
-            status: error.response.status,
-          });
-        }
-        break;
-      case 404:
-        setError({
-          msg: '문제가 발생했습니다.',
-          status: error.response.status,
-        });
-        break;
       case 500:
         setError({
           msg: '서버 오류가 발생했습니다',

--- a/hooks/useAxiosAgendaError.ts
+++ b/hooks/useAxiosAgendaError.ts
@@ -54,6 +54,14 @@ export default function useAxiosAgendaError() {
           }
         } else return defaultReturn();
       }
+      case 400:
+        if (error.config.method === 'get') {
+          setError({
+            msg: '데이터를 가져올 수 없습니다.',
+            status: error.response.status,
+          });
+        }
+        break;
       case 404:
         setError({
           msg: '문제가 발생했습니다.',

--- a/hooks/useAxiosAgendaError.ts
+++ b/hooks/useAxiosAgendaError.ts
@@ -1,0 +1,91 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import Cookies from 'js-cookie';
+import { useEffect, useState } from 'react';
+import { useSetRecoilState } from 'recoil';
+import { instanceInAgenda } from 'utils/axios';
+import { agendaErrorState } from 'utils/recoil/agendaError';
+import { loginState } from 'utils/recoil/login';
+
+export default function useAxiosAgendaError() {
+  const setLogin = useSetRecoilState(loginState);
+  const [isRecalling, setIsRecalling] = useState(false);
+  const setError = useSetRecoilState(agendaErrorState);
+  const refreshToken = Cookies.get('refresh_token') || '';
+
+  const accessTokenHandler = async () => {
+    console.log('accessTokenHandler');
+    try {
+      const res = await instanceInAgenda.post(
+        `/pingpong/users/accesstoken?refreshToken=${refreshToken}`
+      );
+      localStorage.setItem('42gg-token', res.data.accessToken);
+    } catch (error) {
+      setError({ msg: '로그인이 만료되었습니다', status: 401 });
+    }
+  };
+
+  const errorResponseHandler = async (error: AxiosError) => {
+    console.log('errorResponseHandler', error);
+    const defaultReturn = () => {
+      if (isRecalling === true) {
+        setLogin(false);
+        setIsRecalling(false);
+      }
+      return Promise.reject(error);
+    };
+    if (error.response === undefined || error.response?.status === undefined) {
+      return defaultReturn();
+    }
+    switch (error.response.status) {
+      case 401: {
+        if (!isRecalling) {
+          setIsRecalling(true);
+          try {
+            const res = await instanceInAgenda.post(
+              `/pingpong/users/accesstoken?refreshToken=${refreshToken}`
+            );
+            localStorage.setItem('42gg-token', res.data.accessToken);
+            setIsRecalling(false);
+            return instanceInAgenda.request(error.config);
+          } catch (error) {
+            setIsRecalling(false);
+            setError({ msg: '로그인이 만료되었습니다', status: 401 });
+            return Promise.reject(error);
+          }
+        } else return defaultReturn();
+      }
+      case 404:
+        setError({
+          msg: '문제가 발생했습니다.',
+          status: error.response.status,
+        });
+        break;
+      case 500:
+        setError({
+          msg: '서버 오류가 발생했습니다',
+          status: error.response.status,
+        });
+        break;
+    }
+    return defaultReturn();
+  };
+
+  const responseInterceptor = instanceInAgenda.interceptors.response.use(
+    (response: AxiosResponse) => response,
+    errorResponseHandler
+  );
+  useEffect(() => {
+    if (localStorage.getItem('42gg-token')) {
+      setLogin(true);
+    } else {
+      accessTokenHandler();
+      setLogin(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      instanceInAgenda.interceptors.response.eject(responseInterceptor);
+    };
+  }, [responseInterceptor]);
+}

--- a/hooks/useAxiosResponse.ts
+++ b/hooks/useAxiosResponse.ts
@@ -2,7 +2,7 @@ import { AxiosError, AxiosResponse } from 'axios';
 import Cookies from 'js-cookie';
 import { useEffect, useState } from 'react';
 import { useSetRecoilState } from 'recoil';
-import { instance, instanceInAgenda } from 'utils/axios';
+import { instance } from 'utils/axios';
 import { errorState } from 'utils/recoil/error';
 import { loginState } from 'utils/recoil/login';
 
@@ -19,7 +19,7 @@ export default function useAxiosResponse() {
       );
       localStorage.setItem('42gg-token', res.data.accessToken);
     } catch (error) {
-      setError('SW05');
+      // setError('SW05');
     }
   };
 
@@ -50,11 +50,6 @@ export default function useAxiosResponse() {
     (response: AxiosResponse) => response,
     errorResponseHandler
   );
-  const responseInAgendaInterceptor =
-    instanceInAgenda.interceptors.response.use(
-      (response: AxiosResponse) => response,
-      errorResponseHandler
-    );
 
   useEffect(() => {
     if (localStorage.getItem('42gg-token')) {
@@ -68,7 +63,6 @@ export default function useAxiosResponse() {
   useEffect(() => {
     return () => {
       instance.interceptors.response.eject(responseInterceptor);
-      instance.interceptors.response.eject(responseInAgendaInterceptor);
     };
-  }, [responseInterceptor, responseInAgendaInterceptor]);
+  }, [responseInterceptor]);
 }

--- a/hooks/useAxiosResponse.ts
+++ b/hooks/useAxiosResponse.ts
@@ -13,13 +13,16 @@ export default function useAxiosResponse() {
   const refreshToken = Cookies.get('refresh_token') || '';
 
   const accessTokenHandler = async () => {
+    if (!refreshToken) {
+      return;
+    }
     try {
       const res = await instance.post(
         `/pingpong/users/accesstoken?refreshToken=${refreshToken}`
       );
       localStorage.setItem('42gg-token', res.data.accessToken);
     } catch (error) {
-      // setError('SW05');
+      setError('SW05');
     }
   };
 

--- a/hooks/useSearchBar.ts
+++ b/hooks/useSearchBar.ts
@@ -55,12 +55,17 @@ export default function useSearchBar(): useSearchBarReturn {
   }, [keyword, setError]);
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const basePath = router.pathname.split('/')[1];
     if (event.key === 'Enter') {
       searchResult.map((data) => {
         if (data === keyword) {
           setShowDropDown(false);
           event.currentTarget.blur();
-          router.push(`/takgu/users/detail?intraId=${keyword}`);
+          if (basePath === 'takgu') {
+            router.push(`/takgu/users/detail?intraId=${keyword}`);
+          } else if (basePath === 'agenda') {
+            router.push(`/agenda/profile/user?id=${keyword}`);
+          }
         }
       });
     }

--- a/pages/admin/agenda/teamModify.tsx
+++ b/pages/admin/agenda/teamModify.tsx
@@ -6,9 +6,14 @@ import styles from 'styles/agenda/pages/create-team.module.scss';
 
 const TeamModify = () => {
   const { team_key, location } = router.query;
+  const readyState = Boolean(team_key); // + team_key router.query 써서 쿼리로 못가져왔을 시, 에러 가능성 있음
 
-  const teamData = useFetchGet<TeamDetailProps>('admin/team', {
-    team_key: team_key as string,
+  const teamData = useFetchGet<TeamDetailProps>({
+    url: 'admin/team',
+    isReady: readyState,
+    params: {
+      team_key: team_key as string,
+    },
   }).data;
 
   return (

--- a/pages/agenda/detail/host/result.tsx
+++ b/pages/agenda/detail/host/result.tsx
@@ -92,7 +92,11 @@ const SubmitAgendaResult = () => {
   const { data } = useFetchGet<{
     totalSize: number;
     content: ParticipantProps[];
-  }>(`team/confirm/list`, { agenda_key: agenda_key, size: 30, page: 1 }) || {
+  }>({
+    url: `team/confirm/list`,
+    isReady: Boolean(agenda_key),
+    params: { agenda_key: agenda_key, size: 30, page: 1 },
+  }) || {
     data: {},
     status: 400,
   };

--- a/pages/agenda/detail/index.tsx
+++ b/pages/agenda/detail/index.tsx
@@ -17,10 +17,11 @@ const AgendaDetail = () => {
   const agendaKey = useAgendaKey();
   const agendaData = useAgendaInfo(agendaKey as string);
 
-  const { data: myTeam, status: myTeamStatus } = useFetchGet<TeamDataProps>(
-    `team/my`,
-    { agenda_key: agendaKey }
-  );
+  const { data: myTeam, status: myTeamStatus } = useFetchGet<TeamDataProps>({
+    url: `team/my`,
+    isReady: Boolean(agendaKey),
+    params: { agenda_key: agendaKey },
+  });
   const intraId = useUser()?.intraId || '';
   const isHost = getIsHost(intraId, agendaData);
 

--- a/pages/agenda/detail/team/create.tsx
+++ b/pages/agenda/detail/team/create.tsx
@@ -10,8 +10,12 @@ const CreateTeam = () => {
   const router = useRouter();
   const agendaKey = useAgendaKey();
 
-  const agendaInfo = useFetchGet<AgendaDataProps>(`/`, {
-    agenda_key: agendaKey,
+  const agendaInfo = useFetchGet<AgendaDataProps>({
+    url: `/`,
+    isReady: Boolean(agendaKey),
+    params: {
+      agenda_key: agendaKey,
+    },
   }).data;
 
   const backPage = () => {

--- a/pages/agenda/detail/team/index.tsx
+++ b/pages/agenda/detail/team/index.tsx
@@ -27,14 +27,20 @@ export default function TeamDetail() {
    */
   const intraId = useUser()?.intraId;
 
-  const agendaData = useFetchGet<AgendaDataProps>(`/`, {
-    agenda_key: agendaKey,
+  const agendaData = useFetchGet<AgendaDataProps>({
+    url: '/',
+    isReady: Boolean(agendaKey),
+    params: { agenda_key: agendaKey },
   }).data;
 
   const { data: teamDetailData, getData: getTeamDetail } =
-    useFetchGet<TeamDetailProps>('/team', {
-      teamKey: teamUID,
-      agenda_key: agendaKey,
+    useFetchGet<TeamDetailProps>({
+      url: '/team',
+      isReady: Boolean(agendaKey && teamUID),
+      params: {
+        agenda_key: agendaKey,
+        teamKey: teamUID,
+      },
     });
 
   /**

--- a/pages/agenda/index.tsx
+++ b/pages/agenda/index.tsx
@@ -17,8 +17,10 @@ const Agenda: NextPage = () => {
       url: '/history',
     });
 
-  const { data: currentData } = useFetchGet<AgendaDataProps[]>('/confirm');
-  const { data: openData } = useFetchGet<AgendaDataProps[]>('/open');
+  const { data: currentData } = useFetchGet<AgendaDataProps[]>({
+    url: '/confirm',
+  });
+  const { data: openData } = useFetchGet<AgendaDataProps[]>({ url: '/open' });
 
   return (
     <div className={styles.agendaPageContainer}>

--- a/pages/agenda/profile/index.tsx
+++ b/pages/agenda/profile/index.tsx
@@ -1,18 +1,24 @@
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
+import { useSetRecoilState } from 'recoil';
+import { agendaErrorState } from 'utils/recoil/agendaError';
 import { useUser } from 'hooks/agenda/Layout/useUser';
 
 const Index = () => {
   const router = useRouter();
   const { intraId } = useUser() || {};
+  const setError = useSetRecoilState(agendaErrorState);
 
   useEffect(() => {
     if (intraId) {
       router.push(`/agenda/profile/user?id=${intraId}`);
     } else {
-      router.push(`/`);
+      setError({
+        msg: '로그인 정보가 만료되어 재로그인이 필요합니다.',
+        status: 401,
+      });
     }
-  }, [intraId, router]);
+  }, [intraId, router, setError]);
 
   return null;
 };

--- a/pages/agenda/profile/user.tsx
+++ b/pages/agenda/profile/user.tsx
@@ -38,6 +38,12 @@ const AgendaProfile = () => {
       url: profileUrl,
     });
 
+  useEffect(() => {
+    if (intraId) {
+      getProfileData();
+    }
+  }, [intraId]);
+
   // host current
   const {
     content: hostCurrentListData,

--- a/pages/agenda/profile/user.tsx
+++ b/pages/agenda/profile/user.tsx
@@ -1,7 +1,10 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { MyTeamDataProps } from 'types/agenda/agendaDetail/agendaTypes';
 import { HistoryItemProps } from 'types/agenda/profile/historyListTypes';
-import { ProfileDataProps } from 'types/agenda/profile/profileDataTypes';
+import {
+  AgendaProfileDataProps,
+  IntraProfileDataProps,
+} from 'types/agenda/profile/profileDataTypes';
 import AgendaUserSearchBar from 'components/agenda/Profile/AgendaUserSearchBar';
 import CurrentList from 'components/agenda/Profile/CurrentList';
 import HistoryList from 'components/agenda/Profile/HistoryList';
@@ -20,6 +23,8 @@ const AgendaProfile = () => {
   const userIntraId = useUser()?.intraId; // 현재 나의 intraId
   const [profileUrl, setProfileUrl] = useState<string>('/profile');
   const [myProfileCheck, setMyProfileCheck] = useState<boolean | null>(null);
+  const isIntraId = useRef(false); // 인트라 아이디가 42에 있는지 확인
+  const isAgendaId = useRef(false); // 인트라 아이디가 agenda에 있는지 확인
 
   useEffect(() => {
     if (intraId && userIntraId) {
@@ -31,18 +36,27 @@ const AgendaProfile = () => {
       }
     }
   }, [intraId, userIntraId]);
-
-  /** API GET */
-  const { data: profileData, getData: getProfileData } =
-    useFetchGet<ProfileDataProps>({
-      url: profileUrl,
+  const { data: intraData, getData: getIntraData } =
+    useFetchGet<IntraProfileDataProps>({
+      url: `/profile/intra/${intraId}`,
+      isReady: Boolean(intraId),
     });
 
-  useEffect(() => {
-    if (intraId) {
-      getProfileData();
-    }
-  }, [intraId]);
+  /** Agenda API GET */
+  const { data: agendaProfileData, getData: getAgendaProfileData } =
+    useFetchGet<AgendaProfileDataProps>({
+      url: profileUrl,
+      // 본인이거나 42에 아이디가 있는 경우에만 데이터 요청
+      isReady: Boolean(
+        intraId === userIntraId || (intraId && isIntraId.current)
+      ),
+    });
+
+  // useEffect(() => {
+  //   if (intraId) {
+  //     getProfileData();
+  //   }
+  // }, [intraId]);
 
   // host current
   const {
@@ -50,7 +64,7 @@ const AgendaProfile = () => {
     PagaNationElementProps: PagaNationHostCurrent,
   } = usePageNation<MyTeamDataProps>({
     url: `/host/current/list/${intraId}`,
-    isReady: Boolean(intraId),
+    isReady: Boolean(intraId && isAgendaId.current),
   });
 
   // current team
@@ -64,7 +78,7 @@ const AgendaProfile = () => {
     PagaNationElementProps: PagaNationHostHistory,
   } = usePageNation<HistoryItemProps>({
     url: `/host/history/list/${intraId}`,
-    isReady: Boolean(intraId),
+    isReady: Boolean(intraId && isAgendaId.current),
   });
 
   // history
@@ -73,7 +87,7 @@ const AgendaProfile = () => {
     PagaNationElementProps: PagaNationHistory,
   } = usePageNation<HistoryItemProps>({
     url: `/profile/history/list/${intraId}`,
-    isReady: Boolean(intraId),
+    isReady: Boolean(intraId && isAgendaId.current),
   });
 
   if (!intraId || !userIntraId) {
@@ -87,14 +101,17 @@ const AgendaProfile = () => {
           <AgendaUserSearchBar />
         </div>
         {/* ProfileCard */}
-        {profileData && (
+        {intraData && (
           <ProfileCard
-            userIntraId={profileData.userIntraId}
-            userContent={profileData.userContent}
-            userGithub={profileData.userGithub}
-            imageUrl={profileData.imageUrl}
-            achievements={profileData.achievements}
-            getProfileData={getProfileData}
+            userIntraId={intraId}
+            userContent={
+              agendaProfileData?.userContent ||
+              'GG에 가입하지 않은 사용자입니다.'
+            }
+            userGithub={agendaProfileData?.userGithub || ''}
+            imageUrl={intraData.imageUrl}
+            achievements={intraData.achievements}
+            getProfileData={getAgendaProfileData}
             isMyProfile={myProfileCheck}
           />
         )}

--- a/pages/agenda/profile/user.tsx
+++ b/pages/agenda/profile/user.tsx
@@ -101,7 +101,7 @@ const AgendaProfile = () => {
           <AgendaUserSearchBar />
         </div>
         {/* ProfileCard */}
-        {intraData && (
+        {intraData && intraId && (
           <ProfileCard
             userIntraId={intraId}
             userContent={

--- a/styles/agenda/Home/Agenda.module.scss
+++ b/styles/agenda/Home/Agenda.module.scss
@@ -14,7 +14,7 @@
   @include layout;
   position: relative;
   top: -1rem;
-  display: flex;
+  display: flex !important;
   width: 100%;
   flex-direction: column;
   padding: 1rem 0;

--- a/styles/agenda/Home/MyAgendaBtn.module.scss
+++ b/styles/agenda/Home/MyAgendaBtn.module.scss
@@ -78,7 +78,7 @@
   flex-direction: column;
   overflow-y: scroll;
   align-items: flex-start;
-  gap: 1rem;
+  gap: 0.8rem;
   @media screen and (min-width: 961px) {
     display: flex;
     width: auto;

--- a/styles/agenda/Home/MyTeamInfo.module.scss
+++ b/styles/agenda/Home/MyTeamInfo.module.scss
@@ -2,7 +2,7 @@
 
 .Container {
   display: flex;
-  max-width: 100%;
+  width: 16rem;
   padding: 0.5rem 1rem;
   background-color: var(--box-bg-1);
   border: var(--default-border);
@@ -16,7 +16,7 @@
   display: flex;
   width: 100%;
   flex-direction: column;
-  padding: 0.5rem;
+  padding: 0.4rem;
   justify-content: flex-start;
 }
 
@@ -30,12 +30,11 @@
 }
 
 .teamTitle {
-  @include text(sub-title);
+  @include text(tab);
   margin: 0;
 }
 
 .agendaTitle {
-  @include text(sub-title);
+  @include text(description-s);
   margin: 0;
-  font-family: $font-text-light;
 }

--- a/styles/agenda/Layout/Layout.module.scss
+++ b/styles/agenda/Layout/Layout.module.scss
@@ -29,13 +29,16 @@
   color: white;
   cursor: pointer;
 
-  background-color: var(--highlight-yellow);
+  background-color: var(--highlight-violet);
   border: none;
   border-radius: $radius-circle;
   box-shadow: var(--box-shadow-light);
   transition: background-color 0.3s;
 
   &:hover {
-    background-color: var(--highlight-violet);
+    width: 3rem;
+    height: 3rem;
+    transform: translate(10%, 10%);
+    animation: all 1s;
   }
 }

--- a/styles/agenda/Layout/MenuBar.module.scss
+++ b/styles/agenda/Layout/MenuBar.module.scss
@@ -7,6 +7,7 @@
   min-width: 200px;
   height: calc(100vh - 4rem);
   padding: 1rem;
+  overflow-y: auto;
   background: var(--menubar-bg);
 }
 .inactive {
@@ -37,7 +38,7 @@
   align-items: center;
 }
 .last {
-  margin-top: 4rem;
+  margin-top: 2rem;
 }
 
 .content {

--- a/styles/agenda/Profile/AgendaProfile.module.scss
+++ b/styles/agenda/Profile/AgendaProfile.module.scss
@@ -11,6 +11,6 @@
 
 .agendaUserSearchBarWrap {
   display: flex;
-  justify-content: flex-start;
+  justify-content: flex-end;
   width: 100%;
 }

--- a/styles/agenda/Profile/AgendaUserSearchBar.module.scss
+++ b/styles/agenda/Profile/AgendaUserSearchBar.module.scss
@@ -1,27 +1,60 @@
 @import 'styles/agenda/common.scss';
 
-.agendaUserSearchBar {
-  display: flex;
+.warp {
+  position: relative;
   width: 12rem;
+}
+
+.agendaUserSearchBar {
+  position: relative;
+  z-index: 4;
+  display: flex;
   height: 2.5rem;
-  padding: 0.5rem 1rem;
-  background-color: var(--box-bg-3);
+  padding: 0.2rem 1rem;
+  font-size: $font-size-m;
+  color: var(black);
+  background-color: var(--box-bg-1);
   border-radius: $radius-big;
   justify-content: space-between;
   align-items: center;
 
   input {
-    width: 8rem;
+    all: unset;
+    position: relative;
+    z-index: 5;
+    box-sizing: border-box;
+    width: calc(100% - 4rem);
     color: var(--color-text-reverse);
-    background: none;
-    border: none;
-    outline: none;
-    @include text(label);
+    @include text(default);
   }
 
-  .imageBox {
-    width: 1.5rem;
-    height: 1.5rem;
-    color: var(--color-text-reverse);
+  .icons {
+    display: flex;
+    align-items: center;
+    margin-top: 0.2rem;
+    .reset {
+      cursor: pointer;
+    }
+  }
+}
+
+.dropdown {
+  position: absolute;
+  top: 1.1rem;
+  left: 0;
+  z-index: 2;
+
+  box-sizing: border-box;
+  display: block;
+  width: 100%;
+  padding: 1.4rem 0 0 1rem;
+  color: var(--box-bg-1-dark);
+  background: var(--box-bg-1);
+  border-radius: 0 0 $radius-small $radius-small;
+  @include text(default);
+
+  div {
+    padding: 0.4rem 0;
+    cursor: pointer;
   }
 }

--- a/styles/agenda/agendaDetail/AgendaDetail.module.scss
+++ b/styles/agenda/agendaDetail/AgendaDetail.module.scss
@@ -1,17 +1,16 @@
 @import 'styles/agenda/common.scss';
 
 .layout {
-  @include layout;
   grid-template:
     'top top top top' 450px
     'content content match match' auto / 1fr 1fr 1fr 1fr;
-  max-width: 100%;
-  padding-top: 1px;
 }
 
 .agendaDetailWrap {
   @include pageContainer;
+  max-width: 100%;
   height: 100%;
+  padding: 0 5rem;
 }
 .headWrapper {
   // @include gridHidden(web);

--- a/styles/agenda/agendaDetail/AgendaInfo.module.scss
+++ b/styles/agenda/agendaDetail/AgendaInfo.module.scss
@@ -79,7 +79,7 @@ $info-gradient: linear-gradient(
   align-items: center;
 }
 .organizerWrap {
-  @include text('default'); // medium
+  @include text('description-s'); // medium
   display: flex;
   margin-right: auto; // UploadBtn과의 간격 확보
   align-items: center;

--- a/styles/agenda/agendaDetail/AgendaTab.module.scss
+++ b/styles/agenda/agendaDetail/AgendaTab.module.scss
@@ -28,6 +28,9 @@
     display: flex;
     align-items: flex-start;
     width: 100%;
+    @media screen and (min-width: 961px) {
+      justify-content: center;
+    }
   }
 }
 

--- a/styles/agenda/agendaDetail/tabs/ParticipantsList.module.scss
+++ b/styles/agenda/agendaDetail/tabs/ParticipantsList.module.scss
@@ -13,9 +13,8 @@
 }
 
 .participantsContainer {
-  display: flex;
-  justify-content: flex-start;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
   gap: 2rem;
   width: 100%;
 }

--- a/styles/agenda/button/TabButton.module.scss
+++ b/styles/agenda/button/TabButton.module.scss
@@ -21,7 +21,7 @@
   }
 
   &.isActive {
-    background: var(--highlight-yellow);
+    background: var(--highlight-violet);
   }
 }
 

--- a/styles/agenda/button/UploadBtn.module.scss
+++ b/styles/agenda/button/UploadBtn.module.scss
@@ -15,6 +15,6 @@
   gap: 0.3rem;
 
   span {
-    @include text('tab');
+    @include text(tab);
   }
 }

--- a/styles/agenda/common.scss
+++ b/styles/agenda/common.scss
@@ -157,7 +157,7 @@ $font-size-xs: 0.8rem; // $small-font
   } @else if ($type == 'date') {
     // 날짜 - 월,일
     font-family: $font-text-bold;
-    font-size: $font-size-xl;
+    font-size: $font-size-l;
   } @else if ($type == 'sub-title') {
     // 아젠다 리스트 아이템 - 타이틀
     font-family: $font-text-bold;

--- a/styles/agenda/pages/CreateAgenda.module.scss
+++ b/styles/agenda/pages/CreateAgenda.module.scss
@@ -1,13 +1,15 @@
 @import 'styles/agenda/Form/Form.module.scss';
 
 .pageContainer {
-  @include pageContainer;
+  @include layout;
+  display: flex !important;
 }
 .container {
   @include container(1);
+  max-width: 50rem;
   padding: 0.5rem;
-  @include text('default');
   text-align: left;
+  @include text('default');
 }
 
 .cancelBtn {

--- a/styles/agenda/responsive.scss
+++ b/styles/agenda/responsive.scss
@@ -31,23 +31,21 @@
   @include action;
   width: 100%;
   height: max-content;
+  justify-content: center;
   @media screen and (max-width: 480px) {
     display: flex;
     flex-direction: column;
-    // border: 2px solid red;
   }
   @media screen and (min-width: 481px) and (max-width: 960px) {
     display: flex;
     flex-direction: column;
-    // padding: 0 5rem;
-    // border: 2px solid blue;
   }
   @media screen and (min-width: 961px) {
     display: grid;
     padding: 0 5rem;
-    // border: 2px solid yellow;
   }
 }
+
 @mixin pageContainer {
   @include action;
   display: flex;
@@ -61,6 +59,7 @@
   }
   @media screen and (min-width: 961px) {
     height: 100%;
+    padding: 0 5rem;
   }
 }
 

--- a/styles/agenda/utils/AgendaTag.module.scss
+++ b/styles/agenda/utils/AgendaTag.module.scss
@@ -22,8 +22,10 @@ $tags: (
 
 .agendaTag {
   display: flex;
-  width: 3.3rem;
+  width: max-content;
+  min-width: 3.3rem;
   height: 1.2rem;
+  padding: 0.2rem 0.5rem;
   color: var(--color-text-reverse);
   border-radius: $radius-medium;
   justify-content: center;
@@ -33,9 +35,10 @@ $tags: (
 
 .defaultTag {
   display: flex;
-  width: 3.3rem;
+  width: max-content;
+  min-width: 3.3rem;
   height: 1.2rem;
-  padding: 0.2rem;
+  padding: 0.2rem 0.5rem;
 
   background-color: var(--box-bg-2-light);
   border-radius: $radius-medium;

--- a/styles/agenda/utils/PageController.module.scss
+++ b/styles/agenda/utils/PageController.module.scss
@@ -4,9 +4,9 @@
   width: 100%;
   height: max-content;
   @include pageContainer;
+  padding: 0 1rem !important;
   @media screen and (max-width: 960px) {
     height: 90%;
-    padding: 0 1rem !important;
   }
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -18,7 +18,7 @@ input {
     Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
   font-weight: 500;
 }
-/* 
+/*
 @media all and (max-width: 379px) {
   html {
     font-size: 14px;
@@ -39,25 +39,25 @@ input {
 
 @media all and (min-width: 768px) {
   html {
-    font-size: 19px;
+    font-size: 17px;
   }
 }
 
 @media all and (min-width: 1024px) {
   html {
-    font-size: 20px;
+    font-size: 18px;
   }
 }
 
 @media all and (min-width: 1280px) {
   html {
-    font-size: 21px;
+    font-size: 19px;
   }
 }
 
 @media all and (min-width: 1440px) {
   html {
-    font-size: 22px;
+    font-size: 20px;
   }
 }
 

--- a/types/agenda/profile/profileCardTypes.ts
+++ b/types/agenda/profile/profileCardTypes.ts
@@ -7,5 +7,5 @@ export interface ProfileCardProps {
   imageUrl: string;
   achievements: AchievementProps[];
   getProfileData: () => void;
-  isMyProfile: boolean;
+  isMyProfile: boolean | null;
 }

--- a/types/agenda/profile/profileDataTypes.ts
+++ b/types/agenda/profile/profileDataTypes.ts
@@ -1,14 +1,9 @@
 import { AgendaLocation, Coalition } from 'constants/agenda/agenda';
 
-export interface ProfileDataProps {
-  achievements: AchievementProps[];
+export interface IntraProfileDataProps {
+  intraId: string;
   imageUrl: string;
-  ticketCount: number;
-  userCoalition: Coalition;
-  userContent: string;
-  userGithub: string;
-  userIntraId: string;
-  userLocation: AgendaLocation;
+  achievements: AchievementProps[];
 }
 
 export interface LoginInfoDataProps {
@@ -26,4 +21,12 @@ export interface AchievementProps {
   tier: string;
   users_url: string;
   visible: boolean;
+}
+
+export interface AgendaProfileDataProps {
+  userIntraId: string;
+  userContent: string; //50자 이내
+  userGithub: string;
+  userCoalition: string; // ENUM 상단확인
+  userLocation: string; // 혹시나 서울/경산 이외 들어울 경우 예외처리
 }

--- a/utils/recoil/agendaError.ts
+++ b/utils/recoil/agendaError.ts
@@ -1,12 +1,12 @@
 import { atom } from 'recoil';
 import { v1 } from 'uuid';
 
-interface ErrorState {
+export interface ErrorStateType {
   msg: string;
   status: number;
 }
 
-export const agendaErrorState = atom<ErrorState>({
+export const agendaErrorState = atom<ErrorStateType>({
   key: `errorState/${v1()}`,
   default: { msg: '', status: 0 },
 });

--- a/utils/recoil/agendaError.ts
+++ b/utils/recoil/agendaError.ts
@@ -1,0 +1,12 @@
+import { atom } from 'recoil';
+import { v1 } from 'uuid';
+
+interface ErrorState {
+  msg: string;
+  status: number;
+}
+
+export const agendaErrorState = atom<ErrorState>({
+  key: `errorState/${v1()}`,
+  default: { msg: '', status: 0 },
+});


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 에러페이지 등 에러 관련 컴포넌트, 훅 분리
  
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
### axiosHandler분리: 아젠다 전용  
  -  setError 포함시켜서 axios error Handler에서 에러페이지 리턴하게 처리
  - refreshtoken 401, GET 400, 404, 500의 경우 에러페이지 리턴 처리
  - 이외에는 기존처럼 스낵바로 처리하도록 유지
  - 에러페이지에서 홈으로 버튼 누를 경우 셋에러 해제. 
  (401의 경우 로그아웃 처리 되지 않으므로, 로컬스토리지 지우고 로그인상태 false로 만들어 리턴. )
 ### chore
- 탁구 출석보상 뜨지 않는 문제: 경로 의존성 수정
- dev모드시 로그인상태 유지하도록(로그인화면 리턴하지 않도록) 수정
  

 
