### PR TITLE
[Fix] MIME type 상수화

### DIFF
--- a/components/agenda/Form/SubmitAgendaForm.tsx
+++ b/components/agenda/Form/SubmitAgendaForm.tsx
@@ -2,6 +2,8 @@ import { NextRouter } from 'next/router';
 import { SetterOrUpdater } from 'recoil';
 import { agendaModal } from 'types/agenda/modalTypes';
 import { instanceInAgenda } from 'utils/axios';
+import MIME_TYPE from 'constants/common/mimeType';
+
 function agendadataToMsg(data: FormData, isEdit: boolean) {
   let msg = '';
   msg += '행사 제목 : ' + data.get('agendaTitle') + '\n';
@@ -88,8 +90,8 @@ const SubmitAgendaForm = async (
   }
   if (
     poster.size != 0 &&
-    poster.type !== 'image/jpeg' &&
-    poster.type !== 'image/jpg'
+    poster.type !== MIME_TYPE.JPEG &&
+    poster.type !== MIME_TYPE.JPG
   ) {
     errMsg = 'jpg, jpeg 파일만 업로드 가능합니다.\n';
     document.getElementById('agendaPoster')?.focus();

--- a/components/takgu/modal/admin/AdminEditItem.tsx
+++ b/components/takgu/modal/admin/AdminEditItem.tsx
@@ -6,6 +6,7 @@ import { Item } from 'types/takgu/itemTypes';
 import { instanceInManage } from 'utils/axios';
 import { modalState } from 'utils/recoil/takgu/modal';
 import { toastState } from 'utils/recoil/toast';
+import MIME_TYPE from 'constants/common/mimeType';
 import useUploadImg from 'hooks/useUploadImg';
 import styles from 'styles/admin/takgu/modal/AdminEditItem.module.scss';
 
@@ -70,14 +71,11 @@ export default function AdminEditItemModal(item: Item) {
     formData.append(
       'updateItemInfo',
       new Blob([JSON.stringify(data)], {
-        type: 'application/json',
+        type: MIME_TYPE.JSON,
       })
     );
     if (imgData) {
-      formData.append(
-        'imgData',
-        new Blob([imgData], { type: 'image/takgu/jpeg' })
-      );
+      formData.append('imgData', new Blob([imgData], { type: MIME_TYPE.JPEG }));
     }
 
     mutation.mutate(formData, {

--- a/components/takgu/modal/admin/AdminProfileModal.tsx
+++ b/components/takgu/modal/admin/AdminProfileModal.tsx
@@ -6,6 +6,7 @@ import { racketTypes } from 'types/takgu/userTypes';
 import { instanceInManage } from 'utils/axios';
 import { modalState } from 'utils/recoil/takgu/modal';
 import { toastState } from 'utils/recoil/toast';
+import MIME_TYPE from 'constants/common/mimeType';
 import useUploadImg from 'hooks/useUploadImg';
 import styles from 'styles/admin/takgu/modal/AdminProfile.module.scss';
 
@@ -89,14 +90,11 @@ export default function AdminProfileModal(props: { intraId: string }) {
     formData.append(
       'updateUserInfo',
       new Blob([JSON.stringify(data)], {
-        type: 'application/json',
+        type: MIME_TYPE.JSON,
       })
     );
     if (imgData) {
-      formData.append(
-        'imgData',
-        new Blob([imgData], { type: 'image/takgu/jpeg' })
-      );
+      formData.append('imgData', new Blob([imgData], { type: MIME_TYPE.JPEG }));
     }
     try {
       const res = await instanceInManage.put(

--- a/components/takgu/modal/store/inventory/ProfileImageModal.tsx
+++ b/components/takgu/modal/store/inventory/ProfileImageModal.tsx
@@ -8,6 +8,7 @@ import { UseItemData } from 'types/takgu/inventoryTypes';
 import { instance, isAxiosError } from 'utils/axios';
 import { errorState } from 'utils/recoil/error';
 import { modalState } from 'utils/recoil/takgu/modal';
+import MIME_TYPE from 'constants/common/mimeType';
 import { ITEM_ALERT_MESSAGE } from 'constants/takgu/store/itemAlertMessage';
 import {
   ModalButtonContainer,
@@ -83,12 +84,12 @@ export default function ProfileImageModal({
       formData.append(
         'userProfileImageRequestDto',
         new Blob([JSON.stringify({ receiptId: receiptId })], {
-          type: 'application/json',
+          type: MIME_TYPE.JSON,
         })
       );
       formData.append(
         'profileImage',
-        new Blob([imgData], { type: 'image/takgu/jpeg' })
+        new Blob([imgData], { type: MIME_TYPE.JPEG })
       );
       await instance.post('/pingpong/users/profile-image', formData);
       queryClient.invalidateQueries('user');
@@ -140,7 +141,7 @@ export default function ProfileImageModal({
               )}
               <input
                 type='file'
-                accept='image/takgu/jpeg'
+                accept={MIME_TYPE.JPEG}
                 style={{ display: 'none' }}
                 onChange={uploadImg}
               />

--- a/constants/common/mimeType.ts
+++ b/constants/common/mimeType.ts
@@ -1,0 +1,7 @@
+const MIME_TYPE = Object.freeze({
+  JPEG: 'image/jpeg' as const,
+  JSON: 'application/json' as const,
+  JPG: 'image/jpg' as const,
+});
+
+export default MIME_TYPE;

--- a/constants/common/mimeType.ts
+++ b/constants/common/mimeType.ts
@@ -1,7 +1,7 @@
 const MIME_TYPE = Object.freeze({
-  JPEG: 'image/jpeg' as const,
-  JSON: 'application/json' as const,
-  JPG: 'image/jpg' as const,
-});
+  JPEG: 'image/jpeg',
+  JSON: 'application/json',
+  JPG: 'image/jpg',
+} as const);
 
 export default MIME_TYPE;

--- a/hooks/useUploadImg.ts
+++ b/hooks/useUploadImg.ts
@@ -2,6 +2,7 @@ import imageCompression from 'browser-image-compression';
 import { ChangeEvent, useEffect, useState } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { toastState } from 'utils/recoil/toast';
+import MIME_TYPE from 'constants/common/mimeType';
 
 interface ICompressProps {
   maxSizeMB: number;
@@ -25,7 +26,7 @@ export default function useUploadImg({
     const options = {
       maxSizeMB: maxSizeMB,
       maxWidthOrHeight: maxWidthOrHeight,
-      filetype: 'image/takgu/jpeg',
+      filetype: MIME_TYPE.JPEG,
       useWebWorker: true,
     };
     try {


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->

## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->

- #1583 에서 이미지 로드가 실패하는 원인을 파악해본 결과 이미지들이 과거에 썼던 버킷주소에서 이미지를 받아오고 있어서 그런것으로 확인했습니다.
- 이를 해결하기 위해서 이미지를 다시 업로드를 시도해보았고, 업로드 과정에서 에러가 발생하고 있는 것을 확인했습니다.
- 에러 원인은 https://github.com/42organization/42gg.client/commit/792a0bb4db1995ff00f28dcea556e99507ba2247 에서 image 경로를 `image/takgu`로 고치는 과정에서 mime 타입까지 수정된 것으로 보입니다.


## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->

- 잘못된 mime type을 수정했습니다
- 'application/json' 과 'image/jpg', 'image/jpeg'를 인라인스트링으로 관리하던 부분을 상수로 추출했습니다.

## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

- inline에선 mime타입을 기재하던 부분들을 드러내고, MIME_TYPE을 공용상수로 뺴냈습니다.

```ts
// 변경전
{type: 'image/jepg'}
{type: 'application/json'}
// 변경후
{type: MIME_TYPE.JPEG}
{type: MIME_TYPE.JSON}
```

## 💡관련 Issue <!-- 관련 Issue 번호를 기록해주세요. close가 필요한 경우에는 close #[이슈번호]를 해주세요 -->

- fix #1583
