### PR TITLE
[Fix] 확성기 스크롤 오류 수정

### DIFF
--- a/components/takgu/Layout/MegaPhone.tsx
+++ b/components/takgu/Layout/MegaPhone.tsx
@@ -94,16 +94,10 @@ const Megaphone = () => {
       <div className={styles.wrapper}>
         {!!megaphoneData && megaphoneData.length > 0 && (
           <Virtuoso
-            className={styles.virtuoso}
             totalCount={megaphoneData.length}
             data={megaphoneData}
             ref={virtuoso}
-            itemContent={(index) => (
-              <MegaphoneItem
-                content={megaphoneData[index].content}
-                intraId={megaphoneData[index].intraId}
-              />
-            )}
+            itemContent={(_, data) => <MegaphoneItem {...data} />}
             style={{ height: '100%' }}
           />
         )}

--- a/components/takgu/Layout/MegaPhone.tsx
+++ b/components/takgu/Layout/MegaPhone.tsx
@@ -14,44 +14,11 @@ interface IMegaphoneContent {
 
 type MegaphoneList = Array<IMegaphoneContent>;
 
-// type MegaphoneContainerProps = {
-//   children: React.ReactNode;
-//   count: number;
-// };
-
 const adminContent: IMegaphoneContent = {
   megaphoneId: 0,
   content: '상점에서 아이템을 구매해서 확성기를 등록해보세요!(30자 제한)',
   intraId: '관리자',
 };
-
-// export const MegaphoneContainer = ({
-//   children,
-//   count,
-// }: MegaphoneContainerProps) => {
-//   const ref = useRef<HTMLDivElement>(null);
-//   const [selectedIndex, setSelectedIndex] = useState<number>(0);
-
-//   useInterval(() => {
-//     const nextIndex = (selectedIndex + 1) % count;
-//     setSelectedIndex(nextIndex);
-//   }, 4000);
-
-//   return (
-//     <div className={styles.rollingBanner}>
-//       <div
-//         className={styles.wrapper}
-//         style={{
-//           transition: 'all 1s ease-in-out',
-//           transform: `translateY(${selectedIndex * -100}%)`,
-//         }}
-//         ref={ref}
-//       >
-//         {children}
-//       </div>
-//     </div>
-//   );
-// };
 
 export const MegaphoneItem = ({ content, intraId }: IMegaphoneContent) => {
   return (
@@ -143,44 +110,6 @@ const Megaphone = () => {
       </div>
     </div>
   );
-
-  // return (
-  //   <MegaphoneContainer count={megaphoneData.length}>
-  //     {megaphoneData.map((content, idx) => (
-  //       <MegaphoneItem
-  //         content={content.content}
-  //         intraId={content.intraId}
-  //         key={idx}
-  //       />
-  //     ))}
-  //   </MegaphoneContainer>
-  // );
-
-  // return contents.length > 0 ? (
-  //   <MegaphoneContainer count={contents.length}>
-  //     {contents.map((content, idx) => (
-  //       <MegaphoneItem
-  //         content={content.content}
-  //         intraId={content.intraId}
-  //         key={idx}
-  //       />
-  //     ))}
-  //   </MegaphoneContainer>
-  // ) : (
-  //   <MegaphoneContainer count={itemList.length + 1}>
-  //     <MegaphoneItem
-  //       content={adminContent.content}
-  //       intraId={adminContent.intraId}
-  //     />
-  //     {itemList.map((item, idx) => (
-  //       <MegaphoneItem
-  //         content={item.itemName + ' : ' + item.mainContent}
-  //         intraId={'절찬 판매 중!'}
-  //         key={idx}
-  //       />
-  //     ))}
-  //   </MegaphoneContainer>
-  // );
 };
 
 export default Megaphone;

--- a/styles/takgu/Layout/MegaPhone.module.scss
+++ b/styles/takgu/Layout/MegaPhone.module.scss
@@ -49,9 +49,3 @@ $bannerHeight: 3rem;
   justify-content: center;
   align-items: center;
 }
-
-.virtuoso {
-  // NOTE : 라이브러리에서 인라인 스타일로 overflow-y: auto를 주고 있어 스크롤바가 생김
-  // 이를 상쇄하기 위해서 !important를 사용함.
-  overflow-y: hidden !important;
-}


### PR DESCRIPTION
## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->

- 확성기 스크롤 위치 오류 수정

## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->

- 확성기 스크롤 위치가 맞지 않고 빈 메시지가 들어가는 문제를 수정했습니다.
- 문제 원인으로 추정되는 것은 유저가 임의로 스크롤하지 못하도록 추가했던 `overflow-y: hidden !important`
- 스크롤은 정상적으로 동작하도록 하기 위해서 라이브러리 설정 그대로 `overflow-y: auto` 가 적용되도록 하고
- 유저가 스크롤을 시도할 때 발생하는 wheel, touchmove 이벤트에서 스크롤 동작이 발생하지 않도록 설정했습니다.

### 참고
- https://virtuoso.dev/custom-scroll-container
- https://virtuoso.dev/customize-structure
- https://developer.mozilla.org/ko/docs/Web/API/EventTarget/addEventListener#passive

### 수정 결과 스크린샷

![Screen_Shot 2024-12-22 23 15 07](https://github.com/user-attachments/assets/b36ff4e4-e5fe-4b5d-986a-85d48b476b0a)

## 💡관련 Issue <!-- 관련 Issue 번호를 기록해주세요. close가 필요한 경우에는 close #[이슈번호]를 해주세요 -->

- close #1582
