### PR TITLE
[Fix] 프로필 update 오류, 팀 수정 폼 변경, css 정리 #1551

### DIFF
--- a/components/agenda/Form/AdminTeamForm.tsx
+++ b/components/agenda/Form/AdminTeamForm.tsx
@@ -76,7 +76,7 @@ const AdminTeamForm = ({
         )
       ) {
         setTeamMates((prev) => [
-          { intraId: teamData.teamLeaderIntraId, coalition: Coalition.OTHER }, // 팀장을 가장 앞에 추가
+          { intraId: teamData.teamLeaderIntraId, coalition: Coalition.OTHER },
           ...prev,
         ]);
       }
@@ -117,6 +117,18 @@ const AdminTeamForm = ({
       className={styles.container}
     >
       <div className={styles.pageContianer}>
+        {teamData.teamStatus === TeamStatus.CANCEL ? (
+          <div className={styles.topContainer}>
+            <div className={`${styles.label_text} ${styles.highlight}`}>
+              팀 상태 : CANCEL
+            </div>
+            <div className={styles.description}>
+              CANCEL 상태에서는 수정이 불가능합니다.{' '}
+              <span className={styles.span}>[ OPEN/CONFIM ]</span>으로 팀 상태를
+              변경 후 이용해주세요.
+            </div>
+          </div>
+        ) : null}
         <TitleInput
           name='teamName'
           label='팀 이름'
@@ -156,7 +168,7 @@ const AdminTeamForm = ({
         <CheckBoxInput
           name='teamIsPrivate'
           label='비밀방(초대만 가능, 대회 내역에서 보이지 않음)'
-          checked={teamData.teamIsPrivate} // 팀 상세 페이지 - 수정
+          checked={teamData.teamIsPrivate}
         />
         <div className={styles.label_text}>상 이름 : {teamData.teamAward}</div>
         <div className={styles.label_text}>

--- a/components/agenda/Profile/CurrentList.tsx
+++ b/components/agenda/Profile/CurrentList.tsx
@@ -11,8 +11,9 @@ const CurrentList = ({
   isHost: boolean;
 }) => {
   const listTitle = isHost ? '개최중 아젠다' : '참여중 아젠다';
+  const bottomMargin = isHost ? '' : styles.bottomMargin;
   return (
-    <div className={styles.currentListContainer}>
+    <div className={`${styles.currentListContainer} ${bottomMargin}`}>
       <div className={styles.currentListTitle}>{listTitle}</div>
 
       <div className={styles.currentListItems}>

--- a/components/agenda/agendaDetail/tabs/AgendaDescription.tsx
+++ b/components/agenda/agendaDetail/tabs/AgendaDescription.tsx
@@ -36,6 +36,10 @@ export default function AgendaDescription({ agendaData }: AgendaProps) {
       <div className={styles.descriptionWarp}>
         <div className={styles.midContainer}>
           <div className={styles.descriptionItem}>
+            <h3>대회 설명</h3>
+            <span>{agendaContent}</span>
+          </div>
+          <div className={styles.descriptionItem}>
             <h3>모집 완료 기간</h3>
             <span>{formatDate(agendaDeadLine)}</span>
           </div>

--- a/components/agenda/agendaDetail/tabs/Participant.tsx
+++ b/components/agenda/agendaDetail/tabs/Participant.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import React from 'react';
 import { ParticipantProps } from 'types/agenda/agendaDetail/tabs/participantTypes';
 import { colorMapping, iconMapping } from 'types/agenda/utils/colorList';
@@ -18,13 +19,17 @@ export default function Participant({
   const IconComponent = iconMapping[coalitionEnum[0]];
 
   return (
-    <div
-      className={`${styles.participantItem} ${colorMapping[coalitionEnum[0]]}`}
-    >
-      <div className={styles.participantItemWarp}>
-        <div className={styles.participantcontent}>{teamName}</div>
-        {IconComponent ? <IconComponent /> : ''}
+    <Link href={`/agenda/profile/user?id=${teamName}`}>
+      <div
+        className={`${styles.participantItem} ${
+          colorMapping[coalitionEnum[0]]
+        }`}
+      >
+        <div className={styles.participantItemWarp}>
+          <div className={styles.participantcontent}>{teamName}</div>
+          {IconComponent ? <IconComponent /> : ''}
+        </div>
       </div>
-    </div>
+    </Link>
   );
 }

--- a/components/error/AgendaError.tsx
+++ b/components/error/AgendaError.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
-import { useRecoilState, useResetRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState, useResetRecoilState } from 'recoil';
 import { agendaErrorState } from 'utils/recoil/agendaError';
-import { loginState } from 'utils/recoil/login';
 import { modalState } from 'utils/recoil/takgu/modal';
 import { useRouter } from 'next/router';
 import useErrorPage from 'hooks/error/useErrorPage';
@@ -12,20 +11,10 @@ export default function ErrorPage() {
   const { goHome } = useErrorPage();
   const [error, setError] = useRecoilState(agendaErrorState);
   const { msg, status } = error;
-  const setLoggedIn = useSetRecoilState<boolean>(loginState);
   const resetModal = useResetRecoilState(modalState);
   const router = useRouter();
 
-  if (status === 401) {
-    localStorage.removeItem('42gg-token');
-    setLoggedIn(false);
-  }
-
   const resetHandler = () => {
-    if (status === 401) {
-      localStorage.removeItem('42gg-token');
-      setLoggedIn(false);
-    }
     setError({ msg: '', status: 0 });
     goHome();
   };

--- a/pages/agenda/profile/user.tsx
+++ b/pages/agenda/profile/user.tsx
@@ -24,6 +24,8 @@ const AgendaProfile = () => {
   const isMyProfile = useRef(false); // 내 프로필 페이지인지 아닌지 확인
   const [isIntraId, setIsIntraId] = useState<boolean>(false); // 인트라 아이디가 42에 있는지 확인
   const [isAgendaId, setIsAgendaId] = useState<boolean>(false); // 인트라 아이디가 agenda에 있는지 확인
+  const [agendaProfileData, setAgendaProfileData] =
+    useState<AgendaProfileDataProps | null>(null); // agendaProfileData 상태 추가
 
   /** API GET */
   //  GET: intraData (42 인트라 데이터 가져오기)
@@ -32,7 +34,7 @@ const AgendaProfile = () => {
     isReady: Boolean(queryIntraId),
   });
   // GET: agendaProfileData (GG 아젠다 유저 데이터 가져오기)
-  const { data: agendaProfileData, getData: getAgendaProfileData } =
+  const { data: fetchedAgendaProfileData, getData: getAgendaProfileData } =
     useFetchGet<AgendaProfileDataProps>({
       url: `/profile/${queryIntraId}`,
       isReady: isIntraId,
@@ -76,10 +78,15 @@ const AgendaProfile = () => {
       // 2. intraData가 있으면 인트라 아이디가 42에 있다는 뜻이므로 isIntraId = true
       setIsIntraId(!!intraData);
       // 3. agendaProfileData가 있으면 아젠다에 등록된 사용자이므로 isAgendaId = true
-      setIsAgendaId(!!agendaProfileData);
+      setIsAgendaId(!!fetchedAgendaProfileData);
+      if (isAgendaId) {
+        setAgendaProfileData(fetchedAgendaProfileData);
+      } else {
+        setAgendaProfileData(null); // fetchedAgendaProfileData가 없을 때 초기화
+      }
     };
     updateProfileStatus();
-  }, [queryIntraId, intraData, agendaProfileData]);
+  }, [queryIntraId, intraData, fetchedAgendaProfileData]);
 
   useEffect(() => {
     setIsIntraId(false);

--- a/pages/agenda/profile/user.tsx
+++ b/pages/agenda/profile/user.tsx
@@ -21,7 +21,6 @@ import styles from 'styles/agenda/Profile/AgendaProfile.module.scss';
 const AgendaProfile = () => {
   const queryIntraId = useIntraId(); // 쿼리의 id
   const myIntraId = useUser()?.intraId; // 현재 나의 intraId
-  const [profileUrl, setProfileUrl] = useState<string>('/profile');
   const isMyProfile = useRef(false); // 내 프로필 페이지인지 아닌지 확인
   const [isIntraId, setIsIntraId] = useState<boolean>(false); // 인트라 아이디가 42에 있는지 확인
   const [isAgendaId, setIsAgendaId] = useState<boolean>(false); // 인트라 아이디가 agenda에 있는지 확인
@@ -35,9 +34,10 @@ const AgendaProfile = () => {
   // GET: agendaProfileData (GG 아젠다 유저 데이터 가져오기)
   const { data: agendaProfileData, getData: getAgendaProfileData } =
     useFetchGet<AgendaProfileDataProps>({
-      url: profileUrl,
+      url: `/profile/${queryIntraId}`,
       isReady: isIntraId,
     });
+
   // GET: host current
   const {
     content: hostCurrentListData,
@@ -70,24 +70,21 @@ const AgendaProfile = () => {
 
   /** useEffect */
   useEffect(() => {
-    // 1. queryIntraId와 myIntraId가 있을 때 프로필 URL 설정
-    if (queryIntraId && myIntraId) {
-      if (queryIntraId === myIntraId) {
-        isMyProfile.current = true;
-      } else {
-        isMyProfile.current = false;
-        setProfileUrl(`/profile/${queryIntraId}`); // 다른 유저 프로필 URL 설정
-      }
-    }
-    // 2. intraData가 있으면 인트라 아이디가 42에 있다는 뜻이므로 isIntraId = true
-    if (intraData) {
-      setIsIntraId(true);
-    }
-    // 3. agendaProfileData가 있으면 아젠다에 등록된 사용자이므로 isAgendaId = true
-    if (agendaProfileData) {
-      setIsAgendaId(true);
-    }
-  }, [queryIntraId, myIntraId, intraData, agendaProfileData]);
+    const updateProfileStatus = () => {
+      // 1. queryIntraId와 myIntraId가 있을 때 프로필 URL 설정
+      isMyProfile.current = queryIntraId === myIntraId;
+      // 2. intraData가 있으면 인트라 아이디가 42에 있다는 뜻이므로 isIntraId = true
+      setIsIntraId(!!intraData);
+      // 3. agendaProfileData가 있으면 아젠다에 등록된 사용자이므로 isAgendaId = true
+      setIsAgendaId(!!agendaProfileData);
+    };
+    updateProfileStatus();
+  }, [queryIntraId, intraData, agendaProfileData]);
+
+  useEffect(() => {
+    setIsIntraId(false);
+    setIsAgendaId(false);
+  }, [queryIntraId]);
 
   /** UI Rendering */
   if (!queryIntraId || !myIntraId) {

--- a/pages/agenda/ticket/history.tsx
+++ b/pages/agenda/ticket/history.tsx
@@ -10,6 +10,7 @@ const TicketHistoryPage = () => {
       url: '/ticket/history',
       size: size,
       useIdx: true,
+      isReady: true,
     }
   );
 

--- a/styles/agenda/Home/AgendaInfo.module.scss
+++ b/styles/agenda/Home/AgendaInfo.module.scss
@@ -28,7 +28,7 @@
     display: flex;
     width: 100%;
     height: max-content;
-    align-items: center;
+    align-items: flex-start;
     gap: 1.5rem;
     justify-content: space-between;
     @include text(description);

--- a/styles/agenda/Home/AgendaList.module.scss
+++ b/styles/agenda/Home/AgendaList.module.scss
@@ -29,12 +29,13 @@
   justify-content: space-between;
   align-items: center;
   > h2 {
-    margin: 0.5rem;
+    margin: 1rem;
     @include text(sub-menu);
   }
   > div {
+    max-width: 15rem;
     height: max-content;
-    margin-right: 0.5rem;
+    margin-right: 1rem;
     color: var(--text-color);
   }
 }

--- a/styles/agenda/Layout/Layout.module.scss
+++ b/styles/agenda/Layout/Layout.module.scss
@@ -22,6 +22,8 @@
   position: fixed;
   right: 2rem;
   bottom: 2rem;
+
+  display: flex;
   width: 2.5rem;
   height: 2.5rem;
   font-size: var(--font-size-xl);
@@ -33,6 +35,8 @@
   border-radius: $radius-circle;
   box-shadow: var(--box-shadow-light);
   transition: background-color 0.3s;
+  align-items: center;
+  justify-content: center;
 
   &:hover {
     width: 3rem;

--- a/styles/agenda/Profile/AgendaProfile.module.scss
+++ b/styles/agenda/Profile/AgendaProfile.module.scss
@@ -6,7 +6,7 @@
   justify-content: flex-start;
   align-items: center;
   padding: 1rem;
-  gap: 1.5rem;
+  gap: 1rem;
 }
 
 .agendaUserSearchBarWrap {

--- a/styles/agenda/Profile/CurrentList.module.scss
+++ b/styles/agenda/Profile/CurrentList.module.scss
@@ -11,6 +11,9 @@
   border-radius: $radius-big;
   box-shadow: var(--default-box-shadow);
   gap: 1rem;
+  &.bottomMargin {
+    margin-bottom: 1rem;
+  }
 }
 
 .currentListTitle {
@@ -22,7 +25,7 @@
   width: 100%;
   height: 100%;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.7rem;
 }
 
 .currentTeamEmpty {

--- a/styles/agenda/Profile/HistoryList.module.scss
+++ b/styles/agenda/Profile/HistoryList.module.scss
@@ -4,7 +4,7 @@
   display: flex;
   width: 22rem;
   height: auto;
-  max-height: 32rem;
+  max-height: 34rem;
   flex-direction: column;
   padding: 1rem 1.5rem;
   background-color: var(--box-bg-2);
@@ -22,7 +22,7 @@
     width: 100%;
     height: 100%;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.7rem;
   }
 
   .historyEmpty {

--- a/styles/agenda/Profile/ProfileCard.module.scss
+++ b/styles/agenda/Profile/ProfileCard.module.scss
@@ -4,6 +4,7 @@
   width: 22rem;
   height: 31rem;
   perspective: 1000px;
+  margin-bottom: 1rem;
 }
 
 .cardInner {

--- a/styles/agenda/agendaDetail/AgendaDetail.module.scss
+++ b/styles/agenda/agendaDetail/AgendaDetail.module.scss
@@ -10,7 +10,7 @@
   @include pageContainer;
   max-width: 100%;
   height: 100%;
-  padding: 0 2rem;
+  padding: 0 1rem;
 }
 .headWrapper {
   // @include gridHidden(web);

--- a/styles/agenda/agendaDetail/tabs/AgendaDescription.module.scss
+++ b/styles/agenda/agendaDetail/tabs/AgendaDescription.module.scss
@@ -72,7 +72,7 @@
   p {
     margin: 0;
   }
-  @media screen and (max-width: 481px) {
+  @media screen and (max-width: 520px) {
     flex-direction: column;
   }
 }

--- a/styles/agenda/utils/AgendaTag.module.scss
+++ b/styles/agenda/utils/AgendaTag.module.scss
@@ -3,7 +3,8 @@
 .agendaItemTagBox {
   display: flex;
   gap: 0.3rem;
-  max-width: 16rem;
+  max-width: 18rem;
+  flex-wrap: wrap;
 }
 
 $tags: (

--- a/styles/agenda/utils/AgendaTag.module.scss
+++ b/styles/agenda/utils/AgendaTag.module.scss
@@ -39,7 +39,7 @@ $tags: (
   width: max-content;
   min-width: 3.3rem;
   height: 1.2rem;
-  padding: 0.2rem 0.5rem;
+  padding: 0.2rem 0.3rem;
 
   background-color: var(--box-bg-2-light);
   border-radius: $radius-medium;

--- a/styles/agenda/utils/AgendaTag.module.scss
+++ b/styles/agenda/utils/AgendaTag.module.scss
@@ -1,8 +1,9 @@
-@import '../common.scss';
+@import 'styles/agenda/common.scss';
 
 .agendaItemTagBox {
   display: flex;
   gap: 0.3rem;
+  max-width: 16rem;
 }
 
 $tags: (


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 프로필 update 오류, 팀 수정 기능 추가, css 정리 
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->

1. 팀 수정 폼 변경
  - 팀 취소는 팀 목록 테이블에서만 가능하도록 변경
  - 팀 취소상태에서 OPEN/CONFIRM 상태로 변경시, 팀장이름 자동으로 추가
2. css 정리 
3. 프로필 update 오류
   - search를 통해 url이 변경되었지만 페이지 새로고침이 되지 않았을 경우 데이터를 제대로 불러오지 않음
    1) 참여중/참여 기록 변경되지 않음
        - 문제
           - pageNation을 사용하여 불러오는 LIst들이 불러오지 않음
        - 해결
          - usePageNation에서 url과 isReady에 따른 useEffect 추가

    2) agenda에 등록되지 않은 사용자일 경우 content를 불러오지 않음
        - 문제 
          - agendaProfileData가 초기화되지 않음
        - 해결
          - axios.get을 통해 받아온 data와 component에 보내는 data를 분리하여 저장 
          - isAgendaId가 false일 경우 agendaProfileData 초기화