### PR TITLE
Fix: github Ations 설정 업그레이드

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: macos-13
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js version 16.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
 
@@ -30,7 +30,7 @@ jobs:
           npm install
           npm run build
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: macos-13
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js version 16.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
 
@@ -31,7 +31,7 @@ jobs:
           npm install
           npm run build
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-access-key-id: ${{ secrets.AWS_DEV_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_DEV_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->

## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->

- github Actions Deprecation 해결 및 버전 업그레이드

## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->

### (1) 에러 사항 발견
- main, test-deploy, deploy 브랜치에 대한 github Actions 설정들이 정상 작동하지 않는 문제가 발생했습니다.  
 - Error ❌
   - `The macOS-12 environment is deprecated, consider switching to macOS-13, macOS-14 (macos-latest) or macOS-15.`
 - Warning ⚠️ 
   - `The set-***put command is deprecated and will be disabled soon. Please upgrade to using Environment Files.`
 
### (2) 문제 해결 방안
- github Actions 설정 파일 안의 설정된 코드들을 업그레이드 해주었습니다. 위치 -> `.github/workflows/.yml` 
- Error ❌
  - `runs-on: macos-12 ` -> `runs-on: macos-13`
- Warning ⚠️
  - `actions/checkout@v2` ->  `actions/checkout@v3`
  - `actions/setup-node@v1` -> `actions/setup-node@v3`
  - `aws-actions/configure-aws-credentials@v1` -> `aws-actions/configure-aws-credentials@v3`
## 💡관련 Issue <!-- 관련 Issue 번호를 기록해주세요. close가 필요한 경우에는 close #[이슈번호]를 해주세요 -->
- #1586 